### PR TITLE
cli α.23: refine sees mock/src/ as design source-of-truth

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.22",
+  "version": "0.19.0-alpha.23",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/context.ts
+++ b/packages/cli/src/commands/refine/context.ts
@@ -125,6 +125,7 @@ export function readHistoryIndexDigest(repoRoot: string): string | null {
       api_routes?: Array<{ method: string; path: string; file: string }>;
       migrations?: Array<{ file: string; tables_created: string[]; columns_added: Record<string, string[]> }>;
       test_helpers?: Array<{ name: string; file: string; purpose: string }>;
+      mock_surface?: Array<{ file: string; route: string | null; name: string; excerpt: string }>;
     };
     const lines: string[] = [];
     lines.push("## Code history index (auto-generated; treat as authoritative)\n");
@@ -161,6 +162,27 @@ export function readHistoryIndexDigest(repoRoot: string): string | null {
       }
       lines.push("");
       lines.push("Column-level detail is in `.brewing/history-index.json`.");
+      lines.push("");
+    }
+
+    // 0.19.0-α.23 — mock surface is the consumer's hand-authored
+    // design source-of-truth. When the PM says "match the mock" or
+    // gestures at an existing flow, refine reads the actual mock JSX
+    // here instead of asking the PM for paths.
+    if (idx.mock_surface && idx.mock_surface.length > 0) {
+      lines.push("### Mock surface (design source-of-truth)");
+      lines.push(
+        "These are the consumer's hand-authored mock pages/components. When the PM says \"match the mock\" or references an existing flow without citing a file, treat these as the canonical design. Mirror layout, role toggles, copy, and behavior in your spec; only deviate when the PM explicitly asks."
+      );
+      lines.push("");
+      for (const m of idx.mock_surface) {
+        const routeLabel = m.route ? `route \`${m.route}\`` : "component";
+        lines.push(`<details><summary><strong>${m.name}</strong> — ${routeLabel} (\`${m.file}\`)</summary>\n`);
+        lines.push("```tsx");
+        lines.push(m.excerpt);
+        lines.push("```");
+        lines.push("</details>\n");
+      }
       lines.push("");
     }
 

--- a/packages/cli/src/commands/refine/history-index.test.ts
+++ b/packages/cli/src/commands/refine/history-index.test.ts
@@ -6,6 +6,7 @@ import {
   buildHistoryIndex,
   scanMigrations,
   parseTypeOrmMigration,
+  scanMockSurface,
 } from "./history-index.js";
 
 let repo: string;
@@ -250,6 +251,124 @@ describe("scanMigrations — auto-discovery + mixed formats", () => {
     const root = mkdtempSync(join(tmpdir(), "slowcook-none-"));
     try {
       expect(scanMigrations(root, "supabase/migrations")).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanMockSurface — 0.19.0-α.23 mock-aware refine context", () => {
+  it("returns empty when mock/src is absent", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-no-mock-"));
+    try {
+      expect(scanMockSurface(root, "mock/src")).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("captures a page.tsx with inferred route + name + excerpt", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-page-"));
+    try {
+      mkdirSync(join(root, "mock/src/app/login"), { recursive: true });
+      writeFileSync(
+        join(root, "mock/src/app/login/page.tsx"),
+        `export default function LoginPage() {
+  return <form>email + password</form>;
+}`,
+        "utf8"
+      );
+      const out = scanMockSurface(root, "mock/src");
+      expect(out).toHaveLength(1);
+      expect(out[0]!.route).toBe("/login");
+      expect(out[0]!.name).toBe("LoginPage");
+      expect(out[0]!.excerpt).toContain("email + password");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("strips parenthesised layout-group segments from the route", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-group-"));
+    try {
+      mkdirSync(join(root, "mock/src/app/(patient)/dashboard"), { recursive: true });
+      writeFileSync(
+        join(root, "mock/src/app/(patient)/dashboard/page.tsx"),
+        `export default function Dashboard() { return <div />; }`,
+        "utf8"
+      );
+      const out = scanMockSurface(root, "mock/src");
+      // (patient) is a layout group — should NOT appear in the URL
+      expect(out[0]!.route).toBe("/dashboard");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("collapses the root page to / not /page.tsx", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-root-"));
+    try {
+      mkdirSync(join(root, "mock/src/app"), { recursive: true });
+      writeFileSync(
+        join(root, "mock/src/app/page.tsx"),
+        `export default function Root() { return <div/>; }`,
+        "utf8"
+      );
+      const out = scanMockSurface(root, "mock/src");
+      expect(out[0]!.route).toBe("/");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("captures non-page components with route=null", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-comp-"));
+    try {
+      mkdirSync(join(root, "mock/src/components"), { recursive: true });
+      writeFileSync(
+        join(root, "mock/src/components/TicketCard.tsx"),
+        `export function TicketCard() { return null; }`,
+        "utf8"
+      );
+      const out = scanMockSurface(root, "mock/src");
+      expect(out).toHaveLength(1);
+      expect(out[0]!.route).toBeNull();
+      expect(out[0]!.name).toBe("TicketCard");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("truncates excerpts over 1500 chars", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-big-"));
+    try {
+      mkdirSync(join(root, "mock/src/app/big"), { recursive: true });
+      const huge = "// padding\n".repeat(500);
+      writeFileSync(
+        join(root, "mock/src/app/big/page.tsx"),
+        `export default function Big() {\n${huge}\n  return null;\n}`,
+        "utf8"
+      );
+      const out = scanMockSurface(root, "mock/src");
+      expect(out[0]!.excerpt.length).toBeLessThan(1700);
+      expect(out[0]!.excerpt).toContain("truncated");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("is exposed via buildHistoryIndex's mock_surface field", () => {
+    const root = mkdtempSync(join(tmpdir(), "slowcook-mock-build-"));
+    try {
+      mkdirSync(join(root, "mock/src/app/login"), { recursive: true });
+      writeFileSync(
+        join(root, "mock/src/app/login/page.tsx"),
+        `export default function L(){return <div/>;}`,
+        "utf8"
+      );
+      const idx = buildHistoryIndex({ repoRoot: root });
+      expect(idx.mock_surface).toHaveLength(1);
+      expect(idx.mock_surface[0]!.route).toBe("/login");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/refine/history-index.ts
+++ b/packages/cli/src/commands/refine/history-index.ts
@@ -68,6 +68,31 @@ export interface TestFileEntry {
   test_names: string[];
 }
 
+/**
+ * A mock page or component, captured so refine can answer
+ * "match the mock" without making the PM cite paths.
+ *
+ * 0.19.0-α.23 — added because real PM issues describe user pain
+ * ("registration should look like the mock"), and the indexer
+ * previously only saw production `src/`. Refine then either
+ * hallucinated a design or had to ask. Surfacing mock files in
+ * context closes the loop: PM says "as mock" → refine reads the
+ * actual mock excerpt → spec mirrors it.
+ *
+ * The excerpt is bounded to the first ~1.5KB so refine's prompt
+ * doesn't blow up on a 5KB mock file.
+ */
+export interface MockEntry {
+  /** repo-relative path. */
+  file: string;
+  /** Route inferred from app/router-shape file location, or null for components. */
+  route: string | null;
+  /** Component or page name (best-effort extraction, falls back to file basename). */
+  name: string;
+  /** First ~1500 chars of the file (after trimming whitespace) so refine sees the actual JSX/markup. */
+  excerpt: string;
+}
+
 export interface HistoryIndex {
   generated_at: string;
   generator: "slowcook-refine-history-index@0.17.0";
@@ -76,6 +101,8 @@ export interface HistoryIndex {
   migrations: MigrationEntry[];
   test_helpers: TestHelperEntry[];
   test_files: TestFileEntry[];
+  /** 0.19.0-α.23 — mock surface (design source-of-truth). */
+  mock_surface: MockEntry[];
 }
 
 interface BuildOptions {
@@ -87,6 +114,8 @@ interface BuildOptions {
     migrations?: string;
     tests?: string;
     helpers?: string;
+    /** Default: `mock/src` (matches slowcook init scaffold). */
+    mockRoot?: string;
   };
 }
 
@@ -98,6 +127,7 @@ export function buildHistoryIndex(opts: BuildOptions): HistoryIndex {
     migrations: opts.scanPaths?.migrations ?? "supabase/migrations",
     tests: opts.scanPaths?.tests ?? "tests",
     helpers: opts.scanPaths?.helpers ?? "tests/helpers",
+    mockRoot: opts.scanPaths?.mockRoot ?? "mock/src",
   };
 
   const components = scanComponents(repoRoot, paths.components);
@@ -105,6 +135,7 @@ export function buildHistoryIndex(opts: BuildOptions): HistoryIndex {
   const migrations = scanMigrations(repoRoot, paths.migrations);
   const test_helpers = scanTestHelpers(repoRoot, paths.helpers);
   const test_files = scanTestFiles(repoRoot, paths.tests);
+  const mock_surface = scanMockSurface(repoRoot, paths.mockRoot);
 
   // Reverse-index test → component coverage (which components each test
   // imports → annotate components.tests_covering).
@@ -124,6 +155,7 @@ export function buildHistoryIndex(opts: BuildOptions): HistoryIndex {
     api_routes,
     migrations,
     test_helpers,
+    mock_surface,
     test_files,
   };
 }
@@ -472,6 +504,61 @@ function scanTestFiles(repoRoot: string, dir: string): TestFileEntry[] {
     out.push({ file: rel, imports, test_names });
   }
   return out;
+}
+
+// ----- Mock surface scanner (0.19.0-α.23) -----
+//
+// The mock dir is the consumer's hand-authored design source-of-truth.
+// Refine reads each file's route (inferred from app-router shape) +
+// a bounded excerpt, so a PM issue saying "match the mock" produces
+// a spec mirroring the mock without the PM citing paths.
+
+const MOCK_EXCERPT_LIMIT = 1500;
+
+export function scanMockSurface(repoRoot: string, mockRoot: string): MockEntry[] {
+  const root = join(repoRoot, mockRoot);
+  if (!existsSync(root)) return [];
+  const out: MockEntry[] = [];
+  for (const file of walkFiles(root, /\.(tsx|ts)$/)) {
+    const rel = relative(repoRoot, file).replace(/\\/g, "/");
+    // Skip non-page TS files (utilities, types) — focus on UI surface.
+    if (!rel.endsWith(".tsx") && !rel.endsWith("page.ts")) continue;
+    const body = readFileSync(file, "utf8");
+    const route = inferMockRoute(rel, mockRoot);
+    const name = extractComponentName(body, rel) ?? routeOrFileFallback(rel, route);
+    const excerpt = trimExcerpt(body, MOCK_EXCERPT_LIMIT);
+    out.push({ file: rel, route, name, excerpt });
+  }
+  return out;
+}
+
+function inferMockRoute(rel: string, mockRoot: string): string | null {
+  // Next.js app-router shape: <mockRoot>/app/<...segments>/page.tsx → /<segments>
+  // Parenthesised segments are layout groups, stripped from the URL.
+  const appPrefix = `${mockRoot}/app/`;
+  if (!rel.startsWith(appPrefix)) return null;
+  if (!rel.endsWith("/page.tsx") && !rel.endsWith("/page.ts")) return null;
+  // `/?` makes the leading slash optional so the root page
+  // (`mock/src/app/page.tsx`) collapses to "" → final route "/" instead
+  // of the buggy "/page.tsx".
+  const segments = rel
+    .slice(appPrefix.length)
+    .replace(/\/?page\.(tsx|ts)$/, "")
+    .split("/")
+    .filter((s) => s.length > 0 && !(s.startsWith("(") && s.endsWith(")")));
+  return "/" + segments.join("/");
+}
+
+function routeOrFileFallback(rel: string, route: string | null): string {
+  if (route) return route;
+  const base = rel.split("/").pop() ?? rel;
+  return base.replace(/\.(tsx|ts)$/, "");
+}
+
+function trimExcerpt(body: string, limit: number): string {
+  const trimmed = body.trim();
+  if (trimmed.length <= limit) return trimmed;
+  return trimmed.slice(0, limit) + "\n/* ...truncated... */";
 }
 
 // ----- File walker -----


### PR DESCRIPTION
## Summary

PMs shouldn't have to cite paths. Before today, a sparse issue like \"registration should match the mock\" forced refine to ask \"which mock?\" or hallucinate — because the brownfield indexer only scanned \`src/\`. \`mock/\` (the hand-authored design) was invisible.

This PR adds **\`mock_surface\` to HistoryIndex**:

- Walks \`mock/src/**/*.tsx\`
- Captures per file: inferred route (Next app-router shape, parenthesised layout groups stripped, root \`page.tsx\` → \`/\`), component name, first ~1.5KB excerpt of actual JSX
- Refine's context block renders each as a collapsed \`<details>\` block — visible when needed, folded otherwise

Prompt contract: \"When the PM says 'match the mock' or references an existing flow without citing a file, treat these as the canonical design. Mirror layout, role toggles, copy, behavior; only deviate when the PM explicitly asks.\"

## Smoke test on delgoosh

\`\`\`
mock_surface entries: 36
  /login → LoginPage
  / → RoleChooserPage              ← root page now resolves correctly
  /patient/dashboard → PatientDashboardPage
  /patient/appointments → PatientAppointmentsPage
  ... (32 more)
\`\`\`

## Test coverage

- cli **824/824** passing (was 817; +7 scanner tests)
- eval gate **2/2** fixtures green

## What this unlocks downstream

Sparse PM issues like:

> Patient registration / signin — match the mock
>
> As a new patient, I want signing up + logging in to look and behave like our existing mock.
> Today the patient app has no login/signin; the dev URL is blank.

become actionable. Refine sees the mock JSX in context, doesn't ask for paths, and emits a spec mirroring the mock's design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)