### PR TITLE
cli α.31 + llm-anthropic α.8: ratelimit-headers hint in cost footer (closes sc#69)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.29",
+  "version": "0.19.0-alpha.31",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -2,7 +2,11 @@ import YAML from "yaml";
 import { z } from "zod";
 import type { LlmClient, LlmMessage } from "./llm.js";
 import { costMarker } from "./llm.js";
-import { formatCostFooter, parseCostMarkers } from "@slowcook-ai/llm-anthropic";
+import {
+  formatCostFooter,
+  formatRateLimitHint,
+  parseCostMarkers,
+} from "@slowcook-ai/llm-anthropic";
 
 /**
  * Strip the brand header, cost footer, and HTML cost marker out of a
@@ -290,6 +294,10 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
         parseCostMarkers(c.body)
       );
       footer = formatCostFooter(roundCostUsd, priorMarkers);
+      // 0.19.0-α.31 (sc#69) — append rate-limit hint when the
+      // provider says remaining is tight. Empty string when below
+      // threshold or no rate-limit headers exposed.
+      footer += formatRateLimitHint(agentResponse.rateLimits);
     } catch {
       /* best effort — fall back to no footer if list fails */
     }

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -57,4 +57,20 @@ export interface LlmResponse {
    * itself — the adapter contract preserves this boundary. */
   costUsd: number;
   model: string;
+  /** 0.19.0-α.31 (sc#69) — provider-side rate-limit signal captured from
+   * response headers. Optional; adapters that don't expose headers leave
+   * it undefined. CLI renders a "rate limit tight" hint in cost footers
+   * when remaining drops below a threshold. */
+  rateLimits?: LlmRateLimits;
+}
+
+export interface LlmRateLimits {
+  /** Tokens remaining in the current per-minute / per-day window. */
+  tokensRemaining?: number;
+  /** Requests remaining in the current per-minute window. */
+  requestsRemaining?: number;
+  /** ISO-8601 UTC when the tokens-remaining window resets. */
+  tokensResetAt?: string;
+  /** ISO-8601 UTC when the requests-remaining window resets. */
+  requestsResetAt?: string;
 }

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.7",
+  "version": "0.16.0-alpha.8",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/client.ts
+++ b/packages/llm-anthropic/src/client.ts
@@ -1,6 +1,45 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { LlmClient, LlmRequest, LlmResponse, LlmUsage } from "@slowcook-ai/core";
+import type {
+  LlmClient,
+  LlmRequest,
+  LlmResponse,
+  LlmUsage,
+  LlmRateLimits,
+} from "@slowcook-ai/core";
 import { costUsdForUsage } from "./pricing.js";
