### PR TITLE
cli α.34: canonical cost storage + project fuel gauge (closes sc#67, sc#66)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.33",
+  "version": "0.19.0-alpha.34",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -69,6 +69,8 @@ import {
 import { applySupersede } from "@slowcook-ai/core";
 import { enrichBodyWithImages } from "./images.js";
 import { auditSideEffects, sideEffectsCommentBody } from "./side-effects-audit.js";
+import { appendCostEntry, applyCostToSpec, costSidecarPath } from "../../cost-store.js";
+import { fuelGaugeFromRepo } from "../../lib/budget.js";
 
 export const LABEL_CHANGE_OF_MIND = "change-of-mind";
 export const LABEL_BLOCKED_CONTRADICTION = "blocked-contradiction";
@@ -298,6 +300,9 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
       // provider says remaining is tight. Empty string when below
       // threshold or no rate-limit headers exposed.
       footer += formatRateLimitHint(agentResponse.rateLimits);
+      // 0.19.0-α.34 (sc#66) — project-level fuel gauge. Empty
+      // string when no .brewing/budget.yaml exists (opt-in).
+      footer += fuelGaugeFromRepo(ctx.repoRoot, ctx.now);
     } catch {
       /* best effort — fall back to no footer if list fails */
     }
@@ -329,6 +334,27 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
   }
   const specPath = writeSpec(ctx.repoRoot, spec);
 
