### PR TITLE
release: bump cli α.17 + forge-github 0.12.1 + llm-anthropic α.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.16",
+  "version": "0.19.0-alpha.17",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/forge-github/package.json
+++ b/packages/forge-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/forge-github",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "GitHub ForgeAdapter implementation for slowcook",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.1",
+  "version": "0.16.0-alpha.2",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",


### PR DESCRIPTION
Picks up the three merged feature PRs:

- #38 (init gitignore template) → cli α.17
- #39 (investigate chain + prompt) → forge-github 0.12.1, llm-anthropic α.2, cli α.17
- #40 (TypeORM extraction) → cli α.17

Build green; 764/764 cli tests pass.

Merge this, then publish:

```bash
pnpm -r build
pnpm publish --filter @slowcook-ai/forge-github --tag alpha --no-git-checks
pnpm publish --filter @slowcook-ai/llm-anthropic --tag alpha --no-git-checks
pnpm publish --filter @slowcook-ai/cli --tag alpha --no-git-checks
scripts/smoke-install.sh --since-publish
```

Order matters: cli depends on the other two, so publish them first.