### PR TITLE
cli α.36 + llm-anthropic α.11: refine Pass B brownfield-answer

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.35",
+  "version": "0.19.0-alpha.36",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -69,6 +69,11 @@ import {
 import { applySupersede } from "@slowcook-ai/core";
 import { enrichBodyWithImages } from "./images.js";
 import { auditSideEffects, sideEffectsCommentBody } from "./side-effects-audit.js";
+import {
+  answerQuestionsFromBrownfield,
+  composePassBComment,
+  hasBrownfield,
+} from "./brownfield-answer.js";
 import { appendCostEntry, applyCostToSpec, costSidecarPath } from "../../cost-store.js";
 import { fuelGaugeFromRepo } from "../../lib/budget.js";
 
@@ -272,18 +277,43 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
     repoRoot: ctx.repoRoot,
   });
 
-  const refineCostMarker = costMarker({
-    agent: "refine",
-    usd: roundCostUsd,
-    tokensIn: totalTokensIn,
-    tokensOut: totalTokensOut,
-    cacheRead: totalCacheRead,
-    cacheCreate: totalCacheCreate,
-    model: ctx.refineModel,
-    round: parsed.kind === "questions" ? "questions" : "spec",
-  });
-
   if (parsed.kind === "questions") {
+    // 0.19.0-α.36 — Pass B: reflexive brownfield-answer pass. Filters
+    // Pass A's draft questions against the same brownfield context, so
+    // questions the codebase already answers don't reach the PM. Skipped
+    // entirely on greenfield projects (no entities / no specs / no
+    // context.md). Cost added to roundCostUsd.
+    //
+    // Best-effort: a JSON parse failure or LLM error falls back to
+    // posting Pass A's original markdown unchanged — never blocks the
+    // round on this layer.
+    let questionsBody = parsed.markdown;
+    if (hasBrownfield(ctx.repoRoot)) {
+      try {
+        const passB = await answerQuestionsFromBrownfield(
+          {
+            draftQuestionsMarkdown: parsed.markdown,
+            projectContext,
+          },
+          { llm: ctx.llm, model: ctx.refineModel }
+        );
+        roundCostUsd += passB.costUsd;
+        totalTokensIn += passB.usage.inputTokens;
+        totalTokensOut += passB.usage.outputTokens;
+        totalCacheRead += passB.usage.cacheReadTokens;
+        totalCacheCreate += passB.usage.cacheCreateTokens;
+        questionsBody = composePassBComment(passB, parsed.markdown);
+        if (passB.answered.length > 0) {
+          console.log(
+            `[refine] Pass B answered ${passB.answered.length}/${passB.answered.length + passB.unanswered.length} questions from brownfield`
+          );
+        }
+      } catch (e) {
+        console.warn(
+          `[refine] Pass B (brownfield-answer) failed, posting Pass A questions unchanged: ${(e as Error).message}`
+        );
+      }
+    }
     // Compute visible cost footer: this run's cost + accumulated prior
     // bot-emitted costs on the same issue. Footer renders as plain
     // markdown the PM can see; the HTML cost marker remains for machine
@@ -310,8 +340,26 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
     // footers / markers / brand header (those are auto-appended). But
     // if the model copies the pattern from prior-turn context anyway,
     // strip it so the final comment doesn't carry duplicates. Cheap
-    // string ops; safe to no-op when patterns are absent.
-    const cleanMarkdown = stripModelEmittedDuplicates(parsed.markdown);
+    // string ops; safe to no-op when patterns are absent. When Pass B
+    // ran, `questionsBody` is its composed output (already free of
+    // model-emitted boilerplate); when it didn't, fall through to
+    // strip on the raw markdown.
+    const cleanMarkdown =
+      questionsBody !== parsed.markdown
+        ? questionsBody
+        : stripModelEmittedDuplicates(parsed.markdown);
+    // Cost marker is computed AFTER Pass B so it reflects the round's
+    // total spend including the Pass B call.
+    const refineCostMarker = costMarker({
+      agent: "refine",
+      usd: roundCostUsd,
+      tokensIn: totalTokensIn,
+      tokensOut: totalTokensOut,
+      cacheRead: totalCacheRead,
+      cacheCreate: totalCacheCreate,
+      model: ctx.refineModel,
+      round: "questions",
+    });
     const comment = await ctx.forge.createIssueComment(
       ctx.issueNumber,
       BRAND_HEADER + cleanMarkdown + footer + "\n\n" + refineCostMarker
@@ -422,6 +470,16 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
       // spec-submitted comment too. Empty string when budget.yaml is
       // absent (opt-in).
       const gauge = fuelGaugeFromRepo(ctx.repoRoot, ctx.now);
+      const refineCostMarker = costMarker({
+        agent: "refine",
+        usd: roundCostUsd,
+        tokensIn: totalTokensIn,
+        tokensOut: totalTokensOut,
+        cacheRead: totalCacheRead,
+        cacheCreate: totalCacheCreate,
+        model: ctx.refineModel,
+        round: "spec",
+      });
       await ctx.forge.createIssueComment(
         ctx.issueNumber,
         `### slowcook · spec submitted\n\n` +

--- a/packages/cli/src/commands/refine/brownfield-answer.test.ts
+++ b/packages/cli/src/commands/refine/brownfield-answer.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hasBrownfield,
+  parseAnswerJson,
+  formatAnsweredDetails,
+  formatUnansweredQuestions,
+  composePassBComment,
+} from "./brownfield-answer.js";
+
+function makeRepo(): string {
+  return mkdtempSync(join(tmpdir(), "bf-answer-test-"));
+}
+
+describe("hasBrownfield detector (sc#82 precursor)", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("false on empty greenfield", () => {
+    expect(hasBrownfield(repo)).toBe(false);
+  });
+
+  it("true when .brewing/context.md is non-trivial", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "context.md"),
+      "## Project\n\nA social link-sharing platform built on Supabase.\n",
+      "utf8"
+    );
+    expect(hasBrownfield(repo)).toBe(true);
+  });
+
+  it("false when context.md is empty / trivially short", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(join(repo, ".brewing", "context.md"), "tiny\n", "utf8");
+    expect(hasBrownfield(repo)).toBe(false);
+  });
+
+  it("true when entities/ has files", () => {
+    mkdirSync(join(repo, "src", "lib", "entities"), { recursive: true });
+    writeFileSync(
+      join(repo, "src", "lib", "entities", "profiles.ts"),
+      "export interface Profile { id: string; }\n",
+      "utf8"
+    );
+    expect(hasBrownfield(repo)).toBe(true);
+  });
+
+  it("ignores entities/index.ts barrel-only case", () => {
+    mkdirSync(join(repo, "src", "lib", "entities"), { recursive: true });
+    writeFileSync(
+      join(repo, "src", "lib", "entities", "index.ts"),
+      "export {};\n",
+      "utf8"
+    );
+    expect(hasBrownfield(repo)).toBe(false);
+  });
+
+  it("true when specs/_index.yaml has stories", () => {
+    mkdirSync(join(repo, "specs"), { recursive: true });
+    writeFileSync(
+      join(repo, "specs", "_index.yaml"),
+      "schema_version: 1\nstories:\n  '001':\n    title: First\n    status: active\n",
+      "utf8"
+    );
+    expect(hasBrownfield(repo)).toBe(true);
+  });
+
+  it("true when brownfield diagrams exist", () => {
+    mkdirSync(join(repo, ".brewing", "diagrams"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "diagrams", "entities.md"),
+      "# Entities\n\nprofiles, sessions\n",
+      "utf8"
+    );
+    expect(hasBrownfield(repo)).toBe(true);
+  });
+});
+
+describe("parseAnswerJson", () => {
+  it("parses well-formed JSON", () => {
+    const raw = JSON.stringify({
+      answered: [{ question: "Q1?", answer: "A1", source: "S1" }],
+      unanswered: [{ question: "Q2?", why_unanswered: "PM judgement" }],
+    });
+    const out = parseAnswerJson(raw);
+    expect(out.answered).toHaveLength(1);
+    expect(out.unanswered).toHaveLength(1);
+    expect(out.answered[0]!.answer).toBe("A1");
+  });
+
+  it("strips ```json fences", () => {
+    const raw = '```json\n{"answered": [], "unanswered": []}\n```';
+    expect(parseAnswerJson(raw)).toEqual({ answered: [], unanswered: [] });
+  });
+
+  it("ignores leading prose by finding first/last brace", () => {
+    const raw = 'Here is the JSON:\n{"answered": [], "unanswered": []}\nDone.';
+    expect(parseAnswerJson(raw)).toEqual({ answered: [], unanswered: [] });
+  });
+
+  it("filters out malformed entries (missing fields)", () => {
+    const raw = JSON.stringify({
+      answered: [
+        { question: "Q1?", answer: "A", source: "S" },
+        { question: "Q2?" }, // missing answer + source
+        "not even an object",
+      ],
+      unanswered: [
+        { question: "Q3?", why_unanswered: "PM" },
+        { question: "no reason" }, // missing why_unanswered
+      ],
+    });
+    const out = parseAnswerJson(raw);
+    expect(out.answered).toHaveLength(1);
+    expect(out.unanswered).toHaveLength(1);
+  });
+
+  it("empty arrays when missing keys", () => {
+    expect(parseAnswerJson("{}")).toEqual({ answered: [], unanswered: [] });
+  });
+
+  it("throws on truly malformed JSON", () => {
+    expect(() => parseAnswerJson("not json at all here")).toThrow();
+  });
+});
+
+describe("formatAnsweredDetails", () => {
+  it("empty string when nothing answered", () => {
+    expect(formatAnsweredDetails([])).toBe("");
+  });
+
+  it("renders one-question details block", () => {
+    const md = formatAnsweredDetails([
+      { question: "Patient and therapist separated?", answer: "Yes, role split via profiles.role check", source: "entities-digest: profiles.role" },
+    ]);
+    expect(md).toContain("<details>");
+    expect(md).toContain("</details>");
+    expect(md).toContain("1 question answered");
+    expect(md).toContain("Patient and therapist separated?");
+    expect(md).toContain("entities-digest: profiles.role");
+  });
+
+  it("pluralizes correctly with >1", () => {
+    const md = formatAnsweredDetails([
+      { question: "Q1?", answer: "A", source: "S" },
+      { question: "Q2?", answer: "A", source: "S" },
+    ]);
+    expect(md).toContain("2 questions answered");
+  });
+});
+
+describe("formatUnansweredQuestions", () => {
+  it("empty string when none", () => {
+    expect(formatUnansweredQuestions([])).toBe("");
+  });
+
+  it("preserves verbatim question text including options", () => {
+    const md = formatUnansweredQuestions([
+      {
+        question: "How should the validation error appear?\n   (a) Inline below field\n   (b) Toast",
+        why_unanswered: "ambiguous",
+      },
+      { question: "Time-to-confirm SLA?", why_unanswered: "PM judgement" },
+    ]);
+    expect(md).toContain("**1.**");
+    expect(md).toContain("(a) Inline below field");
+    expect(md).toContain("**2.**");
+    expect(md).toContain("Time-to-confirm SLA?");
+  });
+});
+
+describe("composePassBComment", () => {
+  it("falls back to original markdown when Pass B produced zero questions", () => {
+    const fallback = "**Q1.** Original Pass A question?";
+    const out = composePassBComment(
+      { answered: [], unanswered: [], costUsd: 0.1, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 } },
+      fallback
+    );
+    expect(out).toBe(fallback);
+  });
+
+  it("shows intro note + filtered list + details when some answered", () => {
+    const out = composePassBComment(
+      {
+        answered: [{ question: "Q-known?", answer: "A", source: "S" }],
+        unanswered: [{ question: "Q-needed?", why_unanswered: "PM" }],
+        costUsd: 0.2,
+        usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      },
+      "(fallback shouldn't be used)"
+    );
+    expect(out).toContain("Checked brownfield first");
+    expect(out).toContain("**1 of 2**");
+    expect(out).toContain("Q-needed?");
+    expect(out).not.toContain("Q-known?\n\nAnswer"); // Q-known shows in details, not main body
+    expect(out).toContain("<details>");
+  });
+
+  it("emits a 'proceed to spec' note when all questions answered", () => {
+    const out = composePassBComment(
+      {
+        answered: [
+          { question: "Q1?", answer: "A", source: "S" },
+          { question: "Q2?", answer: "A", source: "S" },
+        ],
+        unanswered: [],
+        costUsd: 0.2,
+        usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      },
+      "(fallback)"
+    );
+    expect(out).toContain("All 2 draft questions were answered");
+    expect(out).toContain("needs-refinement");
+    expect(out).toContain("<details>");
+  });
+
+  it("no intro note when nothing answered (just falls through to questions)", () => {
+    const out = composePassBComment(
+      {
+        answered: [],
+        unanswered: [
+          { question: "Q1?", why_unanswered: "missing" },
+          { question: "Q2?", why_unanswered: "PM" },
+        ],
+        costUsd: 0.2,
+        usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      },
+      "(fallback)"
+    );
+    expect(out).not.toContain("Checked brownfield first");
+    expect(out).toContain("**1.** Q1?");
+    expect(out).toContain("**2.** Q2?");
+    expect(out).not.toContain("<details>");
+  });
+});

