### PR TITLE
init: gitignore exempts hand-curated diagrams (entities.md, architecture.md)

### DIFF
--- a/packages/cli/.brewing/recon-result.json
+++ b/packages/cli/.brewing/recon-result.json
@@ -1,0 +1,16 @@
+{
+  "story": "018",
+  "generated_at": "2026-05-04T05:26:08.538Z",
+  "generator": "slowcook-recon@0.17.6",
+  "status": "clean",
+  "renames": [],
+  "testid_gaps": [],
+  "structural_gaps": [],
+  "history_index_components": 0,
+  "warnings": [
+    "No test files found for story-018 under tests/integration/",
+    "brownfield-rename-safety check is not yet implemented in 0.17.6 (recorded by simulation; defer to 0.17.7)",
+    "shape-emit: no mock files discovered for story-018 (no scenarios reference it; no test imports point at mock/src)"
+  ],
+  "shape_file": null
+}

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -351,10 +351,18 @@ export function gitignoreSection(): string {
 .brewing/code-map.json
 .brewing/code-map.md
 .brewing/code-map.target.md
-# 0.13.5+ — brownfield extracts (schema.mmd, tokens.md). Same
-# rationale: regenerated each refine/investigate workflow run via
-# \`slowcook extract\`. Live as derived state, not in source control.
-.brewing/diagrams/
+# 0.13.5+ — brownfield extracts under .brewing/diagrams/. Ephemeral
+# files (schema.mmd, tokens.md) are regenerated each refine/investigate
+# workflow run via \`slowcook extract\` and SHOULD NOT be committed.
+# Hand-curated artifacts (entities.md, architecture.md, etc.) are
+# source-of-truth and SHOULD be tracked — \`!\` exceptions below
+# whitelist them. The \`/*\` form (vs trailing slash) is required for
+# the !-overrides to take effect.
+.brewing/diagrams/*
+!.brewing/diagrams/entities.md
+!.brewing/diagrams/architecture.md
+!.brewing/diagrams/sequence-*.md
+!.brewing/diagrams/.gitkeep
 ${SLOWCOOK_GITIGNORE_MARKER_END}
 `;
 }


### PR DESCRIPTION
Closes part of #36 (the gitignore-template prong).

Before: \`gitignoreSection()\` emitted \`.brewing/diagrams/\` which blanket-ignored everything under the directory — silently hiding hand-curated artifacts that should be tracked (entities.md, architecture.md, sequence diagrams) alongside the ephemeral ones (tokens.md, schema.mmd).

After:
\`\`\`
.brewing/diagrams/*               # blanket ignore (file-glob form so !-overrides work)
!.brewing/diagrams/entities.md
!.brewing/diagrams/architecture.md
!.brewing/diagrams/sequence-*.md
!.brewing/diagrams/.gitkeep
\`\`\`

The \`/*\` form (vs trailing slash) is required for git to honor the \`!\`-overrides — directory-form ignores can't be re-included by file-pattern exceptions.

### Tests
- All 749 cli tests pass unchanged. No test asserted the previous bare pattern.

### Discovered
delgoosh/monorepo dogfood, 2026-05-13. Consumers using TypeORM hand-curate entities.md (until #36's main scope — ORM detection — ships) and the gitignore quietly hid it from \`git add\`. This PR removes the per-consumer workaround.

### Out of scope (separate work under #36)
TypeORM / Prisma / Drizzle entity-graph extraction in \`slowcook extract\`. That's the bigger feature; this PR just fixes the gitignore-template prong so when the extraction lands, the emitted artifact ships tracked-by-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)