### PR TITLE
cli α.35: slowcook budget subcommand + credit-balance gauge

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.34",
+  "version": "0.19.0-alpha.35",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,6 +30,7 @@ import { dispatch } from "./commands/dispatch/index.js";
 import { fixtures } from "./commands/fixtures/index.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
+import { budget } from "./commands/budget/index.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
 // version, the spec's `refined_by` field, and the init template's workflow
@@ -74,6 +75,7 @@ Usage:
   slowcook fixtures check [--max-age-days <n>] [--story <id>]
   slowcook eval (--all | --fixture <id> | --list) [--fixtures-dir <path>]
   slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]
+  slowcook budget [show|set|rm] [--monthly <usd>] [--start-day <1-31>] [--story <usd>] [--cwd <path>]
   slowcook version
   slowcook help
 
@@ -105,6 +107,7 @@ Commands available in ${VERSION}:
   recon              (0.17.6+) Pre-brew structural divergence check. Compares story tests against mock + src/, surfaces missing components / testid gaps / brownfield rename hazards. Runs in slowcook-brew-auto.yml before brew dispatch.
   run-mock           (0.16-α.17) One-command mock launch + auto-pull. \`run-mock <story>\`: checkout mockup branch, npm install in mock/, run next dev with overlay env vars, poll origin every 15s + git pull --ff-only on plate amendments.
   dispatch           Trigger a slowcook GitHub Actions workflow remotely (brew / testgen / refine).
+  budget             (0.19.0-α.35) Manage the project monthly budget for the fuel gauge. \`budget set --monthly 50\` writes .brewing/budget.yaml; no args shows config + month-to-date spend.
 
 Coming in later versions:
   review, dashboard
@@ -317,6 +320,12 @@ async function main(): Promise<void> {
       // a shared branch. push/switch implemented; up/sync/reset stub
       // print canonical shell-outs for now.
       await devEnv(args.slice(1));
+      return;
+    case "budget":
+      // 0.19.0-α.35 (sc#66 follow-up) — manage .brewing/budget.yaml.
+      // No args = show current config + month-to-date spend. `set
+      // --monthly N` writes; `rm` deletes (disables the fuel gauge).
+      await budget(args.slice(1));
       return;
     case "version":
     case "--version":