+  // 0.19.0-α.34 (sc#67) — canonical cost storage. Record this refine
+  // round to the sidecar, then update spec.cost.total_usd. Sidecar is
+  // append-only JSONL; spec yaml is rewritten with the new total.
+  // Best-effort: never fail the spec emit on a cost-storage hiccup.
+  try {
+    appendCostEntry(ctx.repoRoot, spec.story_id, {
+      agent: "refine",
+      usd: roundCostUsd,
+      model: ctx.refineModel,
+      round: "spec",
+      at: ctx.now.toISOString(),
+      tokens_in: totalTokensIn,
+      tokens_out: totalTokensOut,
+      cache_read: totalCacheRead,
+      cache_create: totalCacheCreate,
+    });
+    applyCostToSpec(ctx.repoRoot, spec.story_id, ctx.now.toISOString());
+  } catch (e) {
+    console.warn(`[refine] cost-store update failed: ${(e as Error).message}`);
+  }
+
   const index = readIndex(ctx.repoRoot);
   const updatedIndex = applySupersede(
     index,
@@ -353,6 +379,15 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
   await ctx.forge.git.stage(`specs/_index.yaml`);
   for (const f of mockResult.written) {
     await ctx.forge.git.stage(f);
+  }
+  // 0.19.0-α.34 (sc#67) — stage the cost sidecar so it ships with
+  // the spec PR. Best-effort: skip silently if it doesn't exist
+  // (e.g., cost-store write failed above).
+  try {
+    const sidecar = costSidecarPath(ctx.repoRoot, spec.story_id);
+    await ctx.forge.git.stage(sidecar);
+  } catch {
+    /* best effort */
   }
   await ctx.forge.git.commit(
     `slowcook: spec story-${spec.story_id} — ${spec.title}\n\nRefined from #${ctx.issueNumber}.`
@@ -383,11 +418,16 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
     // Post a cost-carrying comment so the pipeline-total aggregator can
     // see refine's spend alongside testgen's + brew's at the end. Best-effort.
     try {
+      // 0.19.0-α.34 (sc#66) — append the fuel gauge to the
+      // spec-submitted comment too. Empty string when budget.yaml is
+      // absent (opt-in).
+      const gauge = fuelGaugeFromRepo(ctx.repoRoot, ctx.now);
       await ctx.forge.createIssueComment(
         ctx.issueNumber,
         `### slowcook · spec submitted\n\n` +
           `Spec \`story-${spec.story_id}\` opened at [PR #${pr.number}](${pr.url}). Merge to trigger \`slowcook-testgen\`.\n\n` +
-          refineCostMarker
+          refineCostMarker +
+          gauge
       );
     } catch {
       /* best effort */

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -161,6 +161,16 @@ const SpecSchema = z.object({
     )
     .optional(),
   proposals: SpecProposalsSchema.optional(),
+  /**
+   * 0.19.0-α.34 (sc#67) — canonical story cost. Aggregated from the
+   * `specs/story-<id>.cost.jsonl` sidecar by `applyCostToSpec`. Optional
+   * because older specs predate this and the sidecar is the
+   * source-of-truth — the spec field is a glance-readable mirror.
+   */
+  cost: z.object({
+    total_usd: z.number(),
+    last_updated: z.string(),
+  }).optional(),
 });
 
 export function readIndex(repoRoot: string): SpecIndex {

--- a/packages/cli/src/cost-store.test.ts
+++ b/packages/cli/src/cost-store.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import {
+  appendCostEntry,
+  readCostTotal,
+  applyCostToSpec,
+  costSidecarPath,
+} from "./cost-store.js";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "cost-store-test-"));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  return root;
+}
+
+function writeSpec(repoRoot: string, storyId: string, body: Record<string, unknown> = {}): void {
+  const base = {
+    story_id: storyId,
+    title: "test",
+    status: "active",
+    created_at: "2026-05-15T00:00:00Z",
+    supersedes: [],
+    superseded_by: null,
+    actors: [],
+    preconditions: [],
+    invariants: [],
+    acceptance_scenarios: [],
+    non_goals: [],
+    ...body,
+  };
+  writeFileSync(
+    join(repoRoot, "specs", `story-${storyId}.yaml`),
+    YAML.stringify(base, { lineWidth: 0 }),
+    "utf8"
+  );
+}
+
+describe("cost-store sidecar (sc#67)", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("appends entries as one JSON line each", () => {
+    appendCostEntry(repo, "001", {
+      agent: "refine",
+      usd: 0.42,
+      at: "2026-05-15T10:00:00Z",
+    });
+    appendCostEntry(repo, "001", {
+      agent: "refine",
+      usd: 0.18,
+      at: "2026-05-15T10:01:00Z",
+      model: "claude-opus-4-7",
+      round: "questions",
+    });
+    const content = readFileSync(costSidecarPath(repo, "001"), "utf8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).usd).toBe(0.42);
+    expect(JSON.parse(lines[1]).round).toBe("questions");
+  });
+
+  it("creates the specs/ directory on first append", () => {
+    const root = mkdtempSync(join(tmpdir(), "cost-store-fresh-"));
+    appendCostEntry(root, "002", {
+      agent: "vibe",
+      usd: 0.01,
+      at: "2026-05-15T11:00:00Z",
+    });
+    expect(existsSync(costSidecarPath(root, "002"))).toBe(true);
+  });
+
+  it("readCostTotal returns 0 + [] when sidecar missing", () => {
+    const out = readCostTotal(repo, "missing");
+    expect(out.totalUsd).toBe(0);
+    expect(out.entries).toEqual([]);
+  });
+
+  it("readCostTotal sums entries and exposes them", () => {
+    appendCostEntry(repo, "003", { agent: "refine", usd: 1.0, at: "t1" });
+    appendCostEntry(repo, "003", { agent: "vibe", usd: 0.5, at: "t2" });
+    appendCostEntry(repo, "003", { agent: "brew", usd: 2.25, at: "t3" });
+    const { totalUsd, entries } = readCostTotal(repo, "003");
+    expect(totalUsd).toBeCloseTo(3.75, 4);
+    expect(entries.map((e) => e.agent)).toEqual(["refine", "vibe", "brew"]);
+  });
+
+  it("readCostTotal tolerates blank + malformed lines", () => {
+    const p = costSidecarPath(repo, "004");
+    mkdirSync(join(repo, "specs"), { recursive: true });
+    writeFileSync(
+      p,
+      ['{"agent":"refine","usd":0.5,"at":"t1"}', "", "not-json", '{"agent":"vibe","usd":0.25,"at":"t2"}'].join("\n") + "\n",
+      "utf8"
+    );
+    const malformed: number[] = [];
+    const { totalUsd, entries } = readCostTotal(repo, "004", (n) => malformed.push(n));
+    expect(totalUsd).toBeCloseTo(0.75, 4);
+    expect(entries).toHaveLength(2);
+    expect(malformed).toEqual([3]);
+  });
+
+  it("applyCostToSpec is a no-op when spec missing", () => {
+    appendCostEntry(repo, "no-spec", { agent: "refine", usd: 1, at: "t" });
+    const out = applyCostToSpec(repo, "no-spec");
+    expect(out.changed).toBe(false);
+  });
+
+  it("applyCostToSpec writes cost.total_usd + last_updated when spec present", () => {
+    writeSpec(repo, "005");
+    appendCostEntry(repo, "005", { agent: "refine", usd: 0.97, at: "t1" });
+    appendCostEntry(repo, "005", { agent: "refine", usd: 1.26, at: "t2" });
+    const out = applyCostToSpec(repo, "005", "2026-05-15T12:00:00Z");
+    expect(out.changed).toBe(true);
+    expect(out.totalUsd).toBeCloseTo(2.23, 4);
+    const reloaded = YAML.parse(
+      readFileSync(join(repo, "specs", "story-005.yaml"), "utf8")
+    );
+    expect(reloaded.cost.total_usd).toBeCloseTo(2.23, 4);
+    expect(reloaded.cost.last_updated).toBe("2026-05-15T12:00:00Z");
+  });
+
+  it("applyCostToSpec is a no-op when total + last_updated unchanged", () => {
+    writeSpec(repo, "006", { cost: { total_usd: 0.5, last_updated: "frozen" } });
+    appendCostEntry(repo, "006", { agent: "refine", usd: 0.5, at: "t1" });
+    const out = applyCostToSpec(repo, "006");
+    expect(out.changed).toBe(false);
+  });
+
+  it("rounds totals to 4 decimal places", () => {
+    writeSpec(repo, "007");
+    // 0.1 + 0.2 = 0.30000000000000004 in float
+    appendCostEntry(repo, "007", { agent: "refine", usd: 0.1, at: "t1" });
+    appendCostEntry(repo, "007", { agent: "vibe", usd: 0.2, at: "t2" });
+    const out = applyCostToSpec(repo, "007");
+    expect(out.totalUsd).toBe(0.3);
+  });
+});