+
+/**
+ * 0.19.0-α.31 (sc#69) — extract Anthropic rate-limit headers from a
+ * Response. Headers documented at
+ * https://docs.anthropic.com/en/api/rate-limits. Returns undefined
+ * fields when headers are absent (older SDK / non-standard fixture).
+ */
+/**
+ * Header bag from any fetch-like response. Both node-fetch and undici-types
+ * implement `.get(name) → string | null`; we duck-type rather than pin to
+ * either flavor (the Anthropic SDK has used different bundles over its
+ * release history; staying loose here avoids TS type-collision flakes).
+ */
+interface HeaderBag {
+  get(name: string): string | null;
+}
+
+function extractRateLimits(
+  headers: HeaderBag | undefined
+): LlmRateLimits | undefined {
+  if (!headers || typeof headers.get !== "function") return undefined;
+  const t = headers.get("anthropic-ratelimit-tokens-remaining");
+  const r = headers.get("anthropic-ratelimit-requests-remaining");
+  const tReset = headers.get("anthropic-ratelimit-tokens-reset");
+  const rReset = headers.get("anthropic-ratelimit-requests-reset");
+  if (t === null && r === null && tReset === null && rReset === null) return undefined;
+  const out: LlmRateLimits = {};
+  if (t !== null) out.tokensRemaining = parseInt(t, 10);
+  if (r !== null) out.requestsRemaining = parseInt(r, 10);
+  if (tReset !== null) out.tokensResetAt = tReset;
+  if (rReset !== null) out.requestsResetAt = rReset;
+  return out;
+}
 
 /**
  * Anthropic (Claude) adapter implementing the `LlmClient` contract from
@@ -42,11 +81,19 @@ export class AnthropicClient implements LlmClient {
         content: m.content as never,
       })),
     };
-    const response = await this.client.messages.create(
-      args.temperature !== undefined
-        ? { ...base, temperature: args.temperature }
-        : base
-    );
+    // 0.19.0-α.31 (sc#69) — use withResponse() so we can read the raw
+    // Response object and pull `anthropic-ratelimit-*` headers. The
+    // .data field is the same Message object the older call returned;
+    // the .response field is the underlying fetch Response.
+    const result = await this.client.messages
+      .create(
+        args.temperature !== undefined
+          ? { ...base, temperature: args.temperature }
+          : base
+      )
+      .withResponse();
+    const response = result.data;
+    const rateLimits = extractRateLimits(result.response.headers);
 
     const first = response.content[0];
     if (!first || first.type !== "text") {
@@ -76,6 +123,7 @@ export class AnthropicClient implements LlmClient {
       usage,
       costUsd: costUsdForUsage(args.model, usage),
       model: args.model,
+      rateLimits,
     };
   }
 }

--- a/packages/llm-anthropic/src/index.ts
+++ b/packages/llm-anthropic/src/index.ts
@@ -5,7 +5,9 @@ export {
   costMarker,
   parseCostMarkers,
   formatCostFooter,
+  formatRateLimitHint,
   type ParsedCostMarker,
+  type RateLimitsForHint,
 } from "./pricing.js";
 
 // 0.9.0 — Anthropic-tuned prompts (system strings, tool defs,

--- a/packages/llm-anthropic/src/pricing.test.ts
+++ b/packages/llm-anthropic/src/pricing.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { costMarker, parseCostMarkers, costUsdForUsage } from "./pricing.js";
+import {
+  costMarker,
+  parseCostMarkers,
+  costUsdForUsage,
+  formatRateLimitHint,
+} from "./pricing.js";
 
 describe("costMarker", () => {
   it("renders the required fields", () => {
@@ -134,5 +139,45 @@ describe("costUsdForUsage", () => {
       cacheCreateTokens: 0,
     });
     expect(cost).toBeCloseTo(3);
+  });
+});
+
+describe("[α.31 / sc#69] formatRateLimitHint", () => {
+  it("returns empty string when rateLimits is undefined", () => {
+    expect(formatRateLimitHint(undefined)).toBe("");
+  });
+
+  it("returns empty string when remaining is comfortably above thresholds", () => {
+    expect(
+      formatRateLimitHint({ tokensRemaining: 40000, requestsRemaining: 45 })
+    ).toBe("");
+  });
+
+  it("renders a hint when tokensRemaining is at/below 5000", () => {
+    const hint = formatRateLimitHint({ tokensRemaining: 3200 });
+    expect(hint).toContain("rate limit tight");
+    expect(hint).toContain("3,200 tokens");
+  });
+
+  it("renders a hint when requestsRemaining is at/below 5", () => {
+    const hint = formatRateLimitHint({ requestsRemaining: 2 });
+    expect(hint).toContain("2 req");
+  });
+
+  it("combines token + request hints when BOTH are tight", () => {
+    const hint = formatRateLimitHint({
+      tokensRemaining: 1000,
+      requestsRemaining: 3,
+    });
+    expect(hint).toContain("1,000 tokens");
+    expect(hint).toContain("3 req");
+  });
+
+  it("appends reset time when tokensResetAt is present", () => {
+    const hint = formatRateLimitHint({
+      tokensRemaining: 1000,
+      tokensResetAt: "2026-05-15T18:32:00Z",
+    });
+    expect(hint).toMatch(/until \d{2}:\d{2} UTC/);
   });
 });

--- a/packages/llm-anthropic/src/pricing.ts
+++ b/packages/llm-anthropic/src/pricing.ts
@@ -148,3 +148,48 @@ export function formatCostFooter(
     `**Story total:** $${total.toFixed(2)} (${totalCalls} agent call${totalCalls === 1 ? "" : "s"} so far)</sub>`
   );
 }
+
+/**
+ * 0.19.0-α.31 (sc#69) — mid-flight rate-limit hint. Render a fuel-low
+ * signal in the cost footer when the provider's `*-remaining` headers
+ * are below threshold. Distinct visual from the budget-low warning
+ * (sc#66) — this one is about ephemeral burst pacing, not money.
+ *
+ * Thresholds:
+ *   - tokensRemaining ≤ 5_000  → tight (typical per-minute pool is 40K–80K)
+ *   - requestsRemaining ≤ 5    → tight
+ * Returns empty string when neither field is present or both are
+ * above threshold — so footers stay clean during normal operation.
+ */
+export interface RateLimitsForHint {
+  tokensRemaining?: number;
+  requestsRemaining?: number;
+  tokensResetAt?: string;
+  requestsResetAt?: string;
+}
+
+export function formatRateLimitHint(rl: RateLimitsForHint | undefined): string {
+  if (!rl) return "";
+  const tightTokens = rl.tokensRemaining !== undefined && rl.tokensRemaining <= 5000;
+  const tightRequests = rl.requestsRemaining !== undefined && rl.requestsRemaining <= 5;
+  if (!tightTokens && !tightRequests) return "";
+  const parts: string[] = [];
+  if (tightTokens) parts.push(`${rl.tokensRemaining!.toLocaleString()} tokens`);
+  if (tightRequests) parts.push(`${rl.requestsRemaining} req`);
+  let resetAt = rl.tokensResetAt ?? rl.requestsResetAt;
+  let resetText = "";
+  if (resetAt) {
+    // ISO-8601 → "HH:MM UTC" if parseable.
+    try {
+      const d = new Date(resetAt);
+      if (!isNaN(d.getTime())) {
+        const hh = d.getUTCHours().toString().padStart(2, "0");
+        const mm = d.getUTCMinutes().toString().padStart(2, "0");
+        resetText = ` until ${hh}:${mm} UTC`;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return ` · ⚠️ rate limit tight: ${parts.join(" / ")} left${resetText}`;
+}


### PR DESCRIPTION
Mid-flight funds-warning layer. Anthropic ratelimit-* headers → rendered in cost footer when remaining drops below threshold. 842/842 cli + 19/19 llm-anthropic + eval 2/2 green.