### PR TITLE
investigate→recipe-regression→sift chain enforcement (closes #37)

### DIFF
--- a/packages/cli/src/commands/init/plan.test.ts
+++ b/packages/cli/src/commands/init/plan.test.ts
@@ -96,6 +96,7 @@ describe("buildPlan — fresh project", () => {
     expect(paths).toContain(".github/workflows/slowcook.yml");
     expect(paths).toContain(".github/workflows/slowcook-spec-merged.yml");
     expect(paths).toContain(".github/workflows/slowcook-investigate.yml");
+    expect(paths).toContain(".github/workflows/slowcook-recipe-regression.yml");
     expect(paths).toContain(".github/workflows/slowcook-sift.yml");
     expect(paths).toContain(".github/workflows/slowcook-chef.yml");
     expect(paths).toContain("CODEOWNERS");

--- a/packages/forge-github/src/templates.ts
+++ b/packages/forge-github/src/templates.ts
@@ -812,8 +812,10 @@ export function getGitHubCiArtifacts(_params: { cliVersion: string }): CiArtifac
     { path: ".github/workflows/slowcook-brew-auto.yml", contents: slowcookBrewAutoWorkflow() },
     { path: ".github/workflows/slowcook-acceptance.yml", contents: slowcookAcceptanceWorkflow() },
     // 0.13.0-alpha.5 — bug-flow workflows. investigate fires on issues
-    // labeled `bug`; sift fires when a bug-profile PR merges.
+    // labeled `bug`; recipe-regression auto-fires when a bug-profile PR
+    // merges; sift consumes the resulting regression test.
     { path: ".github/workflows/slowcook-investigate.yml", contents: slowcookInvestigateWorkflow() },
+    { path: ".github/workflows/slowcook-recipe-regression.yml", contents: slowcookRecipeRegressionWorkflow() },
     { path: ".github/workflows/slowcook-sift.yml", contents: slowcookSiftWorkflow() },
     { path: ".github/workflows/slowcook-chef.yml", contents: slowcookChefWorkflow() },
     // 0.15.0-α.2 — vibe agent (mockup generator) workflow.
@@ -1159,6 +1161,176 @@ ${RESOLVE_PIN_STEP}
             --max-iterations "\${{ github.event.inputs.max_iterations }}" \\
             --budget-usd "\${{ github.event.inputs.budget_usd }}" \\
             --model "\${{ github.event.inputs.model }}"
+`;
+}
+
+/**
+ * 0.19.0+ (slowcook#37) — slowcook-recipe-regression workflow. The
+ * missing middle of the bug-flow chain. Fires automatically when a PR
+ * labeled `slowcook-bug-profile` merges; reads the just-merged bug-
+ * profile YAML, runs `slowcook recipe --regression --bug <id>` to emit
+ * a failing test under `tests/regression/<bug_id>-*.test.ts`, then
+ * opens a follow-up PR with the test (labeled `slowcook-regression-
+ * test`).
+ *
+ * Why automation: investigate's PR body already promises this chain
+ * ("Merging this PR triggers `slowcook recipe --regression`...") but
+ * pre-0.19 no workflow actually listened. Humans (or agents) could
+ * skip the test-writing step and let sift run against a profile alone.
+ * Per slowcook#37 (chain enforcement), the bug-profile's
+ * `regression_assertion` should be treated as a REQUIRED test gate;
+ * this workflow makes that structural, not advisory.
+ *
+ * Sift's existing entry check (`packages/cli/src/commands/sift/
+ * index.ts:142` refuses to start if no test file matches
+ * `tests/regression/<bug_id>-*.test.ts`) is the hard gate that closes
+ * the loop.
+ */
+function slowcookRecipeRegressionWorkflow(): string {
+  return `name: slowcook recipe-regression
+
+# 0.19.0+ (slowcook#37) — auto-fires when a bug-profile PR merges.
+# Emits the failing regression test that sift consumes. Without this
+# workflow, the investigate → recipe-regression → sift chain is
+# advisory; with it, the test-writing step is enforced for every
+# bug-profile that lands on main.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      bug:
+        description: "Bug id to recipe a regression test for (B-N or just N)"
+        required: true
+        type: string
+
+concurrency:
+  group: slowcook-recipe-regression-\${{ github.event.inputs.bug || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  recipe-regression:
+    # Auto-trigger: only when a slowcook-bug-profile PR actually merged.
+    # workflow_dispatch always runs (manual retry path).
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'slowcook-bug-profile')
+      ) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: \${{ github.event.pull_request.merge_commit_sha || github.ref }}
+
+${RESOLVE_PIN_STEP}
+
+      - name: Configure git identity for agent commits
+        run: |
+          git config user.name  "slowcook-recipe[bot]"
+          git config user.email "slowcook-recipe@users.noreply.github.com"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Detect bug id
+        id: bug
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          INPUT_BUG: \${{ github.event.inputs.bug }}
+          PR_NUM: \${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          if [ -n "\${INPUT_BUG:-}" ]; then
+            # Manual dispatch — normalize \`B-N\` or \`N\` to \`B-N\`.
+            BUG="\${INPUT_BUG}"
+            [[ "\$BUG" == B-* ]] || BUG="B-\$BUG"
+            echo "id=\$BUG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Auto path: derive from the merged PR's branch name
+          # (slowcook/bug-profile/B-N — set by \`slowcook investigate\`).
+          BRANCH=$(gh pr view "$PR_NUM" --repo "\${{ github.repository }}" --json headRefName -q .headRefName)
+          BUG=$(echo "$BRANCH" | sed -nE 's|^slowcook/bug-profile/(B-[a-zA-Z0-9_-]+)$|\\1|p')
+          if [ -z "$BUG" ]; then
+            echo "Could not derive bug id from branch '$BRANCH'. Skipping recipe-regression."
+            exit 0
+          fi
+          echo "id=$BUG" >> "$GITHUB_OUTPUT"
+
+      - name: Skip-if-test-already-on-main
+        if: steps.bug.outputs.id != ''
+        id: existing
+        env:
+          BUG_ID: \${{ steps.bug.outputs.id }}
+        run: |
+          set -eu
+          # Recipe-regression writes to tests/regression/<bug_id>-*.test.ts.
+          # If a matching file already exists, the previous run already
+          # produced the test or a human authored one — skip this run.
+          if compgen -G "tests/regression/\${BUG_ID}-*.test.ts" > /dev/null 2>&1; then
+            echo "Regression test for \${BUG_ID} already exists; skipping recipe-regression."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Recipe (regression)
+        if: steps.bug.outputs.id != '' && steps.existing.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          SLOWCOOK_DEBUG: "1"
+        run: |
+          set -eu
+          npx --yes "$SLOWCOOK_CLI" recipe --regression --bug "\${{ steps.bug.outputs.id }}"
+
+      - name: Push regression test + open PR
+        if: steps.bug.outputs.id != '' && steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          BUG_ID: \${{ steps.bug.outputs.id }}
+        run: |
+          set -eu
+          # Nothing emitted? Recipe-regression failed silently — fail
+          # the step so the operator sees it.
+          if ! compgen -G "tests/regression/\${BUG_ID}-*.test.ts" > /dev/null 2>&1; then
+            echo "::error::Recipe emitted no test file at tests/regression/\${BUG_ID}-*.test.ts"
+            exit 1
+          fi
+
+          BRANCH="slowcook/regression-test/\${BUG_ID}"
+          git checkout -b "$BRANCH"
+          git add tests/regression/
+          git commit -m "test(regression): failing test for \${BUG_ID} (auto-emitted by slowcook recipe)"
+          git push --force-with-lease origin "$BRANCH"
+
+          # Open PR (or update if branch already had one). Labels:
+          # slowcook-regression-test to differentiate from spec/mockup/brew
+          # PRs in dashboards; bug for routing to the bug-flow queue.
+          if gh pr view "$BRANCH" --repo "\${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Existing PR for \$BRANCH found; updated with force-push."
+          else
+            gh pr create \\
+              --repo "\${{ github.repository }}" \\
+              --head "$BRANCH" \\
+              --title "regression test: \${BUG_ID} (slowcook recipe --regression)" \\
+              --body "Auto-emitted failing regression test for \\\`\${BUG_ID}\\\`. The test is red against current code; sift will ratchet it to green.
+
+Merge this PR to admit the test to main. \\\`slowcook sift --bug \${BUG_ID}\\\` will then run against the captured assertion.
+
+Bug profile: .brewing/bug-profiles/\${BUG_ID}.yaml" \\
+              --label "slowcook-regression-test,bug"
+          fi
 `;
 }
 

--- a/packages/llm-anthropic/src/prompts/investigate.ts
+++ b/packages/llm-anthropic/src/prompts/investigate.ts
@@ -71,7 +71,17 @@ failure_locus:
     migration adds 'bar' (verified: grep returns 0 hits)".>
 
 regression_assertion:
-  - "Given <repro context>, when <action>, then <correct behavior>"
+  # Each line is one Given/When/Then. Be concrete enough that the
+  # next agent (slowcook recipe --regression) can translate it
+  # directly into a failing test without re-deriving the diagnosis.
+  # MANDATORY structural elements per line:
+  #   - the SUBJECT of the test (module / class / function), by path
+  #   - the ARRANGE (input state / mocks / fixtures)
+  #   - the ACT (the call or trigger)
+  #   - the ASSERT (the specific observable behavior)
+  # Prose is allowed for clarity but each item MUST contain those four
+  # so the recipe agent has everything it needs.
+  - "Given <fixture state>, when <subject>.<method>(<args>) runs, then <specific assertion>"
   - "(may be multiple if the bug has compound effects)"
 
 fix_scope:
@@ -116,7 +126,7 @@ failure_locus:
     bar — verified via grep').
 
 regression_assertion:
-  - "Given <repro context>, when <action>, then <correct behavior>."
+  - "Given a `NotificationsTypeEnum.PATIENT_10_MIN_BEFORE_APPOINTMENT` notification + user with WHATSAPP preference + phoneNumber set, when `NotificationActivity.sendNotification({ notificationId })` runs, then `whatsappService.sendPatient10MinBeforeAppointmentWhatsapp` is called once with `{ notificationId }` and no `*Email` method on whatsappService is called."
 
 fix_scope:
   - "src/path/to/broken.ts"

--- a/packages/llm-anthropic/src/prompts/investigate.ts
+++ b/packages/llm-anthropic/src/prompts/investigate.ts
@@ -126,7 +126,7 @@ failure_locus:
     bar — verified via grep').
 
 regression_assertion:
-  - "Given a `NotificationsTypeEnum.PATIENT_10_MIN_BEFORE_APPOINTMENT` notification + user with WHATSAPP preference + phoneNumber set, when `NotificationActivity.sendNotification({ notificationId })` runs, then `whatsappService.sendPatient10MinBeforeAppointmentWhatsapp` is called once with `{ notificationId }` and no `*Email` method on whatsappService is called."
+  - "Given a \`NotificationsTypeEnum.PATIENT_10_MIN_BEFORE_APPOINTMENT\` notification + user with WHATSAPP preference + phoneNumber set, when \`NotificationActivity.sendNotification({ notificationId })\` runs, then \`whatsappService.sendPatient10MinBeforeAppointmentWhatsapp\` is called once with \`{ notificationId }\` and no \`*Email\` method on whatsappService is called."
 
 fix_scope:
   - "src/path/to/broken.ts"


### PR DESCRIPTION
Closes #37.

The bug-flow chain — \`investigate\` → \`recipe --regression\` → \`sift\` — had:
- ✅ \`investigate\` emits bug-profile (pre-existing)
- ✅ Sift's entry-check refuses to run without a regression test on disk (pre-existing at \`packages/cli/src/commands/sift/index.ts:142\`)
- ❌ **Missing middle**: nothing auto-emitted the failing test between investigate + sift

Investigate's own PR body even promised the chain (\`packages/cli/src/commands/investigate/index.ts:392\`):

> \"Merging this PR triggers \`slowcook recipe --regression --bug ...\` to emit the failing test\"

But no workflow listened.

This PR ships **two prongs** of the enforcement story:

## Prong 1 — Prompt sharpening (commit `05550b2`)

\`regression_assertion\` template moved from prose to a structured spec the recipe agent can directly translate. Mandates four elements per line: SUBJECT / ARRANGE / ACT / ASSERT. Worked example pulled from the real delgoosh#618 run.

## Prong 2 — Workflow chain (commit `41bfdca`)

New \`slowcook-recipe-regression.yml\`:

- Triggers on \`pull_request: closed\` when the merged PR carries the \`slowcook-bug-profile\` label (investigate already applies that label)
- Also fires on \`workflow_dispatch\` with a manual \`bug\` input
- Detects bug id from the merged PR's branch name (\`slowcook/bug-profile/B-N\`)
- Skips idempotently if a test already exists at \`tests/regression/<bug_id>-*.test.ts\` (re-runs won't clobber human-authored tests)
- Runs \`slowcook recipe --regression --bug B-N\`
- Pushes the failing test to branch \`slowcook/regression-test/B-N\`, opens PR labeled \`slowcook-regression-test\`
- **Hard-errors** if recipe emits no file (catches silent failures)

## Why hard-signal, not prompt-only

Per the \`feedback_soft_steering_vs_hard_signals\` memory: prompt-level \"you should write a regression test\" doesn't survive optimization pressure. Combined with sift's existing entry-check (refuse-start without a test on disk), this PR makes the chain **structurally enforced**, not advisory.

## What this PR does NOT do

- Doesn't make slowcook speak Jest (recipe still emits vitest). Separate stack-detection feature, out of scope.
- Doesn't auto-merge the bug-profile PR (still human PM review per design — PM should sanity-check the diagnosis before burning recipe credit).

## Tests

749/749 cli tests pass. Init plan.test.ts now asserts the new workflow path so any regression that drops it from \`getGitHubCiArtifacts()\` is caught.

## Related

- #36 (entity-graph extraction; gitignore prong shipped in #38)
- Memory: \`feedback_soft_steering_vs_hard_signals\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)