### PR TITLE
cli α.40 + llm-anthropic α.14: Phase 4 of sc#82 — slowcook brand agent

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.39",
+  "version": "0.19.0-alpha.40",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { fixtures } from "./commands/fixtures/index.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
 import { budget } from "./commands/budget/index.js";
+import { brand } from "./commands/brand/index.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
 // version, the spec's `refined_by` field, and the init template's workflow
@@ -76,6 +77,7 @@ Usage:
   slowcook eval (--all | --fixture <id> | --list) [--fixtures-dir <path>]
   slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]
   slowcook budget [show|set|rm] [--monthly <usd>] [--start-day <1-31>] [--story <usd>] [--cwd <path>]
+  slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]
   slowcook version
   slowcook help
 
@@ -108,6 +110,7 @@ Commands available in ${VERSION}:
   run-mock           (0.16-α.17) One-command mock launch + auto-pull. \`run-mock <story>\`: checkout mockup branch, npm install in mock/, run next dev with overlay env vars, poll origin every 15s + git pull --ff-only on plate amendments.
   dispatch           Trigger a slowcook GitHub Actions workflow remotely (brew / testgen / refine).
   budget             (0.19.0-α.35) Manage the project monthly budget for the fuel gauge. \`budget set --monthly 50\` writes .brewing/budget.yaml; no args shows config + month-to-date spend.
+  brand              (0.19.0-α.40, sc#82 Phase 4) Design-system foundation agent. Reads a brand brief (\`.brewing/brand.yaml\` or \`--brief\`) and emits mock/src/design-system/{tokens.ts, css.ts}. Runs once per project; \`--refresh\` overwrites.
 
 Coming in later versions:
   review, dashboard
@@ -326,6 +329,14 @@ async function main(): Promise<void> {
       // No args = show current config + month-to-date spend. `set
       // --monthly N` writes; `rm` deletes (disables the fuel gauge).
       await budget(args.slice(1));
+      return;
+    case "brand":
+      // 0.19.0-α.40 (sc#82 Phase 4) — design-system foundation agent.
+      // Runs once per consumer (or on --refresh) to populate
+      // mock/src/design-system/{tokens.ts, css.ts} from a brand brief.
+      // Vibe/plate/brew inherit these tokens; no more shadcn-default
+      // drift when the consumer has a real brand.
+      await brand(args.slice(1), VERSION);
       return;
     case "version":
     case "--version":

