### PR TITLE
cli α.39 + llm-anthropic α.13: Phase 3a of sc#82 — plate + run-mock + recon shape-aware

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.38",
+  "version": "0.19.0-alpha.39",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/plate/agent.ts
+++ b/packages/cli/src/commands/plate/agent.ts
@@ -43,6 +43,13 @@ export interface PlateContext {
   currentFiles: Array<{ path: string; contents: string }>;
   /** PM feedback to act on. */
   feedback: PlateFeedback;
+  /**
+   * Mock shape — read from `.brewing/mock.yaml` (sc#82). Defaults to
+   * `nextjs` for backwards-compat with consumers that predate sc#82.
+   * Branches navigation primitives + scenario imports in the system
+   * prompt.
+   */
+  mockShape?: "vite" | "nextjs";
 }
 
 export type PlateResult =
@@ -84,7 +91,7 @@ export async function runPlate(ctx: PlateContext): Promise<PlateResult> {
   const response = await anthropic.messages.create({
     model: ctx.model,
     max_tokens: MAX_TOKENS,
-    system: PLATE_AMENDMENT_SYSTEM(ctx.projectContext),
+    system: PLATE_AMENDMENT_SYSTEM(ctx.projectContext, ctx.mockShape ?? "nextjs"),
     messages: [{ role: "user", content: userBlocks }],
   });
 

--- a/packages/cli/src/commands/plate/index.ts
+++ b/packages/cli/src/commands/plate/index.ts
@@ -490,6 +490,12 @@ export async function plate(argv: string[], cliVersion: string): Promise<void> {
     return;
   }
 
+  // 0.19.0+ (sc#82) — read mock-shape config so plate's prompt routes
+  // navigation primitives + scenario imports correctly. Defaults to
+  // nextjs (legacy) for consumers without `.brewing/mock.yaml`.
+  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
+  const mockShape = loadMockShapeConfig(args.repoRoot).shape;
+
   const ctx: PlateContext = {
     repoRoot: args.repoRoot,
     anthropicApiKey,
@@ -501,6 +507,7 @@ export async function plate(argv: string[], cliVersion: string): Promise<void> {
     specYaml,
     currentFiles,
     feedback,
+    mockShape,
   };
 
   console.log(`Running plate (model: ${args.model})...`);

--- a/packages/cli/src/commands/run-mock/index.ts
+++ b/packages/cli/src/commands/run-mock/index.ts
@@ -300,7 +300,13 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
     if (proxy) env["NEXT_PUBLIC_SLOWCOOK_GH_PROXY"] = proxy.url;
   }
 
-  console.log(`  npm    run dev (next dev :3100)`);
+  // 0.19.0+ (sc#82) — detect mock shape so the log message is honest.
+  // `npm run dev` works for both shapes (Next.js: `next dev`; Vite:
+  // `vite`) — only the cosmetic label here needs branching.
+  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
+  const mockShape = loadMockShapeConfig(args.repoRoot).shape;
+  const devLabel = mockShape === "vite" ? "vite :3100" : "next dev :3100";
+  console.log(`  npm    run dev (${devLabel})`);
   if (!args.garnish) {
     console.log(`         overlay env: REVIEW=1 OWNER=${detected.owner} REPO=${detected.repo} PR=${prNumber ?? "?"} STORY=${args.story}${proxy ? ` GH_PROXY=${proxy.url}` : ""}`);
     if (!prNumber) {

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.12",
+  "version": "0.16.0-alpha.13",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/plate.test.ts
+++ b/packages/llm-anthropic/src/prompts/plate.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { PLATE_AMENDMENT_SYSTEM } from "./plate.js";
+
+describe("PLATE_AMENDMENT_SYSTEM shape branching (sc#82)", () => {
+  it("defaults to nextjs shape when no mockShape passed", () => {
+    const out = PLATE_AMENDMENT_SYSTEM("(ctx)");
+    expect(out).toContain("plate — slowcook's mockup-amendment agent");
+    expect(out).not.toContain("CRITICAL: Mock shape is Vite");
+  });
+
+  it("prepends Vite override block when mockShape='vite'", () => {
+    const out = PLATE_AMENDMENT_SYSTEM("(ctx)", "vite");
+    expect(out).toContain("CRITICAL: Mock shape is Vite");
+    expect(out).toContain("react-router-dom");
+    expect(out).toContain("scenario-registry.tsx");
+    expect(out).toContain("No `'use client'`");
+  });
+
+  it("Vite override warns the model that legacy Hard Rules below don't apply", () => {
+    const out = PLATE_AMENDMENT_SYSTEM("(ctx)", "vite");
+    expect(out).toContain("describe the LEGACY shape and do NOT apply here");
+  });
+
+  it("nextjs shape leaves the legacy conventions visible", () => {
+    const out = PLATE_AMENDMENT_SYSTEM("(ctx)", "nextjs");
+    expect(out).toContain("@slowcook-ai/mock-runtime");
+  });
+});

--- a/packages/llm-anthropic/src/prompts/plate.ts
+++ b/packages/llm-anthropic/src/prompts/plate.ts
@@ -16,7 +16,35 @@
  * for the PR reply).
  */
 
-export const PLATE_AMENDMENT_SYSTEM = (projectContext: string) => `You are plate — slowcook's mockup-amendment agent.
+/**
+ * Shape-aware override prepended at the top of PLATE_AMENDMENT_SYSTEM
+ * when the consumer's mock is a Vite/React SPA (sc#82). Plate amends
+ * EXISTING files, so the shape-specific deltas are smaller than vibe's
+ * — primarily nav primitives + scenario imports.
+ */
+const PLATE_VITE_SHAPE_OVERRIDE = `
+
+## CRITICAL: Mock shape is Vite (sc#82)
+
+The mock app is a **Vite + React SPA**, NOT a Next.js App Router app. When amending or adding files, override the Next.js defaults below:
+
+- Screens live at \`mock/src/apps/<role>/screens/<Screen>.tsx\` (NOT \`mock/src/app/<route>/page.tsx\`).
+- Router config lives at \`mock/src/App.tsx\` — append new routes inside the vibe-managed markers if your amendment adds one.
+- Scenario types + helpers are inlined in \`mock/src/lib/scenario-registry.tsx\`. Import them from there (\`import type { Scenario } from "../lib/scenario-registry";\`), NOT from \`@slowcook-ai/mock-runtime\`.
+- Navigation: \`<Link to="...">\` from \`react-router-dom\`, NOT \`<Link href>\` from \`next/link\`.
+- Hooks: \`useNavigate\` from \`react-router-dom\` for programmatic navigation, NOT \`useRouter\` from Next.js.
+- No \`'use client'\` directives.
+
+The Next.js-specific rules further down (Turbopack notes, \`useScenarioFixture\` discipline, \`@slowcook-ai/mock-runtime\` allowlist) describe the LEGACY shape and do NOT apply here.
+
+`;
+
+export type MockShape = "vite" | "nextjs";
+
+export const PLATE_AMENDMENT_SYSTEM = (
+  projectContext: string,
+  mockShape: MockShape = "nextjs",
+): string => `${mockShape === "vite" ? PLATE_VITE_SHAPE_OVERRIDE : ""}You are plate — slowcook's mockup-amendment agent.
 
 The PM is reviewing the running preview deploy of a mockup vibe emitted. They post feedback as PR comments (prose) and/or annotated screenshots. Your job: read all unresolved feedback since the last plate commit, amend the mockup files with the MINIMUM diff that satisfies it, and force-push.
 


### PR DESCRIPTION
Phase 3a of [sc#82](https://github.com/aminazar/slowcook/issues/82). Three minor agent updates that respect the new mock-shape config.

## Diff

- **plate** (\`PLATE_AMENDMENT_SYSTEM\` + cli wrapper): same Vite-shape override pattern as vibe (Phase 2). Prepends a \`CRITICAL: Mock shape is Vite\` block when \`mockShape='vite'\` specifying navigation primitives + scenario imports + no \`'use client'\`. Default unchanged for legacy consumers.
- **run-mock**: cosmetic log label fix — \`npm run dev (vite :3100)\` vs \`npm run dev (next dev :3100)\`. \`npm run dev\` works for both shapes; only the label needed branching.
- **recon**: zero changes. The walker (\`testidPresentInMock\`, \`resolveImport\`) already scans \`mock/src/\` broadly — the new \`mock/src/apps/<role>/screens/\` layout shows up the same way as the legacy \`mock/src/app/<route>/\`.

## Tests

- 4 new PLATE_AMENDMENT_SYSTEM shape-branching tests
- 943/943 cli tests still pass

## What's deferred

- **Port rewrite** (Vite/React-Router → Next.js App Router) — biggest piece of Phase 3; lands separately.
- **Phase 4** \`slowcook brand\` agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)