--- a/packages/cli/src/cost-store.ts
+++ b/packages/cli/src/cost-store.ts
@@ -1,0 +1,147 @@
+/**
+ * 0.19.0-α.34 (sc#67) — canonical cost storage.
+ *
+ * Today each agent emits an HTML cost marker into its own PR comment.
+ * Aggregating a story's total cost means walking every comment across
+ * issue + spec PR + mockup PR + tests PR + brew PR. Fragile and slow.
+ *
+ * This module provides:
+ *   - `appendCostEntry(repoRoot, storyId, entry)` — append-only sidecar
+ *     `specs/story-<id>.cost.jsonl`, one JSON line per LLM call.
+ *   - `readCostTotal(repoRoot, storyId)` — sum + entries, for the fuel-
+ *     gauge command (sc#66) and any reflection tooling.
+ *   - `applyCostToSpec(repoRoot, storyId)` — recomputes spec.cost.total_usd
+ *     and spec.cost.last_updated from the sidecar; callers stage + commit.
+ *
+ * The HTML cost markers + visible cost footer stay for now — they're
+ * how the PR-reader sees cost at a glance. Sidecar is for aggregation.
+ * Migration of all agents to call appendCostEntry is incremental: refine
+ * is wired in α.34; vibe / brew / chef are follow-ups.
+ */
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import YAML from "yaml";
+
+export interface CostEntry {
+  agent: string;
+  usd: number;
+  model?: string;
+  round?: string;
+  /** ISO-8601. Caller supplies — keeps the module testable. */
+  at: string;
+  /** Where the cost was incurred (PR comment URL, run URL, etc.) */
+  source_url?: string;
+  /** Optional token breakdown for forensic audits. */
+  tokens_in?: number;
+  tokens_out?: number;
+  cache_read?: number;
+  cache_create?: number;
+}
+
+const SPECS_DIR = "specs";
+
+/** Sidecar path for a story's cost log. */
+export function costSidecarPath(repoRoot: string, storyId: string): string {
+  return join(repoRoot, SPECS_DIR, `story-${storyId}.cost.jsonl`);
+}
+
+/** Spec yaml path (mirrors spec-yaml.ts; duplicated to avoid cycle). */
+function specYamlPath(repoRoot: string, storyId: string): string {
+  return join(repoRoot, SPECS_DIR, `story-${storyId}.yaml`);
+}
+
+/**
+ * Append one cost entry to the sidecar. Creates the file (and any
+ * missing parent dirs) if it doesn't exist. Does NOT touch the spec
+ * yaml — call `applyCostToSpec` separately so the caller controls
+ * when the spec changes (one write at end-of-round vs N writes per
+ * LLM call).
+ */
+export function appendCostEntry(
+  repoRoot: string,
+  storyId: string,
+  entry: CostEntry
+): void {
+  const p = costSidecarPath(repoRoot, storyId);
+  mkdirSync(dirname(p), { recursive: true });
+  // Trailing newline → safe append on partial-write recovery.
+  appendFileSync(p, JSON.stringify(entry) + "\n", "utf8");
+}
+
+/**
+ * Read + sum all entries in a story's sidecar. Tolerant of:
+ *   - missing sidecar (returns zero/empty).
+ *   - blank lines.
+ *   - malformed lines (logged via the optional callback; total uses parseable ones).
+ */
+export function readCostTotal(
+  repoRoot: string,
+  storyId: string,
+  onMalformed?: (lineNo: number, raw: string) => void
+): { totalUsd: number; entries: CostEntry[] } {
+  const p = costSidecarPath(repoRoot, storyId);
+  if (!existsSync(p)) return { totalUsd: 0, entries: [] };
+  const lines = readFileSync(p, "utf8").split("\n");
+  const entries: CostEntry[] = [];
+  let total = 0;
+  lines.forEach((raw, i) => {
+    const line = raw.trim();
+    if (!line) return;
+    try {
+      const parsed = JSON.parse(line) as CostEntry;
+      if (typeof parsed.usd !== "number" || typeof parsed.agent !== "string") {
+        onMalformed?.(i + 1, raw);
+        return;
+      }
+      entries.push(parsed);
+      total += parsed.usd;
+    } catch {
+      onMalformed?.(i + 1, raw);
+    }
+  });
+  return { totalUsd: total, entries };
+}
+
+/**
+ * Recompute spec.cost.total_usd + spec.cost.last_updated from the
+ * sidecar and write it back. Returns true if the spec was actually
+ * modified (caller stages + commits). Safe to call when the spec
+ * doesn't exist yet — returns false.
+ *
+ * Uses a low-fidelity YAML round-trip (parse + stringify) so it
+ * preserves keys but doesn't preserve comments or key ordering. That's
+ * acceptable for refine-emitted specs which don't carry hand-authored
+ * comments. If we later want comment-preserving updates, switch to
+ * yaml's Document API.
+ */
+export function applyCostToSpec(
+  repoRoot: string,
+  storyId: string,
+  nowIso: string = new Date().toISOString()
+): { changed: boolean; totalUsd: number } {
+  const specPath = specYamlPath(repoRoot, storyId);
+  if (!existsSync(specPath)) return { changed: false, totalUsd: 0 };
+  const { totalUsd } = readCostTotal(repoRoot, storyId);
+  const raw = readFileSync(specPath, "utf8");
+  const parsed = (YAML.parse(raw) ?? {}) as Record<string, unknown> & {
+    cost?: { total_usd?: number; last_updated?: string };
+  };
+  const existing = parsed.cost ?? {};
+  // Round to 4 dp so we don't churn the spec on sub-tenth-of-a-cent diffs.
+  const rounded = Math.round(totalUsd * 10000) / 10000;
+  if (
+    existing.total_usd === rounded &&
+    typeof existing.last_updated === "string"
+  ) {
+    return { changed: false, totalUsd: rounded };
+  }
+  parsed.cost = { total_usd: rounded, last_updated: nowIso };
+  writeFileSync(specPath, YAML.stringify(parsed, { lineWidth: 0 }), "utf8");
+  return { changed: true, totalUsd: rounded };
+}