--- a/packages/cli/src/commands/brand/index.test.ts
+++ b/packages/cli/src/commands/brand/index.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadBrandConfig, buildProjectContext } from "./index.js";
+
+function makeRepo(): string {
+  return mkdtempSync(join(tmpdir(), "brand-test-"));
+}
+
+describe("brand config loader", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("returns null when .brewing/brand.yaml absent", () => {
+    expect(loadBrandConfig(repo)).toBe(null);
+  });
+
+  it("parses a valid config", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "brand.yaml"),
+      `schema_version: 1
+name: Delgoosh
+description: Mental-health platform for Persian speakers.
+palette_hint: soft teals + warm corals
+languages: [fa, en]
+colors:
+  primary: '#3BAFA0'
+  accent: '#E8A07A'
+`,
+      "utf8",
+    );
+    const cfg = loadBrandConfig(repo);
+    expect(cfg).not.toBe(null);
+    expect(cfg!.name).toBe("Delgoosh");
+    expect(cfg!.colors?.primary).toBe("#3BAFA0");
+    expect(cfg!.languages).toEqual(["fa", "en"]);
+  });
+
+  it("rejects malformed hex codes", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "brand.yaml"),
+      `schema_version: 1
+name: X
+description: Y
+colors:
+  primary: red
+`,
+      "utf8",
+    );
+    expect(() => loadBrandConfig(repo)).toThrow();
+  });
+
+  it("rejects missing schema_version", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(join(repo, ".brewing", "brand.yaml"), `name: X\ndescription: Y\n`, "utf8");
+    expect(() => loadBrandConfig(repo)).toThrow();
+  });
+
+  it("defaults languages to [en] when omitted", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "brand.yaml"),
+      `schema_version: 1\nname: X\ndescription: Y\n`,
+      "utf8",
+    );
+    expect(loadBrandConfig(repo)?.languages).toEqual(["en"]);
+  });
+});
+
+describe("buildProjectContext", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  function args(overrides: Partial<{ briefInline: string }> = {}) {
+    return {
+      cwd: repo,
+      refresh: false,
+      dryRun: false,
+      briefInline: overrides.briefInline,
+      model: "claude-opus-4-7",
+    } as const;
+  }
+
+  it("uses --brief when provided", () => {
+    const out = buildProjectContext(repo, args({ briefInline: "Inline brief here" }));
+    expect(out).toContain("Inline brief here");
+    expect(out).toContain("Brand brief");
+  });
+
+  it("uses .brewing/brand.yaml when no inline brief", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "brand.yaml"),
+      `schema_version: 1
+name: Delgoosh
+description: Mental-health platform.
+palette_hint: soft teals + warm corals
+languages: [fa, en]
+`,
+      "utf8",
+    );
+    const out = buildProjectContext(repo, args());
+    expect(out).toContain("**Name:** Delgoosh");
+    expect(out).toContain("Mental-health platform");
+    expect(out).toContain("soft teals + warm corals");
+    expect(out).toContain("**Languages:** fa, en");
+  });
+
+  it("emits explicit-colours block when colors set", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "brand.yaml"),
+      `schema_version: 1
+name: X
+description: Y
+colors:
+  primary: '#3BAFA0'
+  accent: '#E8A07A'
+`,
+      "utf8",
+    );
+    const out = buildProjectContext(repo, args());
+    expect(out).toContain("Explicit colours");
+    expect(out).toContain("primary: #3BAFA0");
+    expect(out).toContain("accent:  #E8A07A");
+  });
+
+  it("falls back to CLAUDE.md when no brand.yaml", () => {
+    writeFileSync(join(repo, "CLAUDE.md"), "# My Project\n\nMental health app.", "utf8");
+    const out = buildProjectContext(repo, args());
+    expect(out).toContain("best-effort context");
+    expect(out).toContain("Mental health app");
+  });
+
+  it("falls back to README.md when no brand.yaml and no CLAUDE.md", () => {
+    writeFileSync(join(repo, "README.md"), "# README\n\nFintech platform.", "utf8");
+    const out = buildProjectContext(repo, args());
+    expect(out).toContain("Fintech platform");
+  });
+
+  it("emits a 'no brief found' note when nothing exists", () => {
+    const out = buildProjectContext(repo, args());
+    expect(out).toContain("No brand brief found");
+  });
+});