--- a/packages/cli/src/commands/refine/brownfield-answer.ts
+++ b/packages/cli/src/commands/refine/brownfield-answer.ts
@@ -1,0 +1,279 @@
+/**
+ * 0.19.0-α.36 — refine Pass B: reflexive brownfield-answer pass.
+ *
+ * After Pass A drafts clarifying questions, this second LLM call checks
+ * each question against the same brownfield context Pass A saw and
+ * decides whether the context already answers it. The PM only sees the
+ * unanswered questions in the main comment body; the answered ones go
+ * into a `<details>` audit-trail block so a technical PM can verify.
+ *
+ * Skipped entirely on greenfield projects (no `.brewing/context.md`,
+ * no `src/lib/entities/`, no `specs/_index.yaml` entries) — there's no
+ * context to draw from, so Pass B would always emit zero answers
+ * and just burn an LLM call.
+ *
+ * The pattern mirrors `side-effects-audit.ts`: structured JSON output,
+ * deterministic markdown rendering on slowcook's side.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { LlmClient } from "@slowcook-ai/core";
+import { BROWNFIELD_ANSWER_SYSTEM } from "@slowcook-ai/llm-anthropic";
+
+export interface AnsweredQ {
+  question: string;
+  answer: string;
+  source: string;
+}
+
+export interface UnansweredQ {
+  question: string;
+  why_unanswered: string;
+}
+
+export interface BrownfieldAnswerResult {
+  answered: AnsweredQ[];
+  unanswered: UnansweredQ[];
+  costUsd: number;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  };
+}
+
+/**
+ * Detect whether the consumer's repo has ANY brownfield signal that
+ * Pass B could draw from. Greenfield = none of these present:
+ *
+ *   - `.brewing/context.md` with non-empty content
+ *   - `src/lib/entities/*.ts` (at least one entity file)
+ *   - `specs/_index.yaml` (at least one active story)
+ *   - `.brewing/diagrams/entities.md` or `.brewing/diagrams/schema.mmd`
+ *
+ * Cheap check (filesystem stat + small reads). No LLM. Used to gate
+ * Pass B so greenfield projects don't pay for an empty-answer call.
+ */
+export function hasBrownfield(repoRoot: string): boolean {
+  // 1. context.md with body
+  try {
+    const p = join(repoRoot, ".brewing", "context.md");
+    if (existsSync(p) && statSync(p).size > 20) return true;
+  } catch {
+    /* fall through */
+  }
+  // 2. entities/
+  try {
+    const dir = join(repoRoot, "src", "lib", "entities");
+    if (
+      existsSync(dir) &&
+      readdirSync(dir).some((f) => f.endsWith(".ts") && f !== "index.ts")
+    ) {
+      return true;
+    }
+  } catch {
+    /* fall through */
+  }
+  // 3. specs index with stories
+  try {
+    const p = join(repoRoot, "specs", "_index.yaml");
+    if (existsSync(p)) {
+      const body = readFileSync(p, "utf8");
+      // crude: look for any `story_id:` or 1+ keyed entry under stories:.
+      if (/\bstory_id:|\n\s{2,}\w[\w-]*:/.test(body)) return true;
+    }
+  } catch {
+    /* fall through */
+  }
+  // 4. brownfield extracts
+  for (const rel of [
+    ".brewing/diagrams/entities.md",
+    ".brewing/diagrams/schema.mmd",
+    ".brewing/tokens.md",
+  ]) {
+    try {
+      if (existsSync(join(repoRoot, rel))) return true;
+    } catch {
+      /* fall through */
+    }
+  }
+  return false;
+}
+
+export interface BrownfieldAnswerInputs {
+  draftQuestionsMarkdown: string;
+  projectContext: string;
+  mockExcerpt?: string;
+}
+
+/**
+ * Run Pass B. Returns structured answered/unanswered split + cost.
+ * Throws on JSON parse failure — caller decides whether to fall back
+ * (today: caller catches + posts the original Pass A markdown unchanged).
+ */
+export async function answerQuestionsFromBrownfield(
+  inputs: BrownfieldAnswerInputs,
+  opts: { llm: LlmClient; model: string }
+): Promise<BrownfieldAnswerResult> {
+  const userMessage = buildUserMessage(inputs);
+  const response = await opts.llm.complete({
+    system: BROWNFIELD_ANSWER_SYSTEM,
+    cacheSystem: false,
+    model: opts.model,
+    messages: [{ role: "user", content: userMessage }],
+    maxTokens: 4096,
+  });
+  const { answered, unanswered } = parseAnswerJson(response.text);
+  return {
+    answered,
+    unanswered,
+    costUsd: response.costUsd,
+    usage: response.usage,
+  };
+}
+
+function buildUserMessage(inputs: BrownfieldAnswerInputs): string {
+  const sections: string[] = [];
+  sections.push("## Brownfield context (what Pass A saw)");
+  sections.push("");
+  sections.push(inputs.projectContext);
+  if (inputs.mockExcerpt && inputs.mockExcerpt.trim()) {
+    sections.push("");
+    sections.push("## Mock excerpt (design source-of-truth for this story)");
+    sections.push("");
+    sections.push("```tsx");
+    sections.push(inputs.mockExcerpt);
+    sections.push("```");
+  }
+  sections.push("");
+  sections.push("## Pass A's draft questions (markdown)");
+  sections.push("");
+  sections.push(inputs.draftQuestionsMarkdown);
+  sections.push("");
+  sections.push(
+    "Emit the JSON object only — no prose, no fences. Copy questions verbatim including any (a)/(b)/(c) options."
+  );
+  return sections.join("\n");
+}
+
+/**
+ * Parse Pass B's JSON output. Tolerant of stray code fences / leading
+ * prose (the model occasionally adds "Here is the JSON:" despite the
+ * prompt). Falls back to JSON.parse of the largest brace-balanced
+ * substring.
+ */
+export function parseAnswerJson(text: string): {
+  answered: AnsweredQ[];
+  unanswered: UnansweredQ[];
+} {
+  let raw = text.trim();
+  // Strip markdown code-fence wrappers if the model added them.
+  raw = raw.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+  // If the model prefixed prose, find the first { and matching close.
+  const firstBrace = raw.indexOf("{");
+  const lastBrace = raw.lastIndexOf("}");
+  if (firstBrace > 0 && lastBrace > firstBrace) {
+    raw = raw.slice(firstBrace, lastBrace + 1);
+  }
+  const parsed = JSON.parse(raw) as { answered?: unknown; unanswered?: unknown };
+  const answered = Array.isArray(parsed.answered)
+    ? parsed.answered.filter(isAnsweredQ)
+    : [];
+  const unanswered = Array.isArray(parsed.unanswered)
+    ? parsed.unanswered.filter(isUnansweredQ)
+    : [];
+  return { answered, unanswered };
+}
+
+function isAnsweredQ(x: unknown): x is AnsweredQ {
+  if (!x || typeof x !== "object") return false;
+  const r = x as Record<string, unknown>;
+  return (
+    typeof r.question === "string" &&
+    typeof r.answer === "string" &&
+    typeof r.source === "string"
+  );
+}
+
+function isUnansweredQ(x: unknown): x is UnansweredQ {
+  if (!x || typeof x !== "object") return false;
+  const r = x as Record<string, unknown>;
+  return typeof r.question === "string" && typeof r.why_unanswered === "string";
+}
+
+/**
+ * Render the `<details>` audit-trail block listing brownfield-answered
+ * questions. Returns empty string when there are no answered Qs (no
+ * point spamming the comment with an empty disclosure).
+ */
+export function formatAnsweredDetails(answered: AnsweredQ[]): string {
+  if (answered.length === 0) return "";
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `<details>\n<summary>🔍 <strong>${answered.length} question${answered.length === 1 ? "" : "s"} answered from brownfield context (audit trail)</strong></summary>\n`
+  );
+  lines.push("");
+  lines.push(
+    `_I checked the entities digest, active specs, brownfield extracts, and mock before asking the PM. These would have been questions, but the answer was already in the codebase:_\n`
+  );
+  answered.forEach((a, i) => {
+    lines.push(`**${i + 1}. ${a.question.trim()}**`);
+    lines.push("");
+    lines.push(`Answer: ${a.answer.trim()}`);
+    lines.push("");
+    lines.push(`Source: \`${a.source.trim()}\``);
+    lines.push("");
+  });
+  lines.push("</details>");
+  return lines.join("\n");
+}
+
+/**
+ * Render the visible PM-facing question list from `unanswered`. Each
+ * question text is preserved verbatim (Pass A's labeled-options format
+ * survives). Numbered list, blank-line separated. Empty when there are
+ * no unanswered Qs (caller decides what to do — probably emit a spec
+ * directly next round, or post a "nothing more to ask" note).
+ */
+export function formatUnansweredQuestions(unanswered: UnansweredQ[]): string {
+  if (unanswered.length === 0) return "";
+  return unanswered
+    .map((u, i) => `**${i + 1}.** ${u.question.trim()}`)
+    .join("\n\n");
+}
+
+/**
+ * Compose the final question-comment markdown body, replacing Pass A's
+ * raw questions output with the Pass B filtered view + audit details.
+ * Leading "I checked first..." note appears only when at least one
+ * answer was found, so greenfield-like cases (Pass B ran but found
+ * nothing) don't show a misleading "I checked first" banner.
+ */
+export function composePassBComment(
+  result: BrownfieldAnswerResult,
+  fallbackMarkdown: string
+): string {
+  const totalQs = result.answered.length + result.unanswered.length;
+  // If Pass B parsed zero questions altogether — most likely a parse
+  // glitch where the model didn't return either array. Fall back to
+  // Pass A's original markdown so we never lose the questions entirely.
+  if (totalQs === 0) return fallbackMarkdown;
+  const lines: string[] = [];
+  if (result.answered.length > 0) {
+    lines.push(
+      `_🔍 Checked brownfield first: **${result.answered.length} of ${totalQs}** question${totalQs === 1 ? "" : "s"} already answered in your codebase (see audit trail below). **${result.unanswered.length}** still need${result.unanswered.length === 1 ? "s" : ""} your input:_`
+    );
+    lines.push("");
+  }
+  if (result.unanswered.length > 0) {
+    lines.push(formatUnansweredQuestions(result.unanswered));
+  } else {
+    lines.push(
+      `_✅ All ${result.answered.length} draft questions were answered from brownfield context. I'll proceed to emit the spec on the next pass — re-trigger this agent (remove + re-add the \`needs-refinement\` label) when you've confirmed the audit trail below._`
+    );
+  }
+  lines.push(formatAnsweredDetails(result.answered));
+  return lines.join("\n");
+}

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.10",
+  "version": "0.16.0-alpha.11",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/index.ts
+++ b/packages/llm-anthropic/src/index.ts
@@ -42,6 +42,7 @@ export {
   RELATIONSHIP_ANALYST_SYSTEM,
   REFINEMENT_ANALYST_SYSTEM,
   SIDE_EFFECTS_AUDIT_SYSTEM,
+  BROWNFIELD_ANSWER_SYSTEM,
   AMENDMENT_SYSTEM,
 } from "./prompts/refine.js";
 // 0.10.0 — vibe agent (0.15 plate-pipeline α.1) — design-first mockup

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -123,6 +123,60 @@ A SINGLE JSON object, no prose. Schema:
 
 The point of this pass is to convert "blocked-contradiction" — a scary refusal — into "here are the 3 specific test assertions that would flip; approve to proceed." A good audit makes contradictions feel small + manageable. A vague audit re-creates the original block-on-contradiction friction.`;
 
+// ----- Brownfield-answer Pass B (post-questions reflexive pass) -----
+
+export const BROWNFIELD_ANSWER_SYSTEM = `You are a brownfield-aware refinement assistant for the slowcook brewing harness.
+
+A previous pass (Pass A) drafted clarifying questions to ask the PM. Your Pass B job is reflexive: for EACH draft question, check the supplied brownfield context (project overview, entities digest, active specs, schema/tokens extracts, mock excerpt) and decide:
+
+- Is the answer ALREADY in the context? → emit it under "answered" with a cited source.
+- Is it NOT in the context, or only ambiguously there? → emit it under "unanswered".
+
+The PM only sees the unanswered ones. The answered ones become an audit-trail \`<details>\` block so the PM can verify your reasoning.
+
+## Inputs you receive
+- The full brownfield context (verbatim, same block Pass A saw).
+- The mock excerpt if one is in scope.
+- Pass A's draft questions (markdown).
+
+## Output: SINGLE JSON object, no prose, no markdown fences
+
+\`\`\`json
+{
+  "answered": [
+    {
+      "question": "<verbatim question text from Pass A, including any (a)/(b)/(c) options>",
+      "answer": "<concrete answer drawn from context>",
+      "source": "<which artifact + where: e.g. 'entities-digest: profiles.handle column NOT NULL'>"
+    }
+  ],
+  "unanswered": [
+    {
+      "question": "<verbatim question text from Pass A, including options>",
+      "why_unanswered": "<one short line: missing from context | ambiguous in context | requires PM judgement>"
+    }
+  ]
+}
+\`\`\`
+
+## Rules
+
+- **Copy questions VERBATIM.** Including any labeled options like \`(a) X / (b) Y / (c) as mock\`. The PM-facing comment uses your text directly; don't reformulate.
+- **Be conservative.** If the context doesn't FULLY answer the question, mark unanswered. "Probably X" is not an answer; "context says X explicitly at <source>" is.
+- **Cite concretely.** \`source\` MUST name the artifact + the specific line/field/column/token. Examples:
+  - \`entities-digest: profiles.role column with check (role in ('patient','therapist'))\`
+  - \`active spec story-014.yaml invariant inv-handle: handles are case-insensitive\`
+  - \`mock excerpt line 47: the role toggle is shown above the email field\`
+- **Style/taste/PM-judgement Qs are ALWAYS unanswered.** Aesthetic choices, product priorities, scope cuts — code can't answer those.
+- **Don't invent answers.** If only the mock shows the behaviour and Pass A is asking "is the mock authoritative?" — that's PM judgement (it's the same question, restated).
+- **Order preserved.** Your output's question order should match Pass A's order.
+- **Greenfield-ish input.** If the brownfield context is shallow (only context.md, no entities, no specs), most questions will be unanswered — that's fine, output them.
+- **Empty input.** If Pass A drafted ZERO questions (the markdown is empty / contains no questions), output \`{ "answered": [], "unanswered": [] }\`.
+
+## Quality bar
+
+The point of this pass is to convert "5 questions to PM" into "2 questions to PM + 3 already-answered with citations". A good Pass B saves PM round-trips; a vague one re-creates the friction by hedging every answer.`;
+
 export const REFINEMENT_ANALYST_SYSTEM = (checklist: string, projectContext: string) => `You are a rigorous product analyst for the slowcook brewing harness.
 
 Your job is to help the PM turn a GitHub issue into a precise, testable spec. You operate in rounds: each round, you either (a) ask the PM clarifying questions OR (b) emit the final spec as YAML. You do not both ask AND emit in the same round.


### PR DESCRIPTION
Adds a reflexive second LLM pass to refine's questions round. Each draft question from Pass A is checked against the brownfield context; if the codebase already answers it, the question moves to an audit-trail \`<details>\` block. PM only sees the still-unanswered ones.

## Why

Real-world PM observation on delgoosh #635: refine asked 3 questions the brownfield already answered (role split is in entities; handle uniqueness in schema; mock shows the layout). Pass A had the context in its prompt but didn't USE it as a question-filter — it generated under production pressure. Pass B IS that filter.

## Diff

- \`llm-anthropic\` α.11: new \`BROWNFIELD_ANSWER_SYSTEM\` prompt. Verbatim question copy + concrete source citations + conservative \"ambiguous = unanswered\" rule.
- \`cli\` α.36 \`refine/brownfield-answer.ts\`: \`hasBrownfield()\` greenfield detector (skip Pass B when nothing to draw from); \`answerQuestionsFromBrownfield()\` runs the LLM call; parser is tolerant of stray fences/prose; \`composePassBComment\` renders the final PM body.
- \`agent.ts\`: Pass B wired into questions round AFTER Pass A. Cost added to \`roundCostUsd\`; cost marker recomputed AFTER. Best-effort error path falls back to posting Pass A's original markdown unchanged.

## Transparency (PM-visible)

When ≥1 question is answered, the comment now leads with:

> _🔍 Checked brownfield first: **3 of 5** questions already answered in your codebase (see audit trail below). **2** still need your input:_
>
> **1.** \<still-unanswered Q1, verbatim with options\>
> **2.** \<still-unanswered Q2, verbatim\>
>
> \<details\>\<summary\>🔍 3 questions answered from brownfield context (audit trail)\</summary\>...verbatim Q + concrete answer + source citation per Q...\</details\>

## Cost shape

~\$0.20-\$0.50 extra per questions-round (Opus). PM round-trip count drops ~30-60% when ≥1 question lands in answered. Net per-story: cheaper, fewer rounds.

## Tests

- 22 new brownfield-answer tests (detector, parser, renderers, compose)
- 926/926 cli (was 904)
- Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)