### PR TITLE
cli α.21: slowcook dev-env command (Phase 2)

### DIFF
--- a/docs/dev-env-checkpoint-phase-2.md
+++ b/docs/dev-env-checkpoint-phase-2.md
@@ -1,0 +1,66 @@
+# Dev-env checkpoint — end of Phase 2
+
+## What's delivered (Phase 1 + Phase 2)
+
+### Phase 1 (delgoosh-only, PR delgoosh#632)
+
+| File | What it does |
+|---|---|
+| `apps/patient/src/components/DevBanner.tsx` | Fixed yellow strip at the top of every page when `NEXT_PUBLIC_DEV_ENV=1`. Shows branch + commit + story baked in at build time. |
+| `apps/patient/src/app/layout.tsx` | Wires `<DevBanner />` into the patient app's root layout. |
+| `scripts/seed-dev-data.ts` | Idempotent seed: 5 patients, 3 therapists, ~30 `patient_tickets` across FREE/RESERVED/COMPLETED. Preserves PM-added rows. `--reset` wipes only seed-owned rows. |
+| `.github/workflows/dev-deploy.yml` | Push to `dev` branch → SSH to delgoosh-box → rebuild + restart patient app with banner env vars → run seed. |
+| `docs/dev-env-setup.md` | One-time SSH-key + Caddy + checkout bootstrap; daily-flow recipes. |
+
+### Phase 2 (slowcook upstreaming, PR slowcook#TBD)
+
+| File | What it does |
+|---|---|
+| `packages/cli/src/commands/dev-env/config.ts` | Zod schema for `.brewing/dev-env.yaml`. Declares apps + their mode (`dev`/`start`/`nest-watch`/`static`/`none`), ports, optional SSH target, persistence volumes, seed script. |
+| `packages/cli/src/commands/dev-env/config.test.ts` | 9 tests — happy paths (minimal + full configs, every mode) + failures (missing file, malformed YAML, unknown mode, negative port, wrong schema_version, incomplete ssh_target). |
+| `packages/cli/src/commands/dev-env/index.ts` | `slowcook dev-env <subcmd>` command. `push --story <id>` (load-bearing for Phase 3) + `switch --story <id>` fully implemented; `up`, `sync`, `reset` print canonical shell-outs for the consumer to wire (Phase 2.1 will fill in the SSH-driven runtime path). |
+| `packages/cli/src/cli.ts` | Routes `slowcook dev-env ...` to the new command. |
+| `packages/cli/package.json` | Cli version bumped 0.19.0-α.20 → α.21. |
+
+## What's NOT yet delivered (deferred to Phase 2.1)
+
+1. **Runtime subcommands** — `up`, `sync`, `reset` currently print the canonical shell command instead of executing it via SSH. The mechanics live in delgoosh's `dev-deploy.yml` workflow for now; Phase 2.1 generalises by having `slowcook dev-env up` SSH to the configured `ssh_target` and run the equivalent.
+2. **Per-app mode dispatch.** The config schema accepts `mode: dev | start | nest-watch | static | none` but no subcommand consumes the mode yet — Phase 2.1 wires it into a per-app docker-compose snippet generator.
+3. **DevBanner as a slowcook-shipped React module.** Phase 1 keeps the component local to `apps/patient/`. Phase 2.1 extracts it to `@slowcook-ai/dev-banner` so all consumers can `<DevBanner />` by import.
+4. **`slowcook dev-env init`.** Scaffolds `.brewing/dev-env.yaml` from detected apps in the consumer's repo. Not implemented; consumers hand-author the file for now (see `apps/patient` shape in delgoosh's docs).
+
+## How a consumer adopts this today (Phase 2 cut)
+
+1. Author `.brewing/dev-env.yaml` (schema in `packages/cli/src/commands/dev-env/config.ts`):
+
+   ```yaml
+   schema_version: 1
+   source_branch: dev
+   seed_script: scripts/seed-dev-data.ts
+   ssh_target:
+     host: my-dev-box
+     user: deploy
+     checkout_dir: /opt/my-app-dev
+     key_secret: MY_APP_DEV_SSH_KEY
+   apps:
+     web:
+       mode: dev
+       port: 3000
+   ```
+
+2. Build their own `dev-deploy.yml` workflow that pushes to `source_branch` triggers an SSH redeploy (delgoosh's `dev-deploy.yml` is the reference shape).
+
+3. From any agent or local dev: `slowcook dev-env push --story <id>` force-pushes the current branch to `dev` → dev-deploy fires.
+
+Phase 3 (next) wires this push into the brew + plate workflows automatically.
+
+## Test coverage
+
+- cli **809/809** tests passing (was 800; +9 for `dev-env/config.test.ts`).
+- eval gate **2/2** fixtures green (untouched by this PR; no prompts changed).
+
+## Open questions for Phase 3+
+
+- Should `dev-env switch` also handle non-PR branches? (E.g., a hand-authored experimental branch with no open PR.)
+- Per-app deploy targets: a story might only touch `patient`, no need to rebuild `therapist`/`admin`. Currently the deploy is all-or-nothing; Phase 2.1 could introduce `--only <app>`.
+- Stop-other-running-agents semantics — does a `dev-env push` from brew cancel a previous push from plate, or queue? Concurrency policy needs a config knob.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.20",
+  "version": "0.19.0-alpha.21",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ import { runMock } from "./commands/run-mock/index.js";
 import { dispatch } from "./commands/dispatch/index.js";
 import { fixtures } from "./commands/fixtures/index.js";
 import { evalCmd } from "./commands/eval/index.js";
+import { devEnv } from "./commands/dev-env/index.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
 // version, the spec's `refined_by` field, and the init template's workflow
@@ -72,6 +73,7 @@ Usage:
   slowcook dispatch <step> [inputs...]
   slowcook fixtures check [--max-age-days <n>] [--story <id>]
   slowcook eval (--all | --fixture <id> | --list) [--fixtures-dir <path>]
+  slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]
   slowcook version
   slowcook help
 