--- a/packages/cli/src/commands/brand/index.ts
+++ b/packages/cli/src/commands/brand/index.ts
@@ -1,0 +1,291 @@
+/**
+ * `slowcook brand` — design-system foundation agent (sc#82 Phase 4).
+ *
+ * Runs ONCE per consumer (or on `--refresh`) to populate
+ * `mock/src/design-system/{tokens.ts, css.ts}` from a brand brief.
+ * Every downstream agent (vibe, plate, brew) inherits the tokens this
+ * emits. Without brand, vibe falls back to the neutral seed values
+ * `slowcook init mock --shape vite` scaffolds and outputs drift toward
+ * shadcn-default styling.
+ *
+ * Brief sources, in priority order:
+ *   1. `--brief "<inline prose>"` flag
+ *   2. `.brewing/brand.yaml` file (consumer-authored)
+ *   3. CLAUDE.md / README.md (best-effort extraction)
+ *
+ * Idempotency: refuses to overwrite `mock/src/design-system/tokens.ts`
+ * + `css.ts` without `--refresh`. Designed to be safe re-run as the
+ * project evolves; PMs explicitly opt-in to brand drift.
+ */
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import YAML from "yaml";
+import { z } from "zod";
+import Anthropic from "@anthropic-ai/sdk";
+import { BRAND_SYSTEM, costUsdForUsage } from "@slowcook-ai/llm-anthropic";
+import { parseVibeOutput, writeVibeFiles } from "../vibe/emit.js";
+
+const DEFAULT_MODEL = "claude-opus-4-7";
+const MAX_TOKENS = 8192;
+
+const BrandConfigSchema = z.object({
+  schema_version: z.literal(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  /** Free-form palette hint (e.g. "soft teals + warm corals"). */
+  palette_hint: z.string().optional(),
+  /** Languages the app supports (e.g. ["en", "fa"]). Drives FONTS entries. */
+  languages: z.array(z.string()).min(1).default(["en"]),
+  /** Optional explicit hex codes (PM nails specific values). */
+  colors: z
+    .object({
+      primary: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+      accent: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+    })
+    .optional(),
+  /** Optional font preferences. */
+  fonts_hint: z.string().optional(),
+});
+
+export type BrandConfig = z.infer<typeof BrandConfigSchema>;
+
+interface BrandArgs {
+  cwd: string;
+  refresh: boolean;
+  dryRun: boolean;
+  briefInline: string | undefined;
+  model: string;
+}
+
+function parseArgs(argv: string[]): BrandArgs {
+  const args: BrandArgs = {
+    cwd: process.cwd(),
+    refresh: false,
+    dryRun: false,
+    briefInline: undefined,
+    model: DEFAULT_MODEL,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === "--cwd" && next) {
+      args.cwd = next;
+      i++;
+    } else if (a === "--refresh") {
+      args.refresh = true;
+    } else if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--brief" && next) {
+      args.briefInline = next;
+      i++;
+    } else if (a === "--model" && next) {
+      args.model = next;
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`
+slowcook brand — design-system foundation agent (sc#82 Phase 4)
+
+Emits mock/src/design-system/{tokens.ts, css.ts} from a brand brief.
+Runs once per project, on demand. Vibe + plate + brew inherit the
+tokens this writes.
+
+Usage:
+  slowcook brand                                  Read brief from .brewing/brand.yaml + emit (refuses to overwrite without --refresh)
+  slowcook brand --brief "<prose>"                Use inline brief instead of brand.yaml
+  slowcook brand --refresh                        Overwrite existing design-system files
+  slowcook brand --dry-run                        Print planned files without writing
+  slowcook brand --cwd <path>                     Project root (default: cwd)
+  slowcook brand --model <id>                     Model (default: claude-opus-4-7)
+
+Brief sources, in priority order:
+  1. --brief flag (inline)
+  2. .brewing/brand.yaml
+  3. CLAUDE.md / README.md (best-effort)
+
+Brand.yaml shape:
+  schema_version: 1
+  name: <project name>
+  description: <one-paragraph brief>
+  palette_hint: soft teals + warm corals      # optional
+  languages: [en, fa]                          # default: [en]
+  colors:                                       # optional
+    primary: '#3BAFA0'
+    accent:  '#E8A07A'
+  fonts_hint: Vazirmatn body, Lalezar headings  # optional
+`);
+}
+
+export function loadBrandConfig(repoRoot: string): BrandConfig | null {
+  const p = join(repoRoot, ".brewing", "brand.yaml");
+  if (!existsSync(p)) return null;
+  const raw = YAML.parse(readFileSync(p, "utf8"));
+  const parsed = BrandConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid .brewing/brand.yaml: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+    );
+  }
+  return parsed.data;
+}
+
+function readBriefFromMarkdown(repoRoot: string): string | null {
+  for (const candidate of ["CLAUDE.md", "README.md"]) {
+    const p = join(repoRoot, candidate);
+    if (existsSync(p)) {
+      const body = readFileSync(p, "utf8");
+      // Use the first ~2000 characters as best-effort context.
+      return body.slice(0, 2000);
+    }
+  }
+  return null;
+}
+
+export function buildProjectContext(repoRoot: string, args: BrandArgs): string {
+  const sections: string[] = [];
+  sections.push("## Brand brief\n");
+  if (args.briefInline) {
+    sections.push(args.briefInline);
+  } else {
+    const cfg = loadBrandConfig(repoRoot);
+    if (cfg) {
+      sections.push(`**Name:** ${cfg.name}\n\n${cfg.description}`);
+      if (cfg.palette_hint) sections.push(`\n**Palette hint:** ${cfg.palette_hint}`);
+      if (cfg.fonts_hint) sections.push(`**Fonts hint:** ${cfg.fonts_hint}`);
+      sections.push(`**Languages:** ${cfg.languages.join(", ")}`);
+      if (cfg.colors) {
+        const lines: string[] = ["**Explicit colours (use VERBATIM, derive variants):**"];
+        if (cfg.colors.primary) lines.push(`- primary: ${cfg.colors.primary}`);
+        if (cfg.colors.accent) lines.push(`- accent:  ${cfg.colors.accent}`);
+        sections.push(lines.join("\n"));
+      }
+    } else {
+      const md = readBriefFromMarkdown(repoRoot);
+      if (md) {
+        sections.push("(No `.brewing/brand.yaml`; reading project README/CLAUDE.md as best-effort context.)\n\n");
+        sections.push(md);
+      } else {
+        sections.push("(No brand brief found. Default to a neutral, professional palette.)");
+      }
+    }
+  }
+  return sections.join("\n");
+}
+
+export async function brand(argv: string[], _cliVersion: string): Promise<void> {
+  let args: BrandArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(2);
+  }
+
+  // Pre-flight: refuse to overwrite without --refresh.
+  const tokensPath = join(args.cwd, "mock", "src", "design-system", "tokens.ts");
+  const cssPath = join(args.cwd, "mock", "src", "design-system", "css.ts");
+  const exists = existsSync(tokensPath) || existsSync(cssPath);
+  if (exists && !args.refresh && !args.dryRun) {
+    console.error(
+      `mock/src/design-system/{tokens.ts,css.ts} already exist. Pass --refresh to overwrite.`,
+    );
+    process.exit(2);
+  }
+
+  const anthropicApiKey = process.env["ANTHROPIC_API_KEY"];
+  if (!anthropicApiKey && !args.dryRun) {
+    console.error(`ANTHROPIC_API_KEY not set. Either set it or pass --dry-run.`);
+    process.exit(2);
+  }
+
+  const projectContext = buildProjectContext(args.cwd, args);
+
+  console.log(
+    `slowcook brand · cwd: ${args.cwd} (model: ${args.model}${args.dryRun ? ", dry-run" : ""}${args.refresh ? ", refresh" : ""})`,
+  );
+
+  if (args.dryRun) {
+    console.log("\n--- Project context the agent will receive ---\n");
+    console.log(projectContext);
+    console.log("\n--dry-run: no LLM call, no files written.");
+    return;
+  }
+
+  const anthropic = new Anthropic({ apiKey: anthropicApiKey! });
+  const userPrompt = `Generate the design-system foundation for this mock app from the brand brief in your system prompt. Emit the two file blocks (\`mock/src/design-system/tokens.ts\` + \`mock/src/design-system/css.ts\`) per the Output format. No prose preamble.`;
+
+  const response = await anthropic.messages.create({
+    model: args.model,
+    max_tokens: MAX_TOKENS,
+    system: BRAND_SYSTEM(projectContext),
+    messages: [{ role: "user", content: userPrompt }],
+  });
+
+  let spendUsd = 0;
+  try {
+    // SDK type for usage has narrowed over versions; read via loose cast so
+    // newer cache-token fields don't trip strict typecheck.
+    const raw = response.usage as unknown as {
+      input_tokens: number;
+      output_tokens: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
+    spendUsd = costUsdForUsage(args.model, {
+      inputTokens: raw.input_tokens,
+      outputTokens: raw.output_tokens,
+      cacheReadTokens: raw.cache_read_input_tokens ?? 0,
+      cacheCreateTokens: raw.cache_creation_input_tokens ?? 0,
+    });
+  } catch {
+    /* cost calc best-effort */
+  }
+
+  let finalText = "";
+  for (const block of response.content) {
+    if (block.type === "text") finalText = block.text;
+  }
+
+  const parsed = parseVibeOutput(finalText);
+  if (parsed.files.length === 0) {
+    console.error(
+      `Brand agent emitted no <file> blocks. Spend: $${spendUsd.toFixed(4)}.`,
+    );
+    if (process.env["SLOWCOOK_DEBUG"]) {
+      console.error("\n--- agent's final text ---\n");
+      console.error(finalText);
+    }
+    process.exit(2);
+  }
+
+  // Validate paths: every file must be under mock/src/design-system/
+  for (const f of parsed.files) {
+    if (!f.path.startsWith("mock/src/design-system/")) {
+      console.error(
+        `Brand emit refused: file outside mock/src/design-system/: ${f.path}. Run with --dry-run to see what the agent wanted to write.`,
+      );
+      process.exit(2);
+    }
+  }
+
+  // Write — writeVibeFiles enforces the mock/ root constraint.
+  const written = writeVibeFiles(args.cwd, parsed.files);
+  for (const p of written) {
+    console.log(`  write  ${p}`);
+  }
+
+  console.log(`\nDone. Spend: $${spendUsd.toFixed(4)}.`);
+  console.log(`Next: \`slowcook vibe --spec <id>\` — vibe will read your new design-system on the next dispatch.`);
+}

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.13",
+  "version": "0.16.0-alpha.14",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/index.ts
+++ b/packages/llm-anthropic/src/index.ts
@@ -27,6 +27,7 @@ export {
   type SiftTurnPromptArgs,
 } from "./prompts/sift.js";
 export { TESTGEN_SYSTEM } from "./prompts/testgen.js";
