### PR TITLE
deps: limit vitest + typescript-core groups to minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,13 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+        # Vitest 4 requires vite >=6 (ERR_PACKAGE_PATH_NOT_EXPORTED on
+        # './module-runner') AND introduces fake-timers behaviour that
+        # bit us at story-005 (see project_fake_timers_block_fetch_microtasks).
+        # Stay on 3.x until vite 6 + vitest 4 ecosystem settles.
+        update-types:
+          - "minor"
+          - "patch"
       # @types/* updates: high volume, low risk; bundle them.
       typescript-types:
         patterns:
@@ -57,6 +64,13 @@ updates:
           - "typescript"
           - "ts-morph"
           - "tsx"
+        # TypeScript 6 changed how `node:fs` etc imports resolve — every
+        # package's tsconfig would need `--module nodenext` (or `bundler`)
+        # to compile. Schedule that migration explicitly; don't let
+        # Dependabot rubber-stamp it.
+        update-types:
+          - "minor"
+          - "patch"
       # Playwright (tier-2 acceptance) + testing-library
       testing:
         patterns:


### PR DESCRIPTION
## Summary

Closes #15 (vitest 2→4) + #16 (typescript 5→6, ts-morph 24→28) — both major bumps that broke CI on different surfaces. Both need scheduled migration work, not a Dependabot rubber-stamp.

- **vitest**: pinned to minor/patch via `update-types`. Vitest 4 requires vite ≥6 (slowcook is on vite 5; PR #15 hit `ERR_PACKAGE_PATH_NOT_EXPORTED` on `./module-runner`) + reintroduces the fake-timers footgun from story-005.
- **typescript-core**: pinned to minor/patch. TS 6 changed how `node:*` imports resolve; would require migrating every package's tsconfig to `--module nodenext`. Schedule that migration explicitly when there's actual upside to running on TS 6.

## Test plan

- [x] No code change beyond `.github/dependabot.yml` comments + `update-types` keys.
- [ ] Verify the next Dependabot weekly run (next Monday) does NOT reopen vitest 4 / typescript 6 PRs.

## After this lands

- Close #15 + #16 as wontfix.
- Future TS 6 / vitest 4 migration: separate scoped effort with proper tsconfig + vite bumps + manual validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)