### PR TITLE
cli α.28: testgen graceful-degrade (closes sc#65)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.27",
+  "version": "0.19.0-alpha.28",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/testgen/agent.test.ts
+++ b/packages/cli/src/commands/testgen/agent.test.ts
@@ -408,10 +408,36 @@ import { it } from "vitest";
     );
   });
 
-  it("throws when <test_file> block is missing", () => {
+  it("throws when <test_file> block is missing AND mode requires it (no fallback available)", () => {
     expect(() => parseTestgenBundle("no tags here", "042")).toThrow(
       /missing a <test_file>/
     );
+  });
+
+  it("[sc#65] graceful-degrade: full mode missing <ui_test_file> → emit handler-only when test_file IS present", () => {
+    const raw = `
+<test_file>import { POST } from "@/app/api/foo/route";</test_file>
+<stub path="src/app/api/foo/route.ts">export async function POST() { return new Response(); }</stub>
+`;
+    const b = parseTestgenBundle(raw, "042", "full");
+    expect(b.testContent).toContain("POST");
+    expect(b.uiTestContent).toBe("");
+  });
+
+  it("[sc#65] graceful-degrade: full mode missing <test_file> → emit ui-only when ui_test_file IS present", () => {
+    const pragmaComment = "// @" + "vitest-environment jsdom";
+    const raw = `
+<ui_test_file>${pragmaComment}
+import { it } from "vitest";</ui_test_file>
+`;
+    const b = parseTestgenBundle(raw, "042", "full");
+    expect(b.uiTestContent).toContain("vitest");
+    expect(b.testContent).toBe("");
+  });
+
+  it("[sc#65] still throws when BOTH blocks missing in full mode", () => {
+    expect(() => parseTestgenBundle("<page_link><page>x</page></page_link>", "042", "full"))
+      .toThrow(/missing a <test_file>/);
   });
 
   it("parses a full bundle with UI test + UI stub (mode: full)", () => {
@@ -453,15 +479,19 @@ import { renderWithProviders } from "@tests/helpers/render";</ui_test_file>
     expect(b.uiTestContent).toContain("renderWithProviders");
   });
 
-  it("requires BOTH handler and UI in full mode", () => {
+  it("[changed in α.28 / sc#65] full mode degrades gracefully when one block missing", () => {
+    // Was throw-on-missing pre-α.28. Now degrades to whichever bundle IS
+    // present + warns so the dev sees the LLM's miss. Only throws when
+    // BOTH blocks are absent (covered by the dedicated test above).
     const handlerOnly = `<test_file>handler</test_file>`;
-    expect(() => parseTestgenBundle(handlerOnly, "042", "full")).toThrow(
-      /missing a <ui_test_file>/
-    );
+    const fromHandler = parseTestgenBundle(handlerOnly, "042", "full");
+    expect(fromHandler.testContent).toContain("handler");
+    expect(fromHandler.uiTestContent).toBe("");
+
     const uiOnly = `<ui_test_file>ui</ui_test_file>`;
-    expect(() => parseTestgenBundle(uiOnly, "042", "full")).toThrow(
-      /missing a <test_file>/
-    );
+    const fromUi = parseTestgenBundle(uiOnly, "042", "full");
+    expect(fromUi.uiTestContent).toContain("ui");
+    expect(fromUi.testContent).toBe("");
   });
 
   it("ignores empty <stub>, <helper>, or <ui_stub> blocks", () => {

--- a/packages/cli/src/commands/testgen/agent.ts
+++ b/packages/cli/src/commands/testgen/agent.ts
@@ -770,23 +770,51 @@ export function parseTestgenBundle(
   const uiRequired = mode !== "handler-only";
 
   const testMatch = body.match(/<test_file>([\s\S]*?)<\/test_file>/);
-  if (handlerRequired && (!testMatch || !testMatch[1])) {
-    throw new Error(
-      `testgen: LLM output for story-${storyId} missing a <test_file> block (mode=${mode}). ` +
-        `Got ${body.length} chars starting with: ${body.slice(0, 120)}...`
-    );
-  }
-  const testContent = testMatch && testMatch[1] ? stripInnerFence(testMatch[1]) : "";
-
   const uiTestMatch = body.match(/<ui_test_file>([\s\S]*?)<\/ui_test_file>/);
-  if (uiRequired && (!uiTestMatch || !uiTestMatch[1])) {
-    throw new Error(
-      `testgen: LLM output for story-${storyId} missing a <ui_test_file> block (mode=${mode}). ` +
-        `Got ${body.length} chars starting with: ${body.slice(0, 120)}...`
-    );
+
+  // 0.19.0-α.28 (closes sc#65) — graceful degradation mirroring refine α.27.
+  // Before: missing required block → throw → workflow exits 2 → PM sees
+  // nothing despite the LLM having emitted 40KB+ of real content in the
+  // OTHER block. After: if the OTHER block IS present, emit just that
+  // bundle + log a warning so the dev sees the LLM's miss + can re-run
+  // for the remaining block via `gh workflow run slowcook-testgen.yml`.
+  // ONLY when BOTH blocks are missing in a required mode do we still
+  // throw — at that point the LLM truly produced nothing usable.
+  const handlerPresent = !!(testMatch && testMatch[1]);
+  const uiPresent = !!(uiTestMatch && uiTestMatch[1]);
+  const degraded: string[] = [];
+
+  if (handlerRequired && !handlerPresent) {
+    if (mode === "full" && uiPresent) {
+      degraded.push("handler tests");
+      console.warn(
+        `[testgen] LLM emit for story-${storyId} missing <test_file> block; UI tests present. ` +
+          `Degrading to ui-only output for this round. Re-run testgen to fill in handler tests.`
+      );
+    } else {
+      throw new Error(
+        `testgen: LLM output for story-${storyId} missing a <test_file> block (mode=${mode}). ` +
+          `Got ${body.length} chars starting with: ${body.slice(0, 120)}...`
+      );
+    }
   }
-  const uiTestContent =
-    uiTestMatch && uiTestMatch[1] ? stripInnerFence(uiTestMatch[1]) : "";
+  const testContent = handlerPresent ? stripInnerFence(testMatch![1]!) : "";
+
+  if (uiRequired && !uiPresent) {
+    if (mode === "full" && handlerPresent) {
+      degraded.push("UI tests");
+      console.warn(
+        `[testgen] LLM emit for story-${storyId} missing <ui_test_file> block; handler tests present. ` +
+          `Degrading to handler-only output for this round. Re-run testgen to fill in UI tests.`
+      );
+    } else {
+      throw new Error(
+        `testgen: LLM output for story-${storyId} missing a <ui_test_file> block (mode=${mode}). ` +
+          `Got ${body.length} chars starting with: ${body.slice(0, 120)}...`
+      );
+    }
+  }
+  const uiTestContent = uiPresent ? stripInnerFence(uiTestMatch![1]!) : "";
 
   const stubs: Array<{ path: string; contents: string }> = [];
   const stubRe = /<stub\s+path="([^"]+)">([\s\S]*?)<\/stub>/g;


### PR DESCRIPTION
Mirror of refine α.27. Lost $1.50 on a real testgen run when LLM forgot <ui_test_file> block; now degrades + warns. 835/835 tests + eval 2/2 green.