--- a/packages/cli/src/commands/budget/index.test.ts
+++ b/packages/cli/src/commands/budget/index.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { budget } from "./index.js";
+import { appendCostEntry } from "../../cost-store.js";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "budget-cmd-test-"));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  return root;
+}
+
+describe("slowcook budget subcommand (sc#66)", () => {
+  let repo: string;
+  let logs: string[];
+  let errs: string[];
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let originalExit: typeof process.exit;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    repo = makeRepo();
+    logs = [];
+    errs = [];
+    exitCode = undefined;
+    originalLog = console.log;
+    originalError = console.error;
+    originalExit = process.exit;
+    console.log = (...a: unknown[]) => {
+      logs.push(a.map(String).join(" "));
+    };
+    console.error = (...a: unknown[]) => {
+      errs.push(a.map(String).join(" "));
+    };
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error(`__EXIT__${code}`);
+    }) as never;
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  });
+
+  async function run(args: string[]): Promise<void> {
+    try {
+      await budget(["--cwd", repo, ...args]);
+    } catch (e) {
+      if (!(e as Error).message.startsWith("__EXIT__")) throw e;
+    }
+  }
+
+  it("show: tells you nothing's configured when budget.yaml absent", async () => {
+    await run([]);
+    expect(logs.join("\n")).toContain("No .brewing/budget.yaml");
+    expect(logs.join("\n")).toContain("slowcook budget set --monthly");
+  });
+
+  it("set: creates config with --monthly", async () => {
+    await run(["set", "--monthly", "50"]);
+    expect(existsSync(join(repo, ".brewing", "budget.yaml"))).toBe(true);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(parsed.monthly_budget_usd).toBe(50);
+    expect(parsed.monthly_start_day).toBe(1);
+    expect(parsed.schema_version).toBe(1);
+  });
+
+  it("set: accepts --start-day and --story", async () => {
+    await run(["set", "--monthly", "50", "--start-day", "15", "--story", "10"]);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(parsed.monthly_start_day).toBe(15);
+    expect(parsed.story_budget_usd).toBe(10);
+  });
+
+  it("set: merges into existing config (only update --start-day)", async () => {
+    await run(["set", "--monthly", "50"]);
+    logs.length = 0;
+    await run(["set", "--start-day", "20"]);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(parsed.monthly_budget_usd).toBe(50);
+    expect(parsed.monthly_start_day).toBe(20);
+  });
+
+  it("set: errors when neither --monthly nor --credit on a fresh repo", async () => {
+    await run(["set", "--start-day", "5"]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("at least one of --monthly or --credit");
+  });
+
+  it("set: creates a credit-only config with --credit", async () => {
+    await run(["set", "--credit", "25", "--credit-baseline", "2026-05-15T00:00:00Z"]);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(parsed.credit_balance_usd).toBe(25);
+    expect(parsed.credit_baseline_at).toBe("2026-05-15T00:00:00Z");
+    expect(parsed.monthly_budget_usd).toBeUndefined();
+  });
+
+  it("set: --credit captures 'now' as baseline when --credit-baseline omitted", async () => {
+    await run(["set", "--credit", "25"]);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(typeof parsed.credit_baseline_at).toBe("string");
+    expect(parsed.credit_baseline_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("set: re-running --credit refreshes the baseline (top-up)", async () => {
+    await run(["set", "--credit", "25", "--credit-baseline", "2026-04-01T00:00:00Z"]);
+    logs.length = 0;
+    await run(["set", "--credit", "50", "--credit-baseline", "2026-05-15T00:00:00Z"]);
+    const parsed = YAML.parse(readFileSync(join(repo, ".brewing", "budget.yaml"), "utf8"));
+    expect(parsed.credit_balance_usd).toBe(50);
+    expect(parsed.credit_baseline_at).toBe("2026-05-15T00:00:00Z");
+  });
+
+  it("set: rejects non-positive --credit", async () => {
+    await run(["set", "--credit", "0"]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("--credit must be a positive number");
+  });
+
+  it("show: reports credit-balance gauge", async () => {
+    await run(["set", "--credit", "25", "--credit-baseline", "2026-05-01T00:00:00Z"]);
+    appendCostEntry(repo, "001", { agent: "refine", usd: 21, at: "2026-05-10T00:00:00Z" });
+    logs.length = 0;
+    await run([]);
+    const out = logs.join("\n");
+    expect(out).toContain("Anthropic credit");
+    expect(out).toContain("$4.00 of $25.00");
+    expect(out).toContain("⚠️");
+  });
+
+  it("set: rejects non-positive --monthly", async () => {
+    await run(["set", "--monthly", "-1"]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("positive");
+  });
+
+  it("set: rejects out-of-range --start-day", async () => {
+    await run(["set", "--monthly", "50", "--start-day", "32"]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("1-31");
+  });
+
+  it("rm: deletes config when present", async () => {
+    await run(["set", "--monthly", "50"]);
+    logs.length = 0;
+    await run(["rm"]);
+    expect(existsSync(join(repo, ".brewing", "budget.yaml"))).toBe(false);
+    expect(logs.join("\n")).toContain("Fuel gauge now disabled");
+  });
+
+  it("rm: tolerates missing config", async () => {
+    await run(["rm"]);
+    expect(logs.join("\n")).toContain("nothing to remove");
+  });
+
+  it("show: reports period + spend from sidecars", async () => {
+    await run(["set", "--monthly", "50"]);
+    const now = new Date();
+    const isoNow = now.toISOString();
+    appendCostEntry(repo, "001", { agent: "refine", usd: 3.5, at: isoNow });
+    logs.length = 0;
+    await run([]);
+    const out = logs.join("\n");
+    expect(out).toContain("$3.50 of $50.00");
+    expect(out).toContain("(7%)");
+    expect(out).toContain("entry across 1 story");
+  });
+
+  it("show: surfaces warn threshold", async () => {
+    await run(["set", "--monthly", "10"]);
+    appendCostEntry(repo, "001", {
+      agent: "refine",
+      usd: 8.5,
+      at: new Date().toISOString(),
+    });
+    logs.length = 0;
+    await run([]);
+    expect(logs.join("\n")).toContain("⚠️");
+  });
+
+  it("rejects unknown verb", async () => {
+    await run(["bogus"]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("Unknown budget action");
+  });
+
+  it("show: invalid config exits 2 with clear error", async () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "budget.yaml"),
+      "schema_version: 99\nmonthly_budget_usd: 50\n",
+      "utf8"
+    );
+    await run([]);
+    expect(exitCode).toBe(2);
+    expect(errs.join("\n")).toContain("invalid");
+  });
+});

--- a/packages/cli/src/commands/budget/index.ts
+++ b/packages/cli/src/commands/budget/index.ts
@@ -1,0 +1,286 @@
+/**
+ * 0.19.0-α.35 (sc#66 follow-up) — `slowcook budget` subcommand.
+ *
+ *   slowcook budget                              # show config + month-to-date spend
+ *   slowcook budget set --monthly 50             # set monthly_budget_usd
+ *   slowcook budget set --monthly 50 --start-day 15 --story 10
+ *   slowcook budget rm                           # delete config (disables gauge)
+ *
+ * Writes/reads `.brewing/budget.yaml`. Idempotent: `set` merges into
+ * existing config; absent flags keep their current values; missing
+ * monthly_budget_usd on a brand-new config defaults nothing (must be
+ * supplied at least once).
+ */
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+import {
+  loadBudgetConfig,
+  aggregateMonthSpend,
+  aggregateSpendSince,
+  currentPeriodStart,
+  classifyBudgetStatus,
+  type BudgetConfig,
+} from "../../lib/budget.js";
+
+interface BudgetArgs {
+  cwd: string;
+  action: "show" | "set" | "rm";
+  monthly?: number;
+  startDay?: number;
+  story?: number;
+  credit?: number;
+  /** ISO timestamp override — defaults to "now" when `--credit` is set. Mostly for tests. */
+  creditBaselineAt?: string;
+}
+
+function parseArgs(argv: string[]): BudgetArgs {
+  const args: BudgetArgs = { cwd: process.cwd(), action: "show" };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--cwd" && next) {
+      args.cwd = next;
+      i++;
+    } else if (arg === "--monthly" && next) {
+      args.monthly = Number(next);
+      i++;
+    } else if (arg === "--start-day" && next) {
+      args.startDay = Number(next);
+      i++;
+    } else if (arg === "--story" && next) {
+      args.story = Number(next);
+      i++;
+    } else if (arg === "--credit" && next) {
+      args.credit = Number(next);
+      i++;
+    } else if (arg === "--credit-baseline" && next) {
+      args.creditBaselineAt = next;
+      i++;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else if (arg && !arg.startsWith("--")) {
+      positional.push(arg);
+    }
+  }
+  const verb = positional[0];
+  if (verb === "set" || verb === "rm") args.action = verb;
+  else if (verb && verb !== "show") {
+    throw new Error(`Unknown budget action: ${verb}. Use show | set | rm.`);
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`
+slowcook budget — manage the project budget(s) for the fuel gauge
+
+Two independent gauges, both optional, both opt-in:
+
+  monthly_budget_usd     A per-period cap that resets each month.
+  credit_balance_usd     A non-recurring credit deposit (e.g. you topped
+                         up $25 on Anthropic and DON'T have auto-recharge);
+                         the gauge subtracts ALL-TIME spend from this.
+
+Usage:
+  slowcook budget                                    Show current config + spend
+  slowcook budget set --monthly <usd>                Set the monthly cap
+  slowcook budget set --monthly 50 --start-day 15    Non-1st reset day
+  slowcook budget set --credit <usd>                 Track a one-shot deposit
+  slowcook budget set --story <usd>                  Optional per-story ceiling
+  slowcook budget rm                                 Delete .brewing/budget.yaml
+
+Flags:
+  --monthly <usd>      Monthly budget in USD. Resets each period.
+  --start-day <1-31>   Calendar day the monthly budget resets. Default 1.
+  --credit <usd>       One-shot credit deposit. Captures the date of set as
+                       a baseline; spend tracked from there. Re-run to top up.
+  --story <usd>        Optional per-story informational ceiling.
+  --cwd <path>         Project root. Defaults to current working dir.
+
+When set, every refine comment appends:
+  ⛽ Project this month: $X of $Y  (monthly cap)
+  🪙 Anthropic credit:   $X of $Y  (credit balance)
+
+Both fire ⚠️ at 80% and 🛑 at 95%.
+
+Top-up workflow (no auto-recharge):
+  $ slowcook budget set --credit 25         # at the start of $25 deposit
+  ... burn through credit ...
+  $ slowcook budget set --credit 50         # after topping up to $50 (new baseline)
+`);
+}
+
+function configPath(cwd: string): string {
+  return join(cwd, ".brewing", "budget.yaml");
+}
+
+function fmtUsd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+export async function budget(argv: string[]): Promise<void> {
+  let parsed: BudgetArgs;
+  try {
+    parsed = parseArgs(argv);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(2);
+  }
+
+  if (parsed.action === "rm") {
+    const p = configPath(parsed.cwd);
+    if (!existsSync(p)) {
+      console.log(`No .brewing/budget.yaml — nothing to remove.`);
+      return;
+    }
+    unlinkSync(p);
+    console.log(`Removed ${p}. Fuel gauge now disabled.`);
+    return;
+  }
+
+  if (parsed.action === "set") {
+    // Merge into existing config; allow updating individual fields.
+    let existing: BudgetConfig | null = null;
+    try {
+      existing = loadBudgetConfig(parsed.cwd);
+    } catch (e) {
+      console.error(`Existing config is invalid — fix or rm first: ${(e as Error).message}`);
+      process.exit(2);
+    }
+    const monthly = parsed.monthly ?? existing?.monthly_budget_usd;
+    if (monthly !== undefined && (!Number.isFinite(monthly) || monthly <= 0)) {
+      console.error(`--monthly must be a positive number, got ${parsed.monthly}`);
+      process.exit(2);
+    }
+    const startDay = parsed.startDay ?? existing?.monthly_start_day ?? 1;
+    if (!Number.isInteger(startDay) || startDay < 1 || startDay > 31) {
+      console.error(`--start-day must be an integer 1-31, got ${parsed.startDay}`);
+      process.exit(2);
+    }
+    const story = parsed.story ?? existing?.story_budget_usd;
+    if (story !== undefined && (!Number.isFinite(story) || story <= 0)) {
+      console.error(`--story must be a positive number, got ${parsed.story}`);
+      process.exit(2);
+    }
+    // Credit handling — a fresh --credit captures "now" as the
+    // baseline. Re-running --credit (top-up) refreshes the baseline so
+    // the gauge tracks ONLY spend from the new deposit forward.
+    let credit: number | undefined = existing?.credit_balance_usd;
+    let creditBaselineAt: string | undefined = existing?.credit_baseline_at;
+    if (parsed.credit !== undefined) {
+      if (!Number.isFinite(parsed.credit) || parsed.credit <= 0) {
+        console.error(`--credit must be a positive number, got ${parsed.credit}`);
+        process.exit(2);
+      }
+      credit = parsed.credit;
+      creditBaselineAt = parsed.creditBaselineAt ?? new Date().toISOString();
+    }
+
+    if (monthly === undefined && credit === undefined) {
+      console.error(
+        `Set at least one of --monthly or --credit. Try: slowcook budget set --credit 25`
+      );
+      process.exit(2);
+    }
+
+    const next: BudgetConfig = {
+      schema_version: 1,
+      monthly_start_day: startDay,
+      ...(monthly !== undefined ? { monthly_budget_usd: monthly } : {}),
+      ...(story !== undefined ? { story_budget_usd: story } : {}),
+      ...(credit !== undefined ? { credit_balance_usd: credit } : {}),
+      ...(creditBaselineAt !== undefined ? { credit_baseline_at: creditBaselineAt } : {}),
+    };
+
+    const p = configPath(parsed.cwd);
+    mkdirSync(join(parsed.cwd, ".brewing"), { recursive: true });
+    writeFileSync(p, YAML.stringify(next, { lineWidth: 0 }), "utf8");
+    const verb = existing ? "Updated" : "Wrote";
+    console.log(`${verb} ${p}`);
+    console.log(readFileSync(p, "utf8"));
+    return;
+  }
+
+  // show
+  let config: BudgetConfig | null;
+  try {
+    config = loadBudgetConfig(parsed.cwd);
+  } catch (e) {
+    console.error(`Config at ${configPath(parsed.cwd)} is invalid: ${(e as Error).message}`);
+    process.exit(2);
+  }
+  if (!config) {
+    console.log(`No .brewing/budget.yaml — fuel gauge disabled.`);
+    console.log(`Set one with:  slowcook budget set --credit 25      (one-shot deposit)`);
+    console.log(`         or:  slowcook budget set --monthly 50     (recurring cap)`);
+    return;
+  }
+  const now = new Date();
+  console.log(`Config: ${configPath(parsed.cwd)}`);
+  if (config.monthly_budget_usd !== undefined) {
+    console.log(`  monthly_budget_usd:  ${fmtUsd(config.monthly_budget_usd)}`);
+    console.log(`  monthly_start_day:   ${config.monthly_start_day}`);
+  }
+  if (config.story_budget_usd !== undefined) {
+    console.log(`  story_budget_usd:    ${fmtUsd(config.story_budget_usd)}`);
+  }
+  if (config.credit_balance_usd !== undefined) {
+    console.log(`  credit_balance_usd:  ${fmtUsd(config.credit_balance_usd)}`);
+    console.log(`  credit_baseline_at:  ${config.credit_baseline_at ?? "(unset)"}`);
+  }
+  console.log(``);
+  if (config.monthly_budget_usd !== undefined) {
+    const period = currentPeriodStart(config, now);
+    const spend = aggregateMonthSpend(parsed.cwd, config, now);
+    const status = classifyBudgetStatus(spend.usd, config.monthly_budget_usd);
+    const pct = Math.round((spend.usd / config.monthly_budget_usd) * 100);
+    const icon = status === "halt" ? "🛑" : status === "warn" ? "⚠️" : "⛽";
+    console.log(`Period start: ${period.toISOString().slice(0, 10)}`);
+    console.log(
+      `${icon} Spent this period: ${fmtUsd(spend.usd)} of ${fmtUsd(config.monthly_budget_usd)} (${pct}%)`
+    );
+    console.log(
+      `   ${spend.entryCount} entr${spend.entryCount === 1 ? "y" : "ies"} across ${spend.storyCount} stor${spend.storyCount === 1 ? "y" : "ies"}.`
+    );
+    if (status === "warn") {
+      console.log(`   ⚠️  approaching monthly budget — consider topping up.`);
+    } else if (status === "halt") {
+      console.log(`   🛑 over budget — agents will halt without the override-budget label.`);
+    }
+    console.log(``);
+  }
+  if (config.credit_balance_usd !== undefined && config.credit_baseline_at) {
+    const baseline = new Date(config.credit_baseline_at);
+    const spend = aggregateSpendSince(parsed.cwd, baseline);
+    const status = classifyBudgetStatus(spend.usd, config.credit_balance_usd);
+    const remaining = Math.max(0, config.credit_balance_usd - spend.usd);
+    const pctLeft = Math.max(
+      0,
+      100 - Math.round((spend.usd / config.credit_balance_usd) * 100)
+    );
+    const icon = status === "halt" ? "🛑" : status === "warn" ? "⚠️" : "🪙";
+    console.log(`Credit baseline: ${config.credit_baseline_at.slice(0, 10)}`);
+    console.log(
+      `${icon} Anthropic credit: ${fmtUsd(remaining)} of ${fmtUsd(config.credit_balance_usd)} remaining (${pctLeft}%)`
+    );
+    console.log(
+      `   Spent ${fmtUsd(spend.usd)} since baseline. ${spend.entryCount} entr${spend.entryCount === 1 ? "y" : "ies"}.`
+    );
+    if (status === "warn") {
+      console.log(
+        `   ⚠️  approaching empty — top up at https://console.anthropic.com/settings/billing.`
+      );
+      console.log(
+        `       Then: slowcook budget set --credit <new-total>     # captures fresh baseline`
+      );
+    } else if (status === "halt") {
+      console.log(`   🛑 credit nearly exhausted — pipeline will halt on 402 imminently.`);
+      console.log(
+        `       Top up + re-run: slowcook budget set --credit <new-total>`
+      );
+    }
+  }
+}

--- a/packages/cli/src/lib/budget.test.ts
+++ b/packages/cli/src/lib/budget.test.ts
@@ -6,8 +6,10 @@ import {
   loadBudgetConfig,
   currentPeriodStart,
   aggregateMonthSpend,
+  aggregateSpendSince,
   classifyBudgetStatus,
   formatFuelGauge,
+  formatCreditGauge,
   fuelGaugeFromRepo,
 } from "./budget.js";
 import { appendCostEntry } from "../cost-store.js";
@@ -42,6 +44,19 @@ describe("budget config (sc#66)", () => {
     });
   });
 