--- a/packages/cli/src/lib/budget.test.ts
+++ b/packages/cli/src/lib/budget.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadBudgetConfig,
+  currentPeriodStart,
+  aggregateMonthSpend,
+  classifyBudgetStatus,
+  formatFuelGauge,
+  fuelGaugeFromRepo,
+} from "./budget.js";
+import { appendCostEntry } from "../cost-store.js";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "budget-test-"));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, ".brewing"), { recursive: true });
+  return root;
+}
+
+function writeBudget(repo: string, body: string): void {
+  writeFileSync(join(repo, ".brewing", "budget.yaml"), body, "utf8");
+}
+
+describe("budget config (sc#66)", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("returns null when budget.yaml absent (opt-in)", () => {
+    expect(loadBudgetConfig(repo)).toBe(null);
+  });
+
+  it("parses a valid config", () => {
+    writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: 50\nmonthly_start_day: 1\n");
+    expect(loadBudgetConfig(repo)).toEqual({
+      schema_version: 1,
+      monthly_budget_usd: 50,
+      monthly_start_day: 1,
+    });
+  });
+
+  it("defaults monthly_start_day to 1 when omitted", () => {
+    writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: 25\n");
+    expect(loadBudgetConfig(repo)?.monthly_start_day).toBe(1);
+  });
+
+  it("rejects malformed config loudly", () => {
+    writeBudget(repo, "schema_version: 2\nmonthly_budget_usd: 50\n");
+    expect(() => loadBudgetConfig(repo)).toThrow();
+  });
+
+  it("rejects negative budgets", () => {
+    writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: -1\n");
+    expect(() => loadBudgetConfig(repo)).toThrow();
+  });
+});
+
+describe("currentPeriodStart", () => {
+  it("returns this month's reset day when today is on or after it", () => {
+    const out = currentPeriodStart({ monthly_start_day: 5 }, new Date("2026-05-15T12:00:00Z"));
+    expect(out.toISOString()).toBe("2026-05-05T00:00:00.000Z");
+  });
+  it("returns last month's reset day when today is before this month's", () => {
+    const out = currentPeriodStart({ monthly_start_day: 20 }, new Date("2026-05-15T12:00:00Z"));
+    expect(out.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+  });
+});
+
+describe("aggregateMonthSpend", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("returns 0 when no sidecars exist", () => {
+    const out = aggregateMonthSpend(
+      repo,
+      { schema_version: 1, monthly_budget_usd: 50, monthly_start_day: 1 },
+      new Date("2026-05-15T12:00:00Z")
+    );
+    expect(out).toEqual({ usd: 0, entryCount: 0, storyCount: 0 });
+  });
+
+  it("sums entries from this period across stories", () => {
+    appendCostEntry(repo, "001", { agent: "refine", usd: 1.0, at: "2026-05-10T00:00:00Z" });
+    appendCostEntry(repo, "001", { agent: "vibe", usd: 0.5, at: "2026-05-12T00:00:00Z" });
+    appendCostEntry(repo, "002", { agent: "refine", usd: 2.0, at: "2026-05-14T00:00:00Z" });
+    const out = aggregateMonthSpend(
+      repo,
+      { schema_version: 1, monthly_budget_usd: 50, monthly_start_day: 1 },
+      new Date("2026-05-15T12:00:00Z")
+    );
+    expect(out.usd).toBeCloseTo(3.5, 4);
+    expect(out.entryCount).toBe(3);
+    expect(out.storyCount).toBe(2);
+  });
+
+  it("excludes entries from before the period start", () => {
+    appendCostEntry(repo, "001", { agent: "refine", usd: 100, at: "2026-04-15T00:00:00Z" });
+    appendCostEntry(repo, "001", { agent: "refine", usd: 1, at: "2026-05-10T00:00:00Z" });
+    const out = aggregateMonthSpend(
+      repo,
+      { schema_version: 1, monthly_budget_usd: 50, monthly_start_day: 1 },
+      new Date("2026-05-15T12:00:00Z")
+    );
+    expect(out.usd).toBeCloseTo(1, 4);
+    expect(out.entryCount).toBe(1);
+  });
+});
+
+describe("classifyBudgetStatus", () => {
+  it("ok under 80%", () => {
+    expect(classifyBudgetStatus(39, 50)).toBe("ok");
+  });
+  it("warn at 80%", () => {
+    expect(classifyBudgetStatus(40, 50)).toBe("warn");
+  });
+  it("warn 80-95%", () => {
+    expect(classifyBudgetStatus(45, 50)).toBe("warn");
+  });
+  it("halt at 95%", () => {
+    expect(classifyBudgetStatus(47.5, 50)).toBe("halt");
+  });
+  it("halt over budget", () => {
+    expect(classifyBudgetStatus(75, 50)).toBe("halt");
+  });
+  it("ok when budget is zero (defensive)", () => {
+    expect(classifyBudgetStatus(1, 0)).toBe("ok");
+  });
+});
+
+describe("formatFuelGauge", () => {
+  it("renders ok status without warning text", () => {
+    const md = formatFuelGauge({ currentUsd: 10, budgetUsd: 50 });
+    expect(md).toContain("⛽");
+    expect(md).toContain("$10.00 of $50.00");
+    expect(md).toContain("(20%)");
+    expect(md).not.toContain("⚠️");
+    expect(md).not.toContain("🛑");
+  });
+
+  it("renders warn at 80% with fuel GIF", () => {
+    const md = formatFuelGauge({ currentUsd: 42, budgetUsd: 50 });
+    expect(md).toContain("⚠️ approaching monthly budget");
+    expect(md).toContain("![fuel low]");
+    expect(md).toContain("giphy.com");
+  });
+
+  it("renders halt at 95% with stop sign", () => {
+    const md = formatFuelGauge({ currentUsd: 49, budgetUsd: 50 });
+    expect(md).toContain("🛑");
+    expect(md).toContain("override-budget");
+    expect(md).toContain("![fuel empty]");
+  });
+
+  it("empty string when budget <= 0", () => {
+    expect(formatFuelGauge({ currentUsd: 5, budgetUsd: 0 })).toBe("");
+  });
+});
+
+describe("fuelGaugeFromRepo (end-to-end)", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("returns empty string when no budget.yaml exists", () => {
+    expect(fuelGaugeFromRepo(repo)).toBe("");
+  });
+
+  it("renders the gauge when budget.yaml + sidecar present", () => {
+    writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: 50\nmonthly_start_day: 1\n");
+    appendCostEntry(repo, "001", { agent: "refine", usd: 42, at: "2026-05-10T00:00:00Z" });
+    const md = fuelGaugeFromRepo(repo, new Date("2026-05-15T12:00:00Z"));
+    expect(md).toContain("$42.00 of $50.00");
+    expect(md).toContain("⚠️");
+  });
+});