@@ -309,6 +311,12 @@ async function main(): Promise<void> {
       // asserts substring contracts. CI workflow guards prompt-PRs
       // against silent context drops.
       await evalCmd(args.slice(1));
+      return;
+    case "dev-env":
+      // 0.19.0-α.21 (dev-env Phase 2) — long-lived preview env on
+      // a shared branch. push/switch implemented; up/sync/reset stub
+      // print canonical shell-outs for now.
+      await devEnv(args.slice(1));
       return;
     case "version":
     case "--version":

--- a/packages/cli/src/commands/dev-env/config.test.ts
+++ b/packages/cli/src/commands/dev-env/config.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadDevEnvConfig, DEV_ENV_CONFIG_PATH } from "./config.js";
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "slowcook-dev-env-"));
+  mkdirSync(join(repo, ".brewing"), { recursive: true });
+});
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+function writeConfig(yaml: string): void {
+  writeFileSync(join(repo, DEV_ENV_CONFIG_PATH), yaml, "utf8");
+}
+
+describe("loadDevEnvConfig — happy path", () => {
+  it("parses a minimal valid config", () => {
+    writeConfig(`
+schema_version: 1
+apps:
+  patient:
+    mode: dev
+    port: 3001
+`);
+    const config = loadDevEnvConfig(repo);
+    expect(config.schema_version).toBe(1);
+    expect(config.source_branch).toBe("dev"); // default
+    expect(config.apps.patient!.mode).toBe("dev");
+    expect(config.apps.patient!.port).toBe(3001);
+    expect(config.apps.patient!.autoheal).toBe(true); // default
+  });
+
+  it("parses a full config with all optional fields", () => {
+    writeConfig(`
+schema_version: 1
+source_branch: dev
+seed_script: scripts/seed-dev-data.ts
+ssh_target:
+  host: delgoosh-box
+  user: gha-runner
+  checkout_dir: /opt/delgoosh-dev
+  key_secret: DELGOOSH_DEV_SSH_KEY
+persistence:
+  db_volume: pg-dev-data
+  uploads_volume: minio-dev-data
+apps:
+  patient:
+    mode: dev
+    port: 3001
+  back:
+    mode: nest-watch
+    port: 4000
+    autoheal: false
+  admin:
+    mode: start
+    port: 3000
+    container: delgoosh-admin
+`);
+    const config = loadDevEnvConfig(repo);
+    expect(config.seed_script).toBe("scripts/seed-dev-data.ts");
+    expect(config.ssh_target?.host).toBe("delgoosh-box");
+    expect(config.ssh_target?.key_secret).toBe("DELGOOSH_DEV_SSH_KEY");
+    expect(config.persistence.db_volume).toBe("pg-dev-data");
+    expect(Object.keys(config.apps).sort()).toEqual(["admin", "back", "patient"]);
+    expect(config.apps.back!.mode).toBe("nest-watch");
+    expect(config.apps.back!.autoheal).toBe(false);
+    expect(config.apps.admin!.container).toBe("delgoosh-admin");
+  });
+
+  it("accepts every documented mode", () => {
+    writeConfig(`
+schema_version: 1
+apps:
+  a: { mode: dev, port: 3001 }
+  b: { mode: start, port: 3002 }
+  c: { mode: nest-watch, port: 4000 }
+  d: { mode: static, port: 8080 }
+  e: { mode: none, port: 9000 }
+`);
+    const config = loadDevEnvConfig(repo);
+    expect(Object.values(config.apps).map((a) => a.mode).sort()).toEqual([
+      "dev",
+      "nest-watch",
+      "none",
+      "start",
+      "static",
+    ]);
+  });
+});
+
+describe("loadDevEnvConfig — failures", () => {
+  it("throws when the file is missing", () => {
+    expect(() => loadDevEnvConfig(repo)).toThrow(/not found/);
+  });
+
+  it("throws on malformed YAML", () => {
+    writeConfig("not: valid: yaml: { because");
+    expect(() => loadDevEnvConfig(repo)).toThrow(/not valid YAML/);
+  });
+
+  it("rejects unknown mode", () => {
+    writeConfig(`
+schema_version: 1
+apps:
+  x:
+    mode: bogus
+    port: 3001
+`);
+    expect(() => loadDevEnvConfig(repo)).toThrow(/failed validation/);
+  });
+
+  it("rejects negative port", () => {
+    writeConfig(`
+schema_version: 1
+apps:
+  x:
+    mode: dev
+    port: -1
+`);
+    expect(() => loadDevEnvConfig(repo)).toThrow(/failed validation/);
+  });
+
+  it("rejects wrong schema_version", () => {
+    writeConfig(`
+schema_version: 2
+apps:
+  x: { mode: dev, port: 3001 }
+`);
+    expect(() => loadDevEnvConfig(repo)).toThrow(/failed validation/);
+  });
+
+  it("rejects ssh_target with missing required fields", () => {
+    writeConfig(`
+schema_version: 1
+ssh_target:
+  host: delgoosh-box
+apps:
+  x: { mode: dev, port: 3001 }
+`);
+    expect(() => loadDevEnvConfig(repo)).toThrow(/failed validation/);
+  });
+});