+  it("parses a credit-only config", () => {
+    writeBudget(
+      repo,
+      "schema_version: 1\ncredit_balance_usd: 25\ncredit_baseline_at: 2026-05-15T00:00:00Z\n"
+    );
+    expect(loadBudgetConfig(repo)).toEqual({
+      schema_version: 1,
+      monthly_start_day: 1,
+      credit_balance_usd: 25,
+      credit_baseline_at: "2026-05-15T00:00:00Z",
+    });
+  });
+
   it("defaults monthly_start_day to 1 when omitted", () => {
     writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: 25\n");
     expect(loadBudgetConfig(repo)?.monthly_start_day).toBe(1);
@@ -54,6 +69,11 @@ describe("budget config (sc#66)", () => {
 
   it("rejects negative budgets", () => {
     writeBudget(repo, "schema_version: 1\nmonthly_budget_usd: -1\n");
+    expect(() => loadBudgetConfig(repo)).toThrow();
+  });
+
+  it("rejects config with neither monthly nor credit set", () => {
+    writeBudget(repo, "schema_version: 1\nmonthly_start_day: 1\n");
     expect(() => loadBudgetConfig(repo)).toThrow();
   });
 });
@@ -177,5 +197,90 @@ describe("fuelGaugeFromRepo (end-to-end)", () => {
     const md = fuelGaugeFromRepo(repo, new Date("2026-05-15T12:00:00Z"));
     expect(md).toContain("$42.00 of $50.00");
     expect(md).toContain("⚠️");
+  });
+
+  it("renders the credit gauge when credit_balance set", () => {
+    writeBudget(
+      repo,
+      "schema_version: 1\ncredit_balance_usd: 25\ncredit_baseline_at: 2026-05-01T00:00:00Z\n"
+    );
+    appendCostEntry(repo, "001", { agent: "refine", usd: 21, at: "2026-05-10T00:00:00Z" });
+    const md = fuelGaugeFromRepo(repo, new Date("2026-05-15T12:00:00Z"));
+    expect(md).toContain("🪙");
+    expect(md).toContain("$4.00 of $25.00 remaining");
+    expect(md).toContain("⚠️");
+  });
+
+  it("renders both gauges when both fields set", () => {
+    writeBudget(
+      repo,
+      "schema_version: 1\nmonthly_budget_usd: 50\ncredit_balance_usd: 25\ncredit_baseline_at: 2026-05-01T00:00:00Z\n"
+    );
+    appendCostEntry(repo, "001", { agent: "refine", usd: 5, at: "2026-05-10T00:00:00Z" });
+    const md = fuelGaugeFromRepo(repo, new Date("2026-05-15T12:00:00Z"));
+    expect(md).toContain("⛽");
+    expect(md).toContain("🪙");
+  });
+});
+
+describe("formatCreditGauge", () => {
+  it("renders ok status (no warning)", () => {
+    const md = formatCreditGauge({
+      depositUsd: 25,
+      spentUsd: 5,
+      baselineAt: "2026-05-01T00:00:00Z",
+    });
+    expect(md).toContain("$20.00 of $25.00 remaining");
+    expect(md).toContain("(80%)");
+    expect(md).not.toContain("⚠️");
+    expect(md).not.toContain("🛑");
+  });
+
+  it("renders warn at 80% with fuel gif", () => {
+    const md = formatCreditGauge({
+      depositUsd: 25,
+      spentUsd: 20,
+      baselineAt: "2026-05-01T00:00:00Z",
+    });
+    expect(md).toContain("$5.00 of $25.00 remaining");
+    expect(md).toContain("⚠️");
+    expect(md).toContain("approaching empty");
+    expect(md).toContain("console.anthropic.com");
+  });
+
+  it("renders halt at 95%", () => {
+    const md = formatCreditGauge({
+      depositUsd: 25,
+      spentUsd: 24,
+      baselineAt: "2026-05-01T00:00:00Z",
+    });
+    expect(md).toContain("🛑");
+    expect(md).toContain("402");
+  });
+
+  it("clamps remaining to 0 when overspent", () => {
+    const md = formatCreditGauge({
+      depositUsd: 25,
+      spentUsd: 30,
+      baselineAt: "2026-05-01T00:00:00Z",
+    });
+    expect(md).toContain("$0.00 of $25.00 remaining");
+  });
+});
+
+describe("aggregateSpendSince", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "agg-since-")) ;
+    mkdirSync(join(repo, "specs"), { recursive: true });
+  });
+
+  it("sums entries from arbitrary baseline (not period-bound)", () => {
+    appendCostEntry(repo, "001", { agent: "refine", usd: 5, at: "2026-04-01T00:00:00Z" });
+    appendCostEntry(repo, "001", { agent: "refine", usd: 3, at: "2026-05-10T00:00:00Z" });
+    appendCostEntry(repo, "002", { agent: "vibe", usd: 7, at: "2026-05-12T00:00:00Z" });
+    const out = aggregateSpendSince(repo, new Date("2026-05-01T00:00:00Z"));
+    expect(out.usd).toBeCloseTo(10, 4);
+    expect(out.storyCount).toBe(2);
   });
 });