--- a/packages/cli/src/lib/budget.ts
+++ b/packages/cli/src/lib/budget.ts
@@ -1,0 +1,176 @@
+/**
+ * 0.19.0-α.34 (sc#66) — project-level fuel gauge.
+ *
+ * Consumer authors `.brewing/budget.yaml`:
+ *
+ *   schema_version: 1
+ *   monthly_budget_usd: 50
+ *   monthly_start_day: 1
+ *
+ * Aggregates spend by reading `specs/story-*.cost.jsonl` sidecars (sc#67)
+ * — much cheaper than walking GH comments. Returns a markdown gauge line
+ * that agents append to their existing cost footer:
+ *
+ *   ⛽ **Project this month:** $42.18 of $50.00 (84%)
+ *   ⚠️ approaching budget — top up at https://console.anthropic.com/...
+ *
+ * Future work (NOT in MVP): halt-before-LLM-call at 95%, override label,
+ * weekly slices, per-scope budgets. Today the gauge is informational.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+import { z } from "zod";
+import { readCostTotal } from "../cost-store.js";
+
+const BudgetConfigSchema = z.object({
+  schema_version: z.literal(1),
+  monthly_budget_usd: z.number().positive(),
+  /** 1-31. The day of the calendar month the budget resets. */
+  monthly_start_day: z.number().int().min(1).max(31).default(1),
+  /** Optional per-story ceiling (informational). */
+  story_budget_usd: z.number().positive().optional(),
+});
+
+export type BudgetConfig = z.infer<typeof BudgetConfigSchema>;
+
+/**
+ * Load `.brewing/budget.yaml`. Returns null when the file is absent —
+ * gauge is opt-in. Throws on malformed YAML / schema violation so a
+ * mis-authored config surfaces loudly instead of silently disabling.
+ */
+export function loadBudgetConfig(repoRoot: string): BudgetConfig | null {
+  const path = join(repoRoot, ".brewing", "budget.yaml");
+  if (!existsSync(path)) return null;
+  const raw = YAML.parse(readFileSync(path, "utf8"));
+  const parsed = BudgetConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid .brewing/budget.yaml: ${parsed.error.issues.map((i) => i.message).join("; ")}`
+    );
+  }
+  return parsed.data;
+}
+
+/** ISO-8601 date of the current monthly budget period start, given config. */
+export function currentPeriodStart(
+  config: Pick<BudgetConfig, "monthly_start_day">,
+  now: Date = new Date()
+): Date {
+  const day = config.monthly_start_day;
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const candidate = new Date(Date.UTC(y, m, day));
+  // If today is before this month's reset day, the period started LAST month.
+  if (now.getTime() < candidate.getTime()) {
+    return new Date(Date.UTC(y, m - 1, day));
+  }
+  return candidate;
+}
+
+/**
+ * Sum cost entries across ALL story sidecars in `specs/` whose entry
+ * `at` falls inside the current monthly period. Story IDs are derived
+ * from filenames (`story-<id>.cost.jsonl`).
+ */
+export function aggregateMonthSpend(
+  repoRoot: string,
+  config: BudgetConfig,
+  now: Date = new Date()
+): { usd: number; entryCount: number; storyCount: number } {
+  const specsDir = join(repoRoot, "specs");
+  if (!existsSync(specsDir)) return { usd: 0, entryCount: 0, storyCount: 0 };
+  const periodStart = currentPeriodStart(config, now);
+  let usd = 0;
+  let entryCount = 0;
+  let storyCount = 0;
+  for (const f of readdirSync(specsDir)) {
+    const m = /^story-(.+)\.cost\.jsonl$/.exec(f);
+    if (!m || !m[1]) continue;
+    const storyId = m[1];
+    const { entries } = readCostTotal(repoRoot, storyId);
+    let storyTouched = false;
+    for (const e of entries) {
+      const at = Date.parse(e.at);
+      if (Number.isFinite(at) && at >= periodStart.getTime()) {
+        usd += e.usd;
+        entryCount++;
+        storyTouched = true;
+      }
+    }
+    if (storyTouched) storyCount++;
+  }
+  return { usd, entryCount, storyCount };
+}
+
+export interface FuelGaugeArgs {
+  currentUsd: number;
+  budgetUsd: number;
+  /** GIF rendered when status === "warn" or "halt". Defaults to fuel-empty. */
+  gifUrl?: string;
+}
+
+export type BudgetStatus = "ok" | "warn" | "halt";
+
+const FUEL_GIF =
+  "https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTVveDJ4bmNuY3dsa2hrNnVweTd6MWhpbXIxc3pvajhsN3Q5b21vdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8CMmJ6F8hTxqX7Ts5k/giphy.gif";
+
+export function classifyBudgetStatus(currentUsd: number, budgetUsd: number): BudgetStatus {
+  if (budgetUsd <= 0) return "ok";
+  const ratio = currentUsd / budgetUsd;
+  if (ratio >= 0.95) return "halt";
+  if (ratio >= 0.8) return "warn";
+  return "ok";
+}
+
+/**
+ * Render the fuel-gauge markdown block. Empty string when budget <= 0
+ * (defensive — the config schema rejects this). Always returns a
+ * trailing newline so callers can concatenate without thinking.
+ */
+export function formatFuelGauge(args: FuelGaugeArgs): string {
+  const { currentUsd, budgetUsd } = args;
+  if (budgetUsd <= 0) return "";
+  const pct = Math.round((currentUsd / budgetUsd) * 100);
+  const status = classifyBudgetStatus(currentUsd, budgetUsd);
+  const lines: string[] = [];
+  lines.push(
+    `\n\n⛽ **Project this month:** $${currentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)} (${pct}%)`
+  );
+  if (status === "warn") {
+    lines.push(
+      `⚠️ approaching monthly budget — consider topping up at https://console.anthropic.com/settings/billing`
+    );
+    lines.push(`![fuel low](${args.gifUrl ?? FUEL_GIF})`);
+  } else if (status === "halt") {
+    lines.push(
+      `🛑 monthly budget exceeded — add the \`override-budget\` label to allow agents to continue, or top up at https://console.anthropic.com/settings/billing`
+    );
+    lines.push(`![fuel empty](${args.gifUrl ?? FUEL_GIF})`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Convenience: read config + aggregate spend + format gauge in one call.
+ * Returns empty string when no budget.yaml exists (gauge disabled).
+ * Best-effort: a parse failure or aggregation error logs to console.warn
+ * and returns "" rather than blocking the agent's comment.
+ */
+export function fuelGaugeFromRepo(repoRoot: string, now: Date = new Date()): string {
+  let config: BudgetConfig | null;
+  try {
+    config = loadBudgetConfig(repoRoot);
+  } catch (e) {
+    console.warn(`[fuel-gauge] config load failed: ${(e as Error).message}`);
+    return "";
+  }
+  if (!config) return "";
+  try {
+    const { usd } = aggregateMonthSpend(repoRoot, config, now);
+    return formatFuelGauge({ currentUsd: usd, budgetUsd: config.monthly_budget_usd });
+  } catch (e) {
+    console.warn(`[fuel-gauge] aggregation failed: ${(e as Error).message}`);
+    return "";
+  }
+}

--- a/packages/core/src/spec.ts
+++ b/packages/core/src/spec.ts
@@ -166,6 +166,16 @@ export interface Spec {
    * schema proposals to unlock allowed-paths for migrations.
    */
   proposals?: SpecProposals;
+
+  /**
+   * 0.19.0-α.34 (sc#67) — canonical story cost. Aggregated from the
+   * `specs/story-<id>.cost.jsonl` sidecar by `applyCostToSpec`. Glance-
+   * readable mirror; sidecar is the source-of-truth.
+   */
+  cost?: {
+    total_usd: number;
+    last_updated: string;
+  };
 }
 
 export interface SpecIndexEntry {


### PR DESCRIPTION
Completes the funds-warning triple. The previous two layers (sc#68 reactive 402, sc#69 mid-flight ratelimit) shipped in α.32 and α.33. This PR adds the proactive project-level gauge backed by canonical cost storage.

## sc#67 — Canonical cost storage

**Today.** Cost data is scattered across HTML markers (\`<!-- slowcook:cost ... -->\`) in PR comments. Aggregating a story's total walks issue + spec PR + mockup PR + tests PR + brew PR.

**Now.** Two files per story:

\`\`\`
specs/story-NNN.cost.jsonl   # append-only, one JSON line per LLM round
specs/story-NNN.yaml         # cost: { total_usd, last_updated }
\`\`\`

\`appendCostEntry\` + \`applyCostToSpec\` from \`packages/cli/src/cost-store.ts\`. The sidecar is the source-of-truth; the spec field is a glance-readable mirror. Migration is incremental — refine is wired in this PR; vibe/brew/chef/sift/testgen follow in α.35+ as their cost-emit sites get touched. HTML markers stay until each agent is wired.

## sc#66 — Project fuel gauge

**Opt-in.** New \`.brewing/budget.yaml\`:

\`\`\`yaml
schema_version: 1
monthly_budget_usd: 50
monthly_start_day: 1
\`\`\`

Renders in refine footers:

\`\`\`
💰 This step: \$0.97 · Story total: \$4.12
⛽ Project this month: \$42.18 of \$50.00 (84%)
⚠️ approaching monthly budget — top up at https://console.anthropic.com/...
\`\`\`

Thresholds: 80% warn (⚠️ + fuel-low GIF), 95% halt-recommended (🛑 + fuel-empty GIF + \`override-budget\` label hint). Halt-before-LLM-call plumbing is a follow-up; this layer is informational + helps PM stop at 80% instead of hitting 402 from sc#68.

Aggregation reads sidecars (sc#67), not GH comments — fast, cheap, no API pagination.

## Diff

- \`core/src/spec.ts\` — \`Spec.cost\` optional field
- \`cli/src/commands/refine/spec-yaml.ts\` — zod schema match
- \`cli/src/cost-store.ts\` + tests (9)
- \`cli/src/lib/budget.ts\` + tests (22)
- \`cli/src/commands/refine/agent.ts\` — wire both into questions-round + spec-submitted footers; stage sidecar in spec PR

## Test plan

- [x] \`pnpm -r build\` green
- [x] \`pnpm --filter @slowcook-ai/cli test\` → 877/877 (was 855)
- [ ] CI green
- [ ] Field test: refine on a fresh story → see \`specs/story-N.cost.jsonl\` in spec PR; see \`cost: { total_usd: ... }\` in spec yaml; see fuel gauge in footer if \`.brewing/budget.yaml\` is authored

🤖 Generated with [Claude Code](https://claude.com/claude-code)