--- a/packages/cli/src/commands/dev-env/config.ts
+++ b/packages/cli/src/commands/dev-env/config.ts
@@ -1,0 +1,111 @@
+/**
+ * `.brewing/dev-env.yaml` config schema — Phase 2 of the dev-env
+ * upstreaming (delgoosh-first proof in Phase 1, generalised here).
+ *
+ * Consumers describe their dev env once: which apps run, in what
+ * mode (hot-reload vs production-shaped), which git branch the env
+ * mirrors (default `dev`), how seed data flows, and the optional SSH
+ * target if the env runs on a remote box.
+ *
+ * Then `slowcook dev-env <subcmd>` reads the file and acts. Today
+ * this Phase 2 cut ships only `push` end-to-end (the load-bearing
+ * operation for Phase 3 brew/plate wiring); `up`, `sync`, `switch`,
+ * `reset` ship as stubs that emit the canonical command shell for
+ * the consumer to wire into their workflow.
+ */
+
+import { z } from "zod";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+
+export const DEV_ENV_CONFIG_PATH = ".brewing/dev-env.yaml";
+
+const AppModeSchema = z.enum([
+  "dev", // Next dev (hot reload) — for apps under active story development
+  "start", // next build + next start — production-shaped, slower restart
+  "nest-watch", // ts-node-dev / nest start --watch — backend hot reload
+  "static", // serve a built static export, never re-run
+  "none", // entry exists but isn't started by `dev-env up` (e.g. cron)
+]);
+
+const AppSchema = z.object({
+  mode: AppModeSchema,
+  port: z.number().int().positive(),
+  /** Restart on crash. Defaults to true. */
+  autoheal: z.boolean().optional().default(true),
+  /** Optional: explicit container/process name override (otherwise the key). */
+  container: z.string().optional(),
+});
+
+const PersistenceSchema = z.object({
+  /**
+   * Named docker volume that survives `dev-env reset`. PM-added DB
+   * rows persist across redeploys; only the seed-owned rows are
+   * touched by reset.
+   */
+  db_volume: z.string().optional(),
+  /** Named volume for uploaded user files / object storage. */
+  uploads_volume: z.string().optional(),
+});
+
+const SshTargetSchema = z.object({
+  host: z.string(),
+  user: z.string(),
+  /** Absolute path on the box where the consumer's checkout lives. */
+  checkout_dir: z.string(),
+  /** Repo secret name holding the SSH private key. */
+  key_secret: z.string().default("DEV_DEPLOY_SSH_KEY"),
+});
+
+export const DevEnvConfigSchema = z.object({
+  $schema: z.string().optional(),
+  schema_version: z.literal(1),
+  /**
+   * The git branch the dev env always reads from. Force-pushable —
+   * agents shove story-branch heads here to preview them. Default:
+   * `dev`.
+   */
+  source_branch: z.string().default("dev"),
+  /**
+   * Path (repo-relative) to the seed script. Run by `dev-env up` and
+   * `dev-env reset`. Must be idempotent on already-seeded data.
+   */
+  seed_script: z.string().optional(),
+  /**
+   * Where the dev env physically runs. Omit for "local docker compose
+   * on the runner" semantics (rare); set for SSH-to-box deploys.
+   */
+  ssh_target: SshTargetSchema.optional(),
+  persistence: PersistenceSchema.optional().default({}),
+  apps: z.record(z.string(), AppSchema),
+});
+
+export type DevEnvConfig = z.infer<typeof DevEnvConfigSchema>;
+export type AppMode = z.infer<typeof AppModeSchema>;
+
+export function loadDevEnvConfig(repoRoot: string): DevEnvConfig {
+  const path = join(repoRoot, DEV_ENV_CONFIG_PATH);
+  if (!existsSync(path)) {
+    throw new Error(
+      `${DEV_ENV_CONFIG_PATH} not found. Run \`slowcook dev-env init\` to scaffold.`,
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = YAML.parse(readFileSync(path, "utf8"));
+  } catch (e) {
+    throw new Error(
+      `${DEV_ENV_CONFIG_PATH} is not valid YAML: ${(e as Error).message}`,
+    );
+  }
+  const parsed = DevEnvConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `${DEV_ENV_CONFIG_PATH} failed validation: ${parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  return parsed.data;
+}

--- a/packages/cli/src/commands/dev-env/index.ts
+++ b/packages/cli/src/commands/dev-env/index.ts
@@ -1,0 +1,245 @@
+/**
+ * `slowcook dev-env <subcmd>` — manages the consumer's long-lived
+ * dev/preview environment. Phase 2 of the dev-env design.
+ *
+ * Subcommands:
+ *
+ *   push --story <id> [--branch <name>]
+ *     Force-push the current branch (or --branch) to the configured
+ *     `source_branch` (default: `dev`). Agents (brew, plate) invoke
+ *     this to preview their story-branch on the shared dev URL.
+ *     Phase 3 wires this into brew/plate workflows automatically.
+ *
+ *   switch --story <id>
+ *     Locate the PR for story <id>, force-push its HEAD to
+ *     `source_branch`. Operator-driven version of `push`.
+ *
+ *   up | sync | reset
+ *     Phase 2 stubs — print the canonical shell-out for the consumer
+ *     to wire into their dev-deploy workflow. Phase 2.1 fills in the
+ *     SSH-driven runtime path.
+ *
+ *   init
+ *     Phase 2.1 stub — scaffold `.brewing/dev-env.yaml` from detected
+ *     apps. Not implemented yet; consumers hand-author for now.
+ */
+
+import { execSync } from "node:child_process";
+import { loadDevEnvConfig, type DevEnvConfig } from "./config.js";
+
+interface ParsedArgs {
+  subcommand: string;
+  story?: string;
+  branch?: string;
+  repoRoot: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    subcommand: argv[0] ?? "help",
+    repoRoot: process.cwd(),
+  };
+  for (let i = 1; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === "--story" && next) {
+      args.story = next;
+      i++;
+    } else if (a === "--branch" && next) {
+      args.branch = next;
+      i++;
+    } else if (a === "--cwd" && next) {
+      args.repoRoot = next;
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`
+slowcook dev-env — manage the long-lived dev/preview environment
+
+Subcommands:
+  push --story <id> [--branch <name>]
+      Force-push the current branch (or --branch) to the dev env's
+      source_branch (default: dev). Agents invoke this to preview a
+      story-branch on the shared dev URL.
+
+  switch --story <id>
+      Look up the PR for story <id> and push its HEAD to source_branch.
+
+  up | sync | reset
+      Phase 2 stubs — print the canonical shell-out for the consumer
+      to wire into their dev-deploy workflow.
+
+Config:
+  .brewing/dev-env.yaml describes apps, modes, ports, ssh target, seed
+  script. See slowcook's docs/dev-env.md for the schema.
+
+Examples:
+  slowcook dev-env push --story 001
+  slowcook dev-env switch --story 001
+`);
+}
+
+export async function devEnv(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  // help has no config dependency — render before anything else
+  if (
+    args.subcommand === "help" ||
+    args.subcommand === "--help" ||
+    args.subcommand === "-h"
+  ) {
+    printHelp();
+    return;
+  }
+
+  let config: DevEnvConfig;
+  try {
+    config = loadDevEnvConfig(args.repoRoot);
+  } catch (e) {
+    console.error(`slowcook dev-env: ${(e as Error).message}`);
+    process.exit(64);
+  }
+
+  switch (args.subcommand) {
+    case "push":
+      return runPush(args, config);
+    case "switch":
+      return runSwitch(args, config);
+    case "up":
+    case "sync":
+    case "reset":
+      return printStubShell(args.subcommand, config);
+    default:
+      console.error(`Unknown subcommand: ${args.subcommand}`);
+      printHelp();
+      process.exit(64);
+  }
+}
+
+/**
+ * Force-push the local branch to source_branch on origin. The git
+ * mechanics are the load-bearing part of Phase 3's auto-preview flow.
+ */
+function runPush(args: ParsedArgs, config: DevEnvConfig): void {
+  const sourceBranch = config.source_branch;
+  const localBranch =
+    args.branch ??
+    execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd: args.repoRoot,
+      encoding: "utf8",
+    }).trim();
+  if (!localBranch || localBranch === "HEAD") {
+    console.error(
+      "slowcook dev-env push: couldn't resolve a local branch (detached HEAD?). Pass --branch <name>.",
+    );
+    process.exit(64);
+  }
+  console.log(
+    `[dev-env push] ${localBranch} → origin/${sourceBranch}${args.story ? ` (story-${args.story})` : ""}`,
+  );
+  try {
+    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, {
+      cwd: args.repoRoot,
+      stdio: "inherit",
+    });
+  } catch {
+    console.error(
+      `slowcook dev-env push: git push failed. Check your push permissions on origin/${sourceBranch}.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `[dev-env push] done. dev-deploy workflow will fire on origin/${sourceBranch}.`,
+  );
+}
+
+/**
+ * Look up a PR by story id (via the gh CLI) and push its HEAD to
+ * source_branch. For operator-driven "show me story X on the dev URL"
+ * without checking out the branch locally.
+ */
+function runSwitch(args: ParsedArgs, config: DevEnvConfig): void {
+  if (!args.story) {
+    console.error("slowcook dev-env switch: --story <id> required.");
+    process.exit(64);
+  }
+  const sourceBranch = config.source_branch;
+  // Use the GitHub CLI to find the open PR for the story. gh is part
+  // of slowcook's hard dependencies (already used by every other
+  // command); fail clearly if missing.
+  let prRef: string;
+  try {
+    const out = execSync(
+      `gh pr list --search "story-${args.story} in:title" --json headRefName,number --limit 1 --jq '.[0].headRefName'`,
+      { cwd: args.repoRoot, encoding: "utf8" },
+    ).trim();
+    if (!out) {
+      console.error(
+        `slowcook dev-env switch: no open PR found with "story-${args.story}" in the title.`,
+      );
+      process.exit(1);
+    }
+    prRef = out;
+  } catch (e) {
+    console.error(
+      `slowcook dev-env switch: gh CLI failed — ${(e as Error).message.slice(0, 200)}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `[dev-env switch] story-${args.story} → ${prRef} → origin/${sourceBranch}`,
+  );
+  // Fetch the PR's branch + push it to source_branch.
+  execSync(`git fetch origin ${prRef}`, {
+    cwd: args.repoRoot,
+    stdio: "inherit",
+  });
+  execSync(`git push --force origin origin/${prRef}:${sourceBranch}`, {
+    cwd: args.repoRoot,
+    stdio: "inherit",
+  });
+  console.log(`[dev-env switch] done.`);
+}
+
+/**
+ * Stub for up / sync / reset — emits the canonical shell command the
+ * consumer wires into their dev-deploy workflow. Phase 2.1 will fill
+ * in the SSH-driven runtime path that respects ssh_target + apps[*].mode.
+ */
+function printStubShell(subcommand: string, config: DevEnvConfig): void {
+  const apps = Object.keys(config.apps).join(", ");
+  console.log(
+    `slowcook dev-env ${subcommand}: phase-2 stub. Apps configured: ${apps}.`,
+  );
+  console.log("");
+  switch (subcommand) {
+    case "up":
+      console.log("Wire this into your dev-deploy workflow:");
+      console.log("  docker compose -f compose.dev.yml up -d --build");
+      if (config.seed_script) {
+        console.log(`  pnpm exec ts-node ${config.seed_script}`);
+      }
+      break;
+    case "sync":
+      console.log("Wire this into your dev-deploy workflow:");
+      console.log(`  git fetch origin && git reset --hard origin/${config.source_branch}`);
+      console.log("  pnpm install --prefer-frozen-lockfile && pnpm build");
+      console.log("  docker compose -f compose.dev.yml up -d --build");
+      break;
+    case "reset":
+      console.log("Wire this into your dev-deploy workflow:");
+      if (config.seed_script) {
+        console.log(`  pnpm exec ts-node ${config.seed_script} --reset`);
+      } else {
+        console.log("  (no seed_script configured — nothing to reset)");
+      }
+      break;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of dev-env upstreaming. Phase 1 (delgoosh#632) proved the shape; this PR generalises so other consumers adopt the same flow by authoring \`.brewing/dev-env.yaml\` + invoking \`slowcook dev-env <subcmd>\`.

Full checkpoint: \`docs/dev-env-checkpoint-phase-2.md\`.

## What lands

- **Zod-validated config** at \`packages/cli/src/commands/dev-env/config.ts\`. Declares apps (mode/port/autoheal), source_branch (default \`dev\`), seed_script, ssh_target, persistence volumes.
- **\`slowcook dev-env push --story <id>\`** — fully wired. Force-pushes current branch to source_branch. Load-bearing for Phase 3 brew/plate auto-preview.
- **\`slowcook dev-env switch --story <id>\`** — locates the PR via gh CLI, force-pushes its HEAD to source_branch.
- **\`up\` / \`sync\` / \`reset\`** — Phase-2 stubs that print canonical shell-outs. Phase 2.1 will SSH-execute via ssh_target.
- 9 config tests covering happy paths + every failure shape.

## Test coverage

- cli **809/809** passing (was 800; +9 for dev-env config tests).
- eval gate **2/2** fixtures green (no prompts touched).

## Phase 3 next

Wire \`slowcook dev-env push\` into brew + plate workflows so a fresh PR auto-previews on the shared dev URL. ~1 small slowcook PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)