--- a/packages/cli/src/lib/budget.ts
+++ b/packages/cli/src/lib/budget.ts
@@ -25,12 +25,37 @@ import { readCostTotal } from "../cost-store.js";
 
 const BudgetConfigSchema = z.object({
   schema_version: z.literal(1),
-  monthly_budget_usd: z.number().positive(),
+  monthly_budget_usd: z.number().positive().optional(),
   /** 1-31. The day of the calendar month the budget resets. */
   monthly_start_day: z.number().int().min(1).max(31).default(1),
   /** Optional per-story ceiling (informational). */
   story_budget_usd: z.number().positive().optional(),
-});
+  /**
+   * 0.19.0-α.35 — anthropic credit deposit tracking. Unlike
+   * `monthly_budget_usd` (which resets each period), this models a
+   * non-recurring credit deposit (e.g. you topped up $25). The gauge
+   * subtracts ALL-TIME spend from this number, so once the sidecar
+   * shows $24 of usage you're down to $1 remaining.
+   *
+   * Set via: slowcook budget set --credit 25
+   *
+   * Re-set whenever you top up: slowcook budget set --credit 50
+   * (the all-time spend baseline is captured at the time of set, so
+   * re-setting resets the gauge to "full" for the new deposit).
+   */
+  credit_balance_usd: z.number().positive().optional(),
+  /**
+   * ISO timestamp captured when `credit_balance_usd` was set / last
+   * topped up. The gauge sums sidecar entries with `at >=` this value;
+   * spend before this is presumed already paid for by an earlier
+   * deposit. Written by `slowcook budget set --credit`; consumers
+   * shouldn't author this by hand.
+   */
+  credit_baseline_at: z.string().optional(),
+}).refine(
+  (data) => data.monthly_budget_usd !== undefined || data.credit_balance_usd !== undefined,
+  { message: "must set monthly_budget_usd or credit_balance_usd (or both)" }
+);
 
 export type BudgetConfig = z.infer<typeof BudgetConfigSchema>;
 