+export { BRAND_SYSTEM } from "./prompts/brand.js";
 export {
   BREW_SYSTEM,
   BREW_TOOLS,

--- a/packages/llm-anthropic/src/prompts/brand.test.ts
+++ b/packages/llm-anthropic/src/prompts/brand.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { BRAND_SYSTEM } from "./brand.js";
+
+describe("BRAND_SYSTEM (sc#82 Phase 4)", () => {
+  it("includes the consumer's project-context block", () => {
+    const out = BRAND_SYSTEM("(my brand context)");
+    expect(out).toContain("(my brand context)");
+  });
+
+  it("requires the canonical COLORS keys", () => {
+    const out = BRAND_SYSTEM("");
+    for (const key of [
+      "primary",
+      "primaryLight",
+      "primaryDark",
+      "primaryGhost",
+      "accent",
+      "success",
+      "danger",
+      "warn",
+      "bg",
+      "bgDark",
+      "sand",
+      "cream",
+      "textDark",
+      "textMid",
+      "textLight",
+    ]) {
+      expect(out).toContain(key);
+    }
+  });
+
+  it("requires SPACING + RADIUS + SHADOW + FONTS exports", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("export const SPACING");
+    expect(out).toContain("export const RADIUS");
+    expect(out).toContain("export const SHADOW");
+    expect(out).toContain("export const FONTS");
+  });
+
+  it("requires makeGlobalCSS with direction-aware branching", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("makeGlobalCSS");
+    expect(out).toContain("dir = lang === 'fa'");
+  });
+
+  it("specifies file paths for both emitted files", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("mock/src/design-system/tokens.ts");
+    expect(out).toContain("mock/src/design-system/css.ts");
+  });
+
+  it("instructs the agent to derive ghost from primary at coherent alpha", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("primary at 12% alpha");
+    expect(out).toContain("Pick consistent variants");
+  });
+
+  it("requires Google Fonts URLs (not self-hosted)", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("Google Fonts");
+    expect(out).toContain("fonts.googleapis.com");
+  });
+
+  it("instructs the agent to emit Output format only — XML blocks, no prose", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("Output ONLY the XML-tagged file blocks");
+    expect(out).toContain("No prose preamble");
+  });
+
+  it("includes self-check rules", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("Self-check before emitting");
+  });
+});

