### PR TITLE
cli α.27: refine spec emit graceful for missing required arrays

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.26",
+  "version": "0.19.0-alpha.27",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/agent.test.ts
+++ b/packages/cli/src/commands/refine/agent.test.ts
@@ -64,16 +64,24 @@ Please answer inline.`;
     expect(out.kind).toBe("spec");
   });
 
-  it("throws a clear error when YAML-shaped output fails schema", () => {
-    const bad = `
+  it("defaults missing required-array fields instead of throwing (α.27 change)", () => {
+    // Was a throw-on-missing test pre-α.27. Now the missing arrays
+    // (preconditions, invariants, non_goals) default to [] so the
+    // PM doesn't lose work to a silent crash.
+    const yaml = `---
 title: missing required fields
 actors:
   - name: x
 acceptance_scenarios:
   - scenario-one
 `;
-    // missing preconditions, invariants, non_goals
-    expect(() => parseAgentOutput(bad, CTX)).toThrow(/validation|required/);
+    const out = parseAgentOutput(yaml, CTX);
+    expect(out.kind).toBe("spec");
+    if (out.kind === "spec") {
+      expect(out.spec.preconditions).toEqual([]);
+      expect(out.spec.invariants).toEqual([]);
+      expect(out.spec.non_goals).toEqual([]);
+    }
   });
 
   it("supersedes field is taken from the provided context, not the agent's output", () => {
@@ -90,6 +98,40 @@ acceptance_scenarios:
 
   it("empty output triggers an explicit error (not silent questions)", () => {
     expect(() => parseAgentOutput("", CTX)).toThrow(/empty/);
+  });
+
+  it("defaults missing non_goals to [] instead of crashing (delgoosh#635 round 6 fix)", () => {
+    const yamlWithoutNonGoals = `---
+title: Test story
+actors:
+  - name: user
+preconditions:
+  - X
+invariants:
+  - Y
+acceptance_scenarios:
+  - Z
+`;
+    const out = parseAgentOutput(yamlWithoutNonGoals, CTX);
+    expect(out.kind).toBe("spec");
+    if (out.kind === "spec") {
+      expect(out.spec.non_goals).toEqual([]);
+    }
+  });
+
+  it("defaults ALL required-array fields when the LLM forgets multiple", () => {
+    const yamlMinimal = `---
+title: Bare-minimum spec
+`;
+    const out = parseAgentOutput(yamlMinimal, CTX);
+    expect(out.kind).toBe("spec");
+    if (out.kind === "spec") {
+      expect(out.spec.actors).toEqual([]);
+      expect(out.spec.preconditions).toEqual([]);
+      expect(out.spec.invariants).toEqual([]);
+      expect(out.spec.acceptance_scenarios).toEqual([]);
+      expect(out.spec.non_goals).toEqual([]);
+    }
   });
 });
 

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -578,6 +578,32 @@ function normalizeEmittedSpec(doc: unknown): unknown {
   stringifyArrayEntries("preconditions");
   stringifyArrayEntries("invariants");
   stringifyArrayEntries("non_goals");
+
+  // 0.19.0-α.27 — default missing required-array fields to []. Without
+  // this guard the LLM forgetting a single field (e.g. `non_goals`)
+  // crashes refine + posts NOTHING to the PM. Empty array is the
+  // semantically safe interpretation ("no non-goals listed") and lets
+  // the spec land; the dev sees a warning if any defaulting fires.
+  // Observed crash: delgoosh#635 round 6.
+  const requiredArrays = [
+    "actors",
+    "preconditions",
+    "invariants",
+    "acceptance_scenarios",
+    "non_goals",
+  ];
+  const defaultedFields: string[] = [];
+  for (const key of requiredArrays) {
+    if (out[key] === undefined || out[key] === null) {
+      out[key] = [];
+      defaultedFields.push(key);
+    }
+  }
+  if (defaultedFields.length > 0) {
+    console.warn(
+      `[refine] LLM emit was missing required-array field(s); defaulted to []: ${defaultedFields.join(", ")}. Spec will still emit.`
+    );
+  }
   return out;
 }
 


### PR DESCRIPTION
delgoosh#635 round 6 lost a complete spec to silent crash because non_goals was undefined. This defaults the 5 required-array fields to [] in normalizeEmittedSpec. 832/832 tests green.