@@ -70,17 +95,17 @@ export function currentPeriodStart(
 
 /**
  * Sum cost entries across ALL story sidecars in `specs/` whose entry
- * `at` falls inside the current monthly period. Story IDs are derived
- * from filenames (`story-<id>.cost.jsonl`).
+ * `at` is >= `since`. Story IDs are derived from filenames
+ * (`story-<id>.cost.jsonl`). Used by both:
+ *   - monthly_budget_usd gauge (since = period start)
+ *   - credit_balance_usd gauge (since = credit_baseline_at)
  */
-export function aggregateMonthSpend(
+export function aggregateSpendSince(
   repoRoot: string,
-  config: BudgetConfig,
-  now: Date = new Date()
+  since: Date
 ): { usd: number; entryCount: number; storyCount: number } {
   const specsDir = join(repoRoot, "specs");
   if (!existsSync(specsDir)) return { usd: 0, entryCount: 0, storyCount: 0 };
-  const periodStart = currentPeriodStart(config, now);
   let usd = 0;
   let entryCount = 0;
   let storyCount = 0;
@@ -92,7 +117,7 @@ export function aggregateMonthSpend(
     let storyTouched = false;
     for (const e of entries) {
       const at = Date.parse(e.at);
-      if (Number.isFinite(at) && at >= periodStart.getTime()) {
+      if (Number.isFinite(at) && at >= since.getTime()) {
         usd += e.usd;
         entryCount++;
         storyTouched = true;
@@ -101,6 +126,18 @@ export function aggregateMonthSpend(
     if (storyTouched) storyCount++;
   }
   return { usd, entryCount, storyCount };
+}
+
+/**
+ * Back-compat wrapper for the period-based aggregation.
+ */
+export function aggregateMonthSpend(
+  repoRoot: string,
+  config: BudgetConfig,
+  now: Date = new Date()
+): { usd: number; entryCount: number; storyCount: number } {
+  const periodStart = currentPeriodStart(config, now);
+  return aggregateSpendSince(repoRoot, periodStart);
 }
 
 export interface FuelGaugeArgs {
@@ -152,8 +189,46 @@ export function formatFuelGauge(args: FuelGaugeArgs): string {
 }
 
 /**
- * Convenience: read config + aggregate spend + format gauge in one call.
- * Returns empty string when no budget.yaml exists (gauge disabled).
+ * Render the credit-balance gauge (sc#66 0.19.0-α.35). Reports remaining
+ * USD on a one-shot Anthropic deposit (no auto-recharge). Spends counted
+ * since `baselineAt`; remaining = `deposit - spent`.
+ */
+export function formatCreditGauge(args: {
+  depositUsd: number;
+  spentUsd: number;
+  baselineAt: string;
+  gifUrl?: string;
+}): string {
+  const remaining = Math.max(0, args.depositUsd - args.spentUsd);
+  const ratio = args.depositUsd <= 0 ? 0 : args.spentUsd / args.depositUsd;
+  const pctSpent = Math.round(ratio * 100);
+  const pctLeft = Math.max(0, 100 - pctSpent);
+  let status: BudgetStatus = "ok";
+  if (ratio >= 0.95) status = "halt";
+  else if (ratio >= 0.8) status = "warn";
+
+  const lines: string[] = [];
+  lines.push(
+    `\n\n🪙 **Anthropic credit:** $${remaining.toFixed(2)} of $${args.depositUsd.toFixed(2)} remaining (${pctLeft}%) — spent $${args.spentUsd.toFixed(2)} since ${args.baselineAt.slice(0, 10)}`
+  );
+  if (status === "warn") {
+    lines.push(
+      `⚠️ approaching empty — top up at https://console.anthropic.com/settings/billing before pipeline runs halt with 402.`
+    );
+    lines.push(`![fuel low](${args.gifUrl ?? FUEL_GIF})`);
+  } else if (status === "halt") {
+    lines.push(
+      `🛑 credit nearly exhausted — pipeline will halt on 402 imminently. Top up at https://console.anthropic.com/settings/billing.`
+    );
+    lines.push(`![fuel empty](${args.gifUrl ?? FUEL_GIF})`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Convenience: read config + aggregate spend + format gauge(s) in one
+ * call. Returns empty string when no budget.yaml exists (gauge disabled).
+ * Renders BOTH gauges when both fields are set in the config.
  * Best-effort: a parse failure or aggregation error logs to console.warn
  * and returns "" rather than blocking the agent's comment.
  */
@@ -166,11 +241,24 @@ export function fuelGaugeFromRepo(repoRoot: string, now: Date = new Date()): str
     return "";
   }
   if (!config) return "";
+  let out = "";
   try {
-    const { usd } = aggregateMonthSpend(repoRoot, config, now);
-    return formatFuelGauge({ currentUsd: usd, budgetUsd: config.monthly_budget_usd });
+    if (config.monthly_budget_usd !== undefined) {
+      const { usd } = aggregateMonthSpend(repoRoot, config, now);
+      out += formatFuelGauge({ currentUsd: usd, budgetUsd: config.monthly_budget_usd });
+    }
+    if (config.credit_balance_usd !== undefined && config.credit_baseline_at) {
+      const baseline = new Date(config.credit_baseline_at);
+      const { usd } = aggregateSpendSince(repoRoot, baseline);
+      out += formatCreditGauge({
+        depositUsd: config.credit_balance_usd,
+        spentUsd: usd,
+        baselineAt: config.credit_baseline_at,
+      });
+    }
   } catch (e) {
     console.warn(`[fuel-gauge] aggregation failed: ${(e as Error).message}`);
     return "";
   }
+  return out;
 }


### PR DESCRIPTION
Adds CLI authoring for the budget config introduced in α.34, and answers a real-world need: tracking a **one-shot Anthropic credit deposit** (no auto-recharge) so the pipeline warns before hitting 402.

## Two gauges, both optional

| Field | Resets? | Use case |
|---|---|---|
| \`monthly_budget_usd\` | yes (monthly) | Recurring cap, e.g. \"don't spend > \$50 / mo on slowcook\" |
| \`credit_balance_usd\` | no | One-shot deposit, e.g. \"I just put \$25 on Anthropic and don't have auto-recharge\" |

Each fires ⚠️ at 80% and 🛑 at 95%. Refine footers render BOTH if both are set.

## Subcommand

\`\`\`bash
slowcook budget                     # show config + spend on both gauges
slowcook budget set --monthly 50    # recurring cap
slowcook budget set --credit 25     # one-shot deposit (captures today as baseline)
slowcook budget set --credit 50     # top-up: refreshes baseline
slowcook budget rm                  # disable
\`\`\`

The credit-balance baseline is the date you last topped up. Spend is summed from sidecars since that date — so re-setting after a top-up resets the gauge to full.

## Why this answers \"warn me before \$25 runs out\"

- Anthropic does NOT expose live account balance via API. The Console shows it; the SDK doesn't.
- Without local tracking, you only find out at 402 (sc#68 catches it — but by then the run halted mid-pipeline).
- This gauge subtracts sc#67 sidecar spend from your deposit; you set the deposit manually whenever you top up.

## Tests

- 18 new \`budget\` subcommand tests (parse, set, rm, show, credit baseline, top-up)
- 31 lib tests (was 22) — adds \`formatCreditGauge\`, \`aggregateSpendSince\`, both-gauges render
- Total: 904 cli (was 877). Build green.

## Migration

\`\`\`bash
# fresh setup for the \$25 deposit:
slowcook budget set --credit 25

# next refine round will now append:
#   🪙 Anthropic credit: \$25.00 of \$25.00 remaining (100%)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)