--- a/packages/llm-anthropic/src/prompts/brand.ts
+++ b/packages/llm-anthropic/src/prompts/brand.ts
@@ -1,0 +1,207 @@
+/**
+ * 0.19.0+ (sc#82 Phase 4) — `slowcook brand` agent prompts.
+ *
+ * Brand is slowcook's design-system-as-pre-vibe-foundation agent. It
+ * runs ONCE per consumer (or on `--refresh`) and emits the design
+ * tokens + global CSS that every downstream agent (vibe, plate, brew)
+ * inherits. Without brand, vibe falls back to the neutral seed
+ * `slowcook init mock --shape vite` scaffolds, and outputs drift
+ * toward shadcn-default visual language.
+ *
+ * The brand agent is single-shot like vibe — one LLM call, XML-block
+ * output, parsed + written to `mock/src/design-system/`.
+ */
+
+export const BRAND_SYSTEM = (projectContext: string): string => `You are brand — slowcook's design-system foundation agent.
+
+Your job: read a brand brief and emit the design tokens + global CSS for the consumer's mock app. Every downstream agent (vibe, plate, brew) reads these files; your output is the visual contract everything else inherits.
+
+You run ONCE per project (or on \`--refresh\` when the brand shifts). Be DECISIVE. The PM gave you a one-paragraph brief; turn it into a complete, internally-consistent token system. Defaults you pick now are the consumer's brand until the PM explicitly refreshes you.
+
+## Project context
+
+${projectContext}
+
+## What you emit
+
+Two files, both in \`mock/src/design-system/\`:
+
+### 1. \`mock/src/design-system/tokens.ts\`
+
+Pure data, no JSX, no imports. Exports five constants:
+
+\`\`\`ts
+export const COLORS = {
+  // Brand (REQUIRED)
+  primary:       '#XXXXXX',  // the dominant brand colour
+  primaryLight:  '#XXXXXX',  // a 10–15% lighter variant
+  primaryDark:   '#XXXXXX',  // a 10–15% darker variant
+  primaryGhost:  'rgba(R,G,B,0.12)',  // primary at 12% alpha
+
+  accent:        '#XXXXXX',  // the warm/contrast colour
+  accentLight:   '#XXXXXX',
+  accentGhost:   'rgba(R,G,B,0.15)',
+
+  // Semantic (REQUIRED — pick coherent palette mates)
+  success:       '#XXXXXX',
+  successGhost:  'rgba(R,G,B,0.12)',
+  danger:        '#XXXXXX',
+  dangerGhost:   'rgba(R,G,B,0.12)',
+  warn:          '#XXXXXX',
+  warnGhost:     '#XXXXXX',  // can be solid
+
+  // Surfaces (REQUIRED)
+  bg:            '#XXXXXX',  // app background — usually very light tint of primary
+  bgDark:        '#XXXXXX',  // dark surface for hero panels / branding
+  white:         '#FFFFFF' OR '#FDFBFC' or similar near-white
+  sidebar:       '#XXXXXX',  // 5% lighter than bg
+
+  // Borders + neutrals (REQUIRED)
+  cardBorder:    'rgba(R,G,B,0.45)',  // primary at 45% alpha
+  sidebarBorder: 'rgba(R,G,B,0.5)',
+  sand:          '#XXXXXX',  // muted version of primary
+  cream:         '#XXXXXX',  // soft pastel — between bg and sand
+
+  // Text (REQUIRED)
+  textDark:      '#XXXXXX',  // body text on light bg — high contrast
+  textMid:       '#XXXXXX',  // secondary text
+  textLight:     '#XXXXXX',  // tertiary / disabled
+  textOnDark:    'rgba(255,255,255,0.85)',
+  textOnDarkSub: 'rgba(255,255,255,0.45)',
+};
+
+export const SPACING = { xs: 4, sm: 8, md: 14, lg: 20, xl: 28, xxl: 40 };
+
+export const RADIUS  = {
+  sm:   8,
+  md:   12,
+  lg:   17,
+  xl:   22,
+  pill: 100,
+  full: '50%' as const,
+};
+
+export const SHADOW = {
+  card:      '0 2px 18px rgba(R,G,B,0.07)',  // primary at 7% alpha
+  stat:      '0 2px 12px rgba(R,G,B,0.06)',
+  btn:       '0 3px 12px rgba(R,G,B,0.28)',
+  btnAccent: '0 3px 12px rgba(R,G,B,0.30)',
+  nav:       '0 -3px 16px rgba(R,G,B,0.10)',
+};
+
+export const FONTS = {
+  // For each language pair the brand brief specifies, emit a key.
+  // Default keys: en (always). Add fa / ar / ... when the brief or
+  // project context mentions multilingual support.
+  en: {
+    heading: "'<FONT>', <fallback>",   // chosen serif/sans for headings
+    body:    "'<FONT>', <fallback>",   // chosen body font
+    import:  'https://fonts.googleapis.com/css2?family=...&display=swap',
+  },
+  // fa: { ... },  // only if multilingual
+};
+
+export type Lang = keyof typeof FONTS;
+\`\`\`
+
+### 2. \`mock/src/design-system/css.ts\`
+
+Direction-aware global stylesheet. Imports COLORS / FONTS / SHADOW / RADIUS from \`./tokens\` and exports a single function \`makeGlobalCSS(lang)\`:
+
+\`\`\`ts
+import { COLORS, FONTS, SHADOW, RADIUS } from './tokens';
+import type { Lang } from './tokens';
+
+export function makeGlobalCSS(lang: Lang): string {
+  const f = FONTS[lang];
+  const dir = lang === 'fa' || lang === 'ar' ? 'rtl' : 'ltr';
+  return \\\`
+    @import url('\${f.import}');
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body {
+      direction: \${dir};
+      font-family: \${f.body};
+      background: \${COLORS.bg};
+      color: \${COLORS.textDark};
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }
+    .ds-heading { font-family: \${f.heading}; }
+    /* Scrollbars, animations, ds-* utility classes — include the canonical set. */
+    /* See the existing baseline if one is in the project context. */
+  \\\`;
+}
+\`\`\`
+
+The CSS file should include (when relevant to the brand):
+- Custom scrollbar styling (\`::-webkit-scrollbar\`)
+- Animation keyframes (\`ds-fadeUp\`, \`ds-fadeIn\`, \`ds-float\`, \`ds-pulse\`, \`ds-spin\`)
+- Layout utility classes (\`ds-sidebar\`, \`ds-main\`, \`ds-page-header\`, \`ds-page-header-mobile\`, \`ds-bottom-nav\`)
+- Form styling (\`input\`, \`textarea\`, \`select\`, \`label\`)
+- Tab bar (\`ds-tab-bar\`, \`ds-tab-btn\`)
+- Divider (\`ds-divider\`)
+- Progress bar (\`ds-progress-bar\`, \`ds-progress-fill\`)
+
+## Rules
+
+### 1. Match the brief
+
+Read the project-context brand brief carefully. Map every signal you find:
+
+- **Mood words** (warm, calm, playful, serious, professional, soft, bold) → palette saturation + temperature
+- **Industry hints** (mental health, fintech, retail, devtools) → conventional palettes (e.g. mental health = soft greens/blues; fintech = bold blues; retail = warm corals)
+- **Cultural/locale signals** (Persian, bilingual fa/en, Arabic, Asian markets) → add the relevant language to \`FONTS\` and pick fonts with proper Unicode coverage (Vazirmatn for Persian, Noto for Asian scripts, etc.)
+- **Explicit hex codes** (PM says "use #3BAFA0 as primary") → use them VERBATIM; derive light/dark/ghost variants from them.
+
+### 2. Pick consistent variants
+
+When you derive \`primaryLight\`/\`primaryDark\`/\`accentGhost\`/etc. from base colours, apply consistent transformations:
+- \`Light\`: +12% lightness (HSL space)
+- \`Dark\`: -12% lightness
+- \`Ghost\`: 12% alpha overlay (for primary) or 15% (for accent)
+
+Don't pick random sibling colours — keep the palette mathematically coherent.
+
+### 3. Don't invent without grounding
+
+\`SPACING\`, \`RADIUS\` defaults are sound for 90%+ of brands; ONLY change them if the brief explicitly calls for sharper edges (small \`RADIUS.md\`, e.g. 6) or chunkier rounding (large, e.g. 24). Default to the seed values above.
+
+### 4. Fonts — use Google Fonts unless the brief overrides
+
+Google Fonts \`@import\` URLs work everywhere. Pick:
+- **Headings**: a friendly display serif (Lalezar for Persian, DM Serif Display for English, Spectral for editorial, etc.) OR a confident sans (Space Grotesk, Outfit) depending on the brief.
+- **Body**: a high-readability sans (Inter, DM Sans, Vazirmatn for Persian, Noto Sans for multilingual).
+
+Don't mix more than two fonts per language. Don't pick fonts that aren't on Google Fonts (you don't know if the consumer has self-hosted alternatives).
+
+### 5. Bilingual / multilingual
+
+When the brief mentions multiple languages, emit a \`FONTS\` entry per language with appropriate fonts + import URLs. The css \`makeGlobalCSS\` already branches on \`lang\`.
+
+## Output format
+
+Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, no markdown headings outside blocks.
+
+\`\`\`xml
+<file path="mock/src/design-system/tokens.ts">
+// (file contents)
+</file>
+
+<file path="mock/src/design-system/css.ts">
+// (file contents)
+</file>
+\`\`\`
+
+## Self-check before emitting
+
+1. Every required key in COLORS is present + has a sensible value.
+2. \`primaryGhost\` / \`accentGhost\` are derived from \`primary\` / \`accent\` (same RGB, alpha 0.12 / 0.15).
+3. \`cardBorder\` / \`sidebarBorder\` are derived from \`sand\` or \`primary\`.
+4. \`FONTS\` has at least one language entry; the brand brief's languages are all represented.
+5. \`SHADOW\` colours are coherent with \`primary\` / \`accent\` (not random greys).
+6. \`makeGlobalCSS\` imports the Google Fonts URL from \`FONTS[lang].import\`.
+7. Both files end with a trailing newline.
+
+If any check fails, fix before emitting.
+`;


### PR DESCRIPTION
Phase 4 of [sc#82](https://github.com/aminazar/slowcook/issues/82). New design-system foundation agent. Runs ONCE per consumer (or on \`--refresh\`) to populate \`mock/src/design-system/{tokens.ts, css.ts}\` from a brand brief.

## Why

Without brand, \`slowcook init mock --shape vite\` scaffolds a neutral-seed token file. Vibe has nothing brand-specific to anchor on and produces mocks that ignore the consumer's actual visual identity. Phase 4 closes that gap — empirically the right move per delgoosh PR #639 where the consumer had a working brand but vibe never read it.

## Diff

- **\`BRAND_SYSTEM\` prompt** (llm-anthropic α.14): specifies required COLORS / SPACING / RADIUS / SHADOW / FONTS shape, ghost-derivation rule (primary at 12% alpha), Google Fonts defaults, bilingual handling, XML-block output.
- **\`slowcook brand\` command** (cli α.40):
  - \`--brief "<prose>"\` inline brief
  - \`.brewing/brand.yaml\` config (zod-validated)
  - Falls back to CLAUDE.md / README.md
  - \`--refresh\` overwrites; \`--dry-run\` prints context without LLM call
- **\`brand.yaml\` schema**: \`name\`, \`description\`, \`palette_hint\`, \`fonts_hint\`, \`languages\` (default \`[en]\`), optional \`colors.primary\` / \`colors.accent\` hex codes
- **CLI dispatch + USAGE** updated

## Validation

\`\`\`
\$ slowcook brand --cwd /Users/amin/Downloads/rewo --dry-run
slowcook brand · cwd: /Users/amin/Downloads/rewo (model: claude-opus-4-7, dry-run)
--- Project context the agent will receive ---
## Brand brief
(No \`.brewing/brand.yaml\`; reading project README/CLAUDE.md as best-effort context.)
# CLAUDE.md — rewo (Reaction Worthy)
...
\`\`\`

Dry-run confirms the fallback to CLAUDE.md works. End-to-end LLM run requires \`ANTHROPIC_API_KEY\` in the env (refuses without it unless \`--dry-run\`).

## Tests

- 9 BRAND_SYSTEM prompt-shape tests (llm-anthropic)
- 11 brand cli unit tests (config loader + fallback chain + project-context builder)
- 954/954 cli tests pass (was 943)
- 42/42 llm-anthropic tests pass (was 33)

## Sequencing

- ✅ Phase 1: Vite mock template (#83)
- ✅ Phase 2: vibe shape-aware (#84)
- ✅ Phase 3a: plate / run-mock / recon shape-aware (#85)
- ✅ Phase 4: brand agent (this PR)
- ⏳ Phase 3b: port rewrite (Vite/React-Router → Next.js) — separate PR
- ✅ Phase 5: rewo mock migrated to Vite (rewo PR #158, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)