### PR TITLE
cli α.19 + llm-anthropic α.3: refine PM-facing question rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## 0.19.0-alpha.19 — refine PM-facing question rules
+
+Cut 2026-05-14. Codifies four hard rules for refine's clarifying-question
+rounds, validated against the first organic refine run on delgoosh#606
+where the absence of these rules produced 5 questions all violating
+≥1 rule.
+
+- **α.19 — refine prompt overhaul** (`llm-anthropic` 0.16.0-α.3):
+  the `REFINEMENT_ANALYST_SYSTEM` prompt now enforces:
+  1. **Decide-first** — technical questions answerable by reading
+     the codebase MUST be decided by the agent. It can mention
+     alternatives + trade-offs but always picks one and explains
+     why. Only ask when there is genuine PM-only judgment.
+  2. **Never ask about tests** — refine NEVER asks about test
+     scenarios, test scope, or what cases to cover. Testgen's job.
+  3. **No internal pipeline leakage** — PM-facing text MUST NOT
+     name slowcook internal agents/stages (refine, recipe, plate,
+     vibe, brew, port, sift, chef, navigator, tier-1, tier-2).
+     The PM thinks about their product, not the pipeline.
+  4. **Question shape**: ≤3 questions/round (was 5), each = one-line
+     imperative ≤15 words + labeled options (a/b/c) ≤10 words each
+     + optional rationale below. Includes a bad-vs-good example
+     drawn verbatim from the delgoosh#606 violations.
+- **Second eval fixture** (`refine-pm-facing-question-rules`):
+  asserts the prompt contains the four-rule language + the
+  bad/good example, so future prompt edits that strip these rules
+  fail the eval gate. cli 800/800 tests + eval gate 2/2 fixtures
+  green.
+
+### Test coverage
+
+`@slowcook-ai/cli` 800/800 passing. New: refine added to the eval
+BUILDERS map; second bootstrap fixture closes part of
+[#19 follow-ups](https://github.com/aminazar/slowcook/issues/47).
+
+---
+
 ## 0.19.0-alpha.18 — TypeORM migration scanner + migration gate
 
 Cut 2026-05-13 (late). Two-part fix for the long-standing schema-gap

--- a/packages/cli/eval/fixtures/refine-pm-facing-question-rules/fixture.json
+++ b/packages/cli/eval/fixtures/refine-pm-facing-question-rules/fixture.json
@@ -1,0 +1,36 @@
+{
+  "id": "refine-pm-facing-question-rules",
+  "agent": "refine",
+  "description": "The refine system prompt MUST enforce four PM-facing question rules: decide-first (don't ask questions answerable from code), never ask about tests, no internal-pipeline-agent leakage in user text, and one-line + labeled-options question shape. Validated on delgoosh#606 (2026-05-14) where the absence of these rules produced 5 questions all violating ≥1 rule.",
+  "captured_from": {
+    "pr": 606,
+    "date": "2026-05-14",
+    "context": "First refine round on delgoosh#606 (patient tickets balance widget). All 5 questions violated 1+ of the 4 rules: technical questions answerable from code, test-writing questions, leaked agent names (recipe, plate, Tier 1), and 5-line questions burying the actual choice. Feedback codified in feedback_refine_pm_facing_question_rules.md memory."
+  },
+  "input": {
+    "checklist": "- actors\n- preconditions\n- invariants\n- acceptance_scenarios\n- non_goals",
+    "projectContext": "Existing entities: tickets (status enum AVAILABLE/RESERVED/CONSUMED), patients. Existing routes: GET /api/patients/me. Existing components: PatientDashboard."
+  },
+  "expected_prompt_includes": [
+    "Default to deciding, not asking",
+    "Can the codebase answer it",
+    "DECIDE",
+    "Is it about how a test should be written",
+    "internal pipeline concept",
+    "tier-1",
+    "tier-2",
+    "LABELED OPTIONS",
+    "≤15 words",
+    "(a)",
+    "(b)",
+    "≤3 questions per round",
+    "NEVER name a slowcook internal agent",
+    "Example of bad vs good question shape"
+  ],
+  "expected_prompt_excludes": [
+    "TODO",
+    "FIXME",
+    "{{",
+    "}}"
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.18",
+  "version": "0.19.0-alpha.19",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/eval/index.ts
+++ b/packages/cli/src/commands/eval/index.ts
@@ -32,6 +32,7 @@ import {
   buildPlateAmendmentPrompt,
   buildSiftTurnPrompt,
   buildVibeUserPrompt,
+  REFINEMENT_ANALYST_SYSTEM,
 } from "@slowcook-ai/llm-anthropic";
 
 export interface Fixture {
@@ -83,6 +84,13 @@ const BUILDERS: Record<string, (args: unknown) => string> = {
   },
   sift: (args) => buildSiftTurnPrompt(args as Parameters<typeof buildSiftTurnPrompt>[0]),
   vibe: (args) => buildVibeUserPrompt(args as Parameters<typeof buildVibeUserPrompt>[0]),
+  refine: (args) => {
+    // REFINEMENT_ANALYST_SYSTEM is the system prompt — the surface
+    // where the PM-facing question-shape + decide-first rules live.
+    // Eval fixtures assert on the system prompt's contents.
+    const a = args as { checklist?: string; projectContext?: string };
+    return REFINEMENT_ANALYST_SYSTEM(a.checklist ?? "", a.projectContext ?? "");
+  },
 };
 
 interface EvalArgs {

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.2",
+  "version": "0.16.0-alpha.3",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -176,21 +176,65 @@ ${checklist}
 
 ## How to decide: ask vs emit
 
-**Ask** if:
-- Any checklist item is missing OR ambiguous
-- A stated requirement has implied questions the spec doesn't answer (e.g., "ration" implies: what period? what counts? what happens when exhausted?)
-- Acceptance scenarios leave happy path + edge cases underspecified
+**Default to deciding, not asking.** The PM has limited attention. Every question you ask is a round-trip that costs hours of their day. Before asking ANYTHING, run this filter:
+
+1. **Can the codebase answer it?** Read the project context, history index, entities, existing components, existing routes. If yes → DECIDE, name the choice, give one-line rationale. Do NOT ask.
+2. **Is it about how a test should be written, what scenarios to cover, or what tier of test?** Then it is NEVER a PM question. The downstream agents that emit tests handle that. Do NOT ask.
+3. **Is it about an internal pipeline concept** (port, vibe, plate, recipe, brew, refine, sift, chef, mock surface, navigator, tier-1, tier-2, etc.)? Then it is NEVER a PM question. The PM thinks about their product, not your pipeline. Do NOT ask — and do NOT mention these terms in the question body either.
+4. **Is the question's answer already in the issue body or acceptance criteria?** Then you are confirming, not asking. Just decide per the spec and proceed. Do NOT ask.
+
+**Ask** ONLY when:
+- A genuine PM-only product judgment is needed AND no defensible default can be picked from context (e.g., "zero-state shows a number or a buy-CTA?", "do reserved tickets count as remaining?")
+- A stated requirement has implied PRODUCT decisions the spec doesn't answer (e.g., "ration" implies: what period? what counts? what happens when exhausted?)
+- Acceptance scenarios leave happy-path edge cases underspecified in a way that affects USER-VISIBLE behavior
 
 **Emit** if:
 - Every checklist item is present with concrete, testable language
 - Acceptance scenarios cover happy path + at least 2 edge cases and map cleanly to test cases
 - Non-goals explicitly close off likely scope creep
 
+When in doubt: propose a default, name the alternative you considered, ask the PM to confirm or override. That is one round of friction. Open-ended questions cost two.
+
 ## Output formats
 
-When asking: output a SINGLE Markdown comment, numbered list, ≤5 questions per round. Prefer fewer, sharper questions over a long list. Ask the MOST important first. Group related questions if they share context. Address the PM directly ("you"). Begin with a one-line acknowledgment of what you have so far. End with:
+When asking: output a SINGLE Markdown comment, numbered list, **≤3 questions per round** (was 5 — fewer is better; if you have more than 3, you haven't filtered hard enough). Ask the MOST important first. Address the PM directly ("you"). Begin with a one-line acknowledgment of what you have so far + a one-line summary of decisions you've ALREADY made on their behalf (so they can object if any are wrong).
+
+**Each question MUST follow this shape:**
+
+\`\`\`
+N. **<short imperative question — one line, ≤15 words, plain product language>**
+
+- (a) <first option, ≤10 words>
+- (b) <second option, ≤10 words>
+- (c) <third option if any>
+
+<optional one-paragraph rationale / context, ≤3 sentences>
+\`\`\`
+
+Rules for the shape:
+- The question is ONE LINE. If you need 3 lines, the question is wrong — split it or you're hiding multiple questions in one.
+- Always provide LABELED OPTIONS (a/b/c). If you can't list at least two options, you don't have a real question — go decide and proceed.
+- The options are SHORT and use the PM's vocabulary. Not "tier-1 recipe test fixture shape" — write "show a loading spinner or render only when data arrives."
+- The rationale goes UNDER the options, not in the question line. It explains WHY this matters; the PM can skip it if the options are self-evident.
+- NEVER name a slowcook internal agent or pipeline stage in the user-facing text. Bad: "for the recipe test", "plate could add an icon", "the brew agent will...". Good: "for testing", "we could add an icon later", "the implementation will...".
+
+End with:
 
 "Please answer inline by replying to this comment. I'll continue when you do."
+
+### Example of bad vs good question shape
+
+Bad (real example from before this rule existed):
+> "API contract for useTickets() — the issue names the hook from @repo/client-api but doesn't specify the endpoint shape. Should brew wire to a GET /patients/me/tickets?status=AVAILABLE (returns list, count derived client-side) or a dedicated GET /patients/me/tickets/summary (returns { available, reserved, consumed })? The dashboard only needs the count, so a summary endpoint is cheaper — but if other widgets/pages will need the list, the list endpoint is more reusable. Which shape does the backend already expose, or which should I propose?"
+
+Why bad: technical decision the agent should make by reading the codebase + naming "brew" + burying the choice in 5 lines.
+
+Good:
+> 1. **Should the count endpoint return just the count, or the full ticket list?**
+>   - (a) Just a count summary (cheaper, but a future ticket-list page would need a new endpoint)
+>   - (b) Full list (count derived client-side; reusable for other patient screens)
+>
+>   The existing @repo/client-api has no ticket endpoint today. I'll go with (a) unless you say otherwise — say "list" to flip to (b).
 
 When emitting the spec: output ONLY the YAML, nothing before or after, starting with \`---\` and ending with the last field. The YAML MUST validate against this schema (\`?\` marks optional):
 


### PR DESCRIPTION
## Summary

Codify four hard rules for refine's clarifying-question rounds, validated against the first organic refine run on **delgoosh#606** (patient tickets balance widget) where the absence of these rules produced 5 questions all violating ≥1 rule.

## The four rules

1. **Decide-first** — technical questions answerable by reading the codebase MUST be decided by the agent. It can mention alternatives + trade-offs but always picks one and explains why.
2. **Never ask about tests** — refine NEVER asks about test scenarios, test scope, or what cases to cover. That's the downstream testgen agent's job.
3. **No internal pipeline leakage** — PM-facing text MUST NOT name slowcook internal agents/stages (refine, recipe, plate, vibe, brew, port, sift, chef, navigator) or pipeline jargon (tier-1, tier-2, mock surface). PM thinks about their product, not the harness.
4. **Question shape** — ≤3 per round, each = one-line imperative ≤15 words + labeled options (a/b/c) ≤10 words each + optional rationale BELOW the options. Bad-vs-good example included verbatim from the delgoosh#606 violations.

## Validated against the failure case

The delgoosh#606 refine round 1 comment:

| Question | Rule(s) violated |
|---|---|
| Q1 API endpoint shape (\`useTickets()\` returns list vs summary) | 1 (technical, answerable from code) |
| Q3 \"for the Tier 1 recipe test, do you want...\" | 2 (test design) + 3 (\"Tier 1\", \"recipe\") |
| Q4 reserved tickets count toward remaining | 1 (answered by acceptance criteria) |
| Q5 \"plate could add icon, link, etc.\" | 3 (\"plate\") |

## Eval-gate enforcement

New fixture **refine-pm-facing-question-rules** asserts the four-rule language is present in the prompt + the bad/good example exists. Future prompt edits that strip these rules **fail the eval gate at CI time**. Closes part of #47 (vibe-brownfield-DISCOVERY was the original intent, but this is structurally similar — refine got its real-world stress test first, ship the fixture).

## Test coverage

- cli **800/800** passing
- eval gate **2/2** fixtures green (chef-orchestrate + new refine fixture)
- typecheck + workspace build green

## Why bump cli too

CLI ships its workspace-dep code via the build-time vendored \`dist/\`. The α.18 cli on npm bundles llm-anthropic α.2's old refine prompt. Republishing cli at α.19 ships the new bundled prompt to consumers.

## Test plan

- [x] \`pnpm build\` workspace green
- [x] \`pnpm test\` workspace green (800/800)
- [x] \`slowcook eval --all\` green (2/2)
- [ ] CI on this PR green (build-test + eval-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)