### PR TITLE
cli α.43-α.45: history-index git-attention + refine multifurcation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.42",
+  "version": "0.19.0-alpha.43",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.44",
+  "version": "0.19.0-alpha.45",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.43",
+  "version": "0.19.0-alpha.44",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -70,6 +70,11 @@ import { applySupersede } from "@slowcook-ai/core";
 import { enrichBodyWithImages } from "./images.js";
 import { auditSideEffects, sideEffectsCommentBody } from "./side-effects-audit.js";
 import {
+  assessMultifurcation,
+  multifurcationCommentBody,
+  hasExistingMultifurcationComment,
+} from "./multifurcate.js";
+import {
   answerQuestionsFromBrownfield,
   composePassBComment,
   hasBrownfield,
@@ -83,6 +88,13 @@ export const LABEL_BLOCKED_OVERLAP = "blocked-overlap";
 export const LABEL_SPEC_SUBMITTED = "spec-submitted";
 export const LABEL_SPEC_READY = "spec-ready";
 export const LABEL_NEEDS_REFINEMENT = "needs-refinement";
+/**
+ * cli α.44 — applied to an issue when refine has posted a multifurcation
+ * proposal. While present, future refine runs skip the multifurcation
+ * step (the PM is still deciding whether to file the split). PM removes
+ * the label after acting on the proposal.
+ */
+export const LABEL_MULTIFURCATION_PROPOSED = "slowcook-multifurcation-proposed";
 
 /**
  * Branded header prepended to every clarifying-question comment so reviewers
@@ -118,6 +130,7 @@ export type RefineOutcome =
   | { kind: "follow-up-noted"; related_ids: string[] }
   | { kind: "contradiction-blocked"; conflicting_ids: string[] }
   | { kind: "change-of-mind-accepted"; supersedes: string[] }
+  | { kind: "multifurcation-proposed"; commentId: number; subIssueCount: number }
   | { kind: "noop"; reason: string };
 
 /** Schema for the <sentinel> block the agent uses when it emits a spec. */
@@ -131,6 +144,68 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
   }
   if (!issue.labels.includes(LABEL_NEEDS_REFINEMENT)) {
     return { kind: "noop", reason: `issue is not labeled ${LABEL_NEEDS_REFINEMENT}` };
+  }
+
+  // Step 0: multifurcation check (cli α.44).
+  //
+  // Cheap LLM pass that detects "this issue is actually many stories"
+  // BEFORE refine wastes a heavy-reasoning call producing a fuzzy
+  // mega-spec. Sits ahead of relationship analysis because if we're
+  // going to ask the PM to split, that conversation precedes any
+  // overlap/contradiction reasoning against existing specs (the
+  // existing specs we'd compare against are per-sub-issue, not per-
+  // parent).
+  //
+  // Skipped when:
+  //   - the issue already carries `slowcook-multifurcation-proposed`
+  //     (refine has already posted a proposal; PM is deciding)
+  //   - a multifurcation comment marker is already in the thread
+  //     (defense-in-depth against label drift)
+  //
+  // The model can fall back to "one" silently if the verdict is
+  // unparseable — that's safer than blocking refine on a parser bug.
+  if (!issue.labels.includes(LABEL_MULTIFURCATION_PROPOSED)) {
+    const existingComments = await ctx.forge.listIssueComments(ctx.issueNumber);
+    if (!hasExistingMultifurcationComment(existingComments)) {
+      try {
+        const mf = await assessMultifurcation(
+          { issueTitle: issue.title, issueBody: issue.body },
+          { llm: ctx.llm, model: ctx.relationshipModel }
+        );
+        if (mf.verdict.kind === "many") {
+          const marker = costMarker({
+            agent: "refine",
+            usd: mf.costUsd,
+            tokensIn: mf.usage.inputTokens,
+            tokensOut: mf.usage.outputTokens,
+            cacheRead: mf.usage.cacheReadTokens,
+            cacheCreate: mf.usage.cacheCreateTokens,
+            model: ctx.relationshipModel,
+            round: "multifurcation",
+          });
+          const body =
+            multifurcationCommentBody(
+              { rationale: mf.verdict.rationale, sub_issues: mf.verdict.sub_issues },
+              { issueTitle: issue.title }
+            ) +
+            "\n\n" +
+            marker;
+          const comment = await ctx.forge.createIssueComment(ctx.issueNumber, body);
+          await ctx.forge.addIssueLabels(ctx.issueNumber, [LABEL_MULTIFURCATION_PROPOSED]);
+          return {
+            kind: "multifurcation-proposed",
+            commentId: comment.id,
+            subIssueCount: mf.verdict.sub_issues.length,
+          };
+        }
+      } catch (e) {
+        // Multifurcation is an optimization; if the LLM call fails we
+        // still want refine to proceed. Log only.
+        console.warn(
+          `  (multifurcation check failed; proceeding with single-spec refine: ${(e as Error).message.slice(0, 200)})`
+        );
+      }
+    }
   }
 
   // Step 1: relationship analysis

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -71,6 +71,7 @@ import { enrichBodyWithImages } from "./images.js";
 import { auditSideEffects, sideEffectsCommentBody } from "./side-effects-audit.js";
 import {
   assessMultifurcation,
+  digestActiveSpecs,
   multifurcationCommentBody,
   hasExistingMultifurcationComment,
 } from "./multifurcate.js";
@@ -164,12 +165,22 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
   //
   // The model can fall back to "one" silently if the verdict is
   // unparseable — that's safer than blocking refine on a parser bug.
+  // cli α.45 — hoist listActiveSpecs above multifurcation so the model
+  // can annotate overlapping sub-issues with their `existing_spec_id`
+  // instead of silently omitting them. Same call is reused for the
+  // relationship-analysis step below.
+  const activeSpecs = listActiveSpecs(ctx.repoRoot);
+
   if (!issue.labels.includes(LABEL_MULTIFURCATION_PROPOSED)) {
     const existingComments = await ctx.forge.listIssueComments(ctx.issueNumber);
     if (!hasExistingMultifurcationComment(existingComments)) {
       try {
         const mf = await assessMultifurcation(
-          { issueTitle: issue.title, issueBody: issue.body },
+          {
+            issueTitle: issue.title,
+            issueBody: issue.body,
+            activeSpecs: digestActiveSpecs(activeSpecs),
+          },
           { llm: ctx.llm, model: ctx.relationshipModel }
         );
         if (mf.verdict.kind === "many") {
@@ -208,8 +219,8 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
     }
   }
 
-  // Step 1: relationship analysis
-  const existingSpecs = listActiveSpecs(ctx.repoRoot);
+  // Step 1: relationship analysis (reuses `activeSpecs` from above)
+  const existingSpecs = activeSpecs;
   const relationshipResult = await analyzeRelationship(
     { issueTitle: issue.title, issueBody: issue.body, activeSpecs: existingSpecs },
     { llm: ctx.llm, model: ctx.relationshipModel }

--- a/packages/cli/src/commands/refine/context.ts
+++ b/packages/cli/src/commands/refine/context.ts
@@ -126,6 +126,12 @@ export function readHistoryIndexDigest(repoRoot: string): string | null {
       migrations?: Array<{ file: string; tables_created: string[]; columns_added: Record<string, string[]> }>;
       test_helpers?: Array<{ name: string; file: string; purpose: string }>;
       mock_surface?: Array<{ file: string; route: string | null; name: string; excerpt: string }>;
+      git_attention?: {
+        rename_chains?: Record<string, string[]>;
+        co_changes?: Record<string, Array<{ file: string; strength: number }>>;
+        recent_prs_by_file?: Record<string, Array<{ number: number; title: string; merged_at: string | null }>>;
+        pr_spec_corpus?: Array<{ source: "pr" | "spec"; id: string; title: string; tokens: string[] }>;
+      };
     };
     const lines: string[] = [];
     lines.push("## Code history index (auto-generated; treat as authoritative)\n");
@@ -193,6 +199,70 @@ export function readHistoryIndexDigest(repoRoot: string): string | null {
         lines.push(`- \`${h.name}\` from \`${h.file}\`${purpose}`);
       }
       lines.push("");
+    }
+
+    // 0.19.0-α.43 — git-history attention layer. Surface the four
+    // signals (renames, co-changes, recent PRs per file, PR+spec
+    // corpus) so refine grounds new specs in actual project history,
+    // not just snapshot structure. Cap each list aggressively so the
+    // digest stays prompt-sized; full data is in the json on disk.
+    const ga = idx.git_attention;
+    if (ga) {
+      const renameEntries = Object.entries(ga.rename_chains ?? {});
+      const coChangeEntries = Object.entries(ga.co_changes ?? {});
+      const prEntries = Object.entries(ga.recent_prs_by_file ?? {});
+      const corpus = ga.pr_spec_corpus ?? [];
+      const anyContent =
+        renameEntries.length > 0 ||
+        coChangeEntries.length > 0 ||
+        prEntries.length > 0 ||
+        corpus.length > 0;
+
+      if (anyContent) {
+        lines.push("### Git-history attention (renames, couplings, recent PRs, corpus)");
+        lines.push(
+          "Brownfield repos are sequential. These four signals come from `git log` + `gh pr list` and tell refine which surface area carries prior intent — DON'T propose a rename or new file when the history shows the existing name is what reviewers and the PM use."
+        );
+        lines.push("");
+
+        if (renameEntries.length > 0) {
+          lines.push("**Files that were renamed** (use the CURRENT path; older names are just for grep continuity):");
+          for (const [current, previous] of renameEntries.slice(0, 20)) {
+            lines.push(`- \`${current}\` ← was \`${previous.join("\`, \`")}\``);
+          }
+          lines.push("");
+        }
+
+        if (coChangeEntries.length > 0) {
+          lines.push("**Change-coupling** (files that historically change together — if your spec touches one, expect to touch the others):");
+          for (const [file, partners] of coChangeEntries.slice(0, 15)) {
+            const partnerStr = partners
+              .map((p) => `\`${p.file}\` (${Math.round(p.strength * 100)}%)`)
+              .join(", ");
+            lines.push(`- \`${file}\` → ${partnerStr}`);
+          }
+          lines.push("");
+        }
+
+        if (prEntries.length > 0) {
+          lines.push("**Recent PRs per file** (intent-shaped Keys: PR titles describe WHY, not WHAT — read these before proposing changes near the listed files):");
+          for (const [file, prs] of prEntries.slice(0, 15)) {
+            const prStr = prs
+              .slice(0, 3)
+              .map((p) => `#${p.number} ${p.title}${p.merged_at ? "" : " (open)"}`)
+              .join(" · ");
+            lines.push(`- \`${file}\` — ${prStr}`);
+          }
+          lines.push("");
+        }
+
+        if (corpus.length > 0) {
+          lines.push(
+            `**Searchable PR + spec corpus** (${corpus.length} entries in \`pr_spec_corpus\` on disk). Each entry has tokens for cheap keyword retrieval — when the PM's issue mentions a concept, find the corpus entries whose tokens overlap before assuming the concept is new.`
+          );
+          lines.push("");
+        }
+      }
     }
 
     lines.push("### Brownfield-conflict Q&A discipline");

--- a/packages/cli/src/commands/refine/git-attention.test.ts
+++ b/packages/cli/src/commands/refine/git-attention.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseRenameChain,
+  parseLogIntoCommits,
+  computeCoChanges,
+  parseGhPRList,
+  indexPRsByFile,
+  tokeniseForCorpus,
+  buildPRSpecCorpus,
+  computeGitAttention,
+  type PRRecord,
+} from "./git-attention.js";
+
+describe("parseRenameChain", () => {
+  it("extracts old paths from R-status lines in name-status output", () => {
+    const stdout = [
+      "",
+      "R094\tsrc/components/ReactionsPage.tsx\tsrc/components/MemberReactionsPage.tsx",
+      "",
+      "M\tsrc/components/MemberReactionsPage.tsx",
+      "",
+      "R087\tsrc/old/Reactions.tsx\tsrc/components/ReactionsPage.tsx",
+      "",
+      "A\tsrc/old/Reactions.tsx",
+    ].join("\n");
+    const chain = parseRenameChain(stdout, "src/components/MemberReactionsPage.tsx");
+    expect(chain).toEqual([
+      "src/components/ReactionsPage.tsx",
+      "src/old/Reactions.tsx",
+    ]);
+  });
+
+  it("ignores non-rename lines + drops the current file itself", () => {
+    const stdout = "M\tsrc/foo.tsx\nR090\tsrc/foo.tsx\tsrc/foo.tsx\n";
+    expect(parseRenameChain(stdout, "src/foo.tsx")).toEqual([]);
+  });
+
+  it("dedupes repeated rename sources", () => {
+    const stdout = [
+      "R094\tsrc/A.tsx\tsrc/B.tsx",
+      "R092\tsrc/A.tsx\tsrc/B.tsx",
+    ].join("\n");
+    expect(parseRenameChain(stdout, "src/B.tsx")).toEqual(["src/A.tsx"]);
+  });
+});
+
+describe("parseLogIntoCommits", () => {
+  it("groups files under their COMMIT header", () => {
+    const stdout = [
+      "COMMIT abc",
+      "src/a.ts",
+      "src/b.ts",
+      "",
+      "COMMIT def",
+      "src/c.ts",
+    ].join("\n");
+    expect(parseLogIntoCommits(stdout)).toEqual([
+      { sha: "abc", files: ["src/a.ts", "src/b.ts"] },
+      { sha: "def", files: ["src/c.ts"] },
+    ]);
+  });
+
+  it("returns [] on empty stdout", () => {
+    expect(parseLogIntoCommits("")).toEqual([]);
+  });
+});
+
+describe("computeCoChanges", () => {
+  it("ranks co-changing files by frequency + normalises strengths", () => {
+    const stdout = [
+      "COMMIT 1",
+      "src/a.ts",
+      "src/b.ts",
+      "src/c.ts",
+      "",
+      "COMMIT 2",
+      "src/a.ts",
+      "src/b.ts",
+      "",
+      "COMMIT 3",
+      "src/a.ts",
+      "src/c.ts",
+    ].join("\n");
+    const fakeGit = () => stdout;
+    const result = computeCoChanges(
+      ["src/a.ts", "src/b.ts", "src/c.ts"],
+      fakeGit,
+      { windowMonths: 6, maxFilesPerCommit: 50, topPerFile: 5 }
+    );
+    // a co-occurs with b in 2 commits, with c in 2 commits; 4 total
+    // co-change events → 0.5 strength each. Insertion order preserves
+    // b before c (b comes first in commit 1's file list).
+    expect(result["src/a.ts"]).toEqual([
+      { file: "src/b.ts", strength: 0.5 },
+      { file: "src/c.ts", strength: 0.5 },
+    ]);
+  });
+
+  it("skips mass-refactor commits over maxFilesPerCommit", () => {
+    const massFiles = Array.from({ length: 60 }, (_, i) => `src/f${i}.ts`);
+    const stdout = ["COMMIT mass", ...massFiles].join("\n");
+    const result = computeCoChanges(["src/f0.ts", "src/f1.ts"], () => stdout, {
+      windowMonths: 6,
+      maxFilesPerCommit: 50,
+      topPerFile: 5,
+    });
+    expect(result).toEqual({});
+  });
+
+  it("ignores commits with no overlap with tracked files", () => {
+    const stdout = ["COMMIT 1", "other/x.ts", "other/y.ts"].join("\n");
+    const result = computeCoChanges(["src/a.ts"], () => stdout, {
+      windowMonths: 6,
+      maxFilesPerCommit: 50,
+      topPerFile: 5,
+    });
+    expect(result).toEqual({});
+  });
+});
+
+describe("parseGhPRList", () => {
+  it("parses gh JSON into PRRecord[]", () => {
+    const json = JSON.stringify([
+      {
+        number: 42,
+        title: "feat: thing",
+        body: "body text",
+        mergedAt: "2026-05-01T00:00:00Z",
+        files: [{ path: "src/a.ts" }, { path: "src/b.ts" }],
+      },
+      {
+        number: 43,
+        title: "open one",
+        body: "",
+        mergedAt: null,
+        files: [{ path: "src/c.ts" }],
+      },
+    ]);
+    const prs = parseGhPRList(json);
+    expect(prs).toHaveLength(2);
+    expect(prs[0]).toMatchObject({ number: 42, title: "feat: thing", merged_at: "2026-05-01T00:00:00Z" });
+    expect(prs[0]!.files).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(prs[1]!.merged_at).toBeNull();
+  });
+
+  it("returns [] on malformed JSON", () => {
+    expect(parseGhPRList("not json")).toEqual([]);
+    expect(parseGhPRList("{}")).toEqual([]);
+  });
+});
+
+describe("indexPRsByFile", () => {
+  const prs: PRRecord[] = [
+    {
+      number: 1,
+      title: "old merged",
+      body: "",
+      merged_at: "2026-04-01T00:00:00Z",
+      files: ["src/a.ts"],
+    },
+    {
+      number: 2,
+      title: "new merged",
+      body: "",
+      merged_at: "2026-05-15T00:00:00Z",
+      files: ["src/a.ts", "src/b.ts"],
+    },
+    {
+      number: 3,
+      title: "open",
+      body: "",
+      merged_at: null,
+      files: ["src/a.ts"],
+    },
+    {
+      number: 99,
+      title: "untracked",
+      body: "",
+      merged_at: null,
+      files: ["other/x.ts"],
+    },
+  ];
+
+  it("orders open PRs before merged, then merged newest-first", () => {
+    const result = indexPRsByFile(prs, ["src/a.ts", "src/b.ts"]);
+    expect(result["src/a.ts"]!.map((p) => p.number)).toEqual([3, 2, 1]);
+    expect(result["src/b.ts"]!.map((p) => p.number)).toEqual([2]);
+  });
+
+  it("caps each file at 5 PRs", () => {
+    const many: PRRecord[] = Array.from({ length: 8 }, (_, i) => ({
+      number: i + 1,
+      title: `pr ${i}`,
+      body: "",
+      merged_at: `2026-05-0${i + 1}T00:00:00Z`,
+      files: ["src/a.ts"],
+    }));
+    const result = indexPRsByFile(many, ["src/a.ts"]);
+    expect(result["src/a.ts"]).toHaveLength(5);
+  });
+});
+
+describe("tokeniseForCorpus", () => {
+  it("strips stopwords + dedupes + lowercases", () => {
+    const tokens = tokeniseForCorpus(
+      "The Reactions Page handles the bookmark feed for member rewos."
+    );
+    expect(tokens).toContain("reactions");
+    expect(tokens).toContain("page");
+    expect(tokens).toContain("bookmark");
+    expect(tokens).toContain("feed");
+    expect(tokens).toContain("member");
+    expect(tokens).toContain("rewos");
+    expect(tokens).not.toContain("the");
+    expect(tokens).not.toContain("for");
+    // deduped
+    expect(tokens.filter((t) => t === "the")).toHaveLength(0);
+  });
+
+  it("caps token list at 60", () => {
+    const longText = Array.from({ length: 200 }, (_, i) => `word${i}`).join(" ");
+    expect(tokeniseForCorpus(longText)).toHaveLength(60);
+  });
+});
+
+describe("buildPRSpecCorpus", () => {
+  let repo: string;
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "slowcook-corpus-"));
+    mkdirSync(join(repo, "specs"), { recursive: true });
+    writeFileSync(
+      join(repo, "specs/story-007.yaml"),
+      "title: Reactions feed\nsummary: Show member reactions in a chronological feed.\n",
+      "utf8"
+    );
+    writeFileSync(
+      join(repo, "specs/story-008.yaml"),
+      "title: Pin a rewo\nsummary: Allow members to pin a reaction so it surfaces in the strip.\n",
+      "utf8"
+    );
+  });
+
+  afterAll(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("combines PR + spec entries with stable ids + token lists", () => {
+    const prs: PRRecord[] = [
+      {
+        number: 99,
+        title: "feat: pin rewo",
+        body: "Adds the pin strip to /member/[handle].",
+        merged_at: "2026-05-01T00:00:00Z",
+        files: ["src/components/PinnedStrip.tsx"],
+      },
+    ];
+    const corpus = buildPRSpecCorpus(prs, repo);
+    const ids = corpus.map((e) => e.id);
+    expect(ids).toContain("pr#99");
+    expect(ids).toContain("spec:story-007");
+    expect(ids).toContain("spec:story-008");
+
+    const pinSpec = corpus.find((e) => e.id === "spec:story-008")!;
+    expect(pinSpec.title).toBe("Pin a rewo");
+    expect(pinSpec.tokens).toContain("pin");
+    expect(pinSpec.tokens).toContain("strip");
+
+    const pr = corpus.find((e) => e.id === "pr#99")!;
+    expect(pr.files_touched).toEqual(["src/components/PinnedStrip.tsx"]);
+    expect(pr.tokens).toContain("pin");
+    expect(pr.tokens).toContain("rewo");
+  });
+
+  it("returns just PRs when specs/ is absent", () => {
+    const repo2 = mkdtempSync(join(tmpdir(), "slowcook-corpus-empty-"));
+    try {
+      const corpus = buildPRSpecCorpus(
+        [{ number: 1, title: "x", body: "y", merged_at: null, files: [] }],
+        repo2
+      );
+      expect(corpus).toHaveLength(1);
+      expect(corpus[0]!.id).toBe("pr#1");
+    } finally {
+      rmSync(repo2, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("computeGitAttention orchestrator", () => {
+  it("degrades gracefully when git + gh both fail", () => {
+    const repo = mkdtempSync(join(tmpdir(), "slowcook-attn-fail-"));
+    try {
+      const result = computeGitAttention({
+        repoRoot: repo,
+        trackedFiles: ["src/a.ts"],
+        gitExec: () => {
+          throw new Error("not a git repo");
+        },
+        ghExec: () => {
+          throw new Error("gh: command not found");
+        },
+      });
+      expect(result.rename_chains).toEqual({});
+      expect(result.co_changes).toEqual({});
+      expect(result.recent_prs_by_file).toEqual({});
+      expect(result.pr_spec_corpus).toEqual([]);
+      expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+      expect(result.warnings.join(" ")).toMatch(/git/i);
+      expect(result.warnings.join(" ")).toMatch(/gh/i);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("wires all four signals when git + gh both work", () => {
+    const repo = mkdtempSync(join(tmpdir(), "slowcook-attn-ok-"));
+    try {
+      mkdirSync(join(repo, "specs"), { recursive: true });
+      writeFileSync(
+        join(repo, "specs/story-001.yaml"),
+        "title: Bookmarks\nsummary: members bookmark rewos.\n",
+        "utf8"
+      );
+
+      const fakeGit = (cmd: string): string => {
+        if (cmd.startsWith("rev-parse")) return ".git\n";
+        if (cmd.includes("--follow")) {
+          // rename history for src/components/Reactions.tsx
+          return "R094\tsrc/old/Old.tsx\tsrc/components/Reactions.tsx\n";
+        }
+        // co-change log
+        return [
+          "COMMIT 1",
+          "src/components/Reactions.tsx",
+          "src/components/PinnedStrip.tsx",
+          "",
+          "COMMIT 2",
+          "src/components/Reactions.tsx",
+          "src/components/PinnedStrip.tsx",
+        ].join("\n");
+      };
+
+      const fakeGh = (_cmd: string): string =>
+        JSON.stringify([
+          {
+            number: 154,
+            title: "feat: pin rewos",
+            body: "Pinned strip on /member/[handle].",
+            mergedAt: "2026-05-04T00:00:00Z",
+            files: [{ path: "src/components/Reactions.tsx" }],
+          },
+        ]);
+
+      const result = computeGitAttention({
+        repoRoot: repo,
+        trackedFiles: [
+          "src/components/Reactions.tsx",
+          "src/components/PinnedStrip.tsx",
+        ],
+        gitExec: fakeGit,
+        ghExec: fakeGh,
+      });
+
+      expect(result.warnings).toEqual([]);
+      expect(result.rename_chains["src/components/Reactions.tsx"]).toEqual([
+        "src/old/Old.tsx",
+      ]);
+      expect(result.co_changes["src/components/Reactions.tsx"]).toEqual([
+        { file: "src/components/PinnedStrip.tsx", strength: 1 },
+      ]);
+      expect(result.recent_prs_by_file["src/components/Reactions.tsx"]).toHaveLength(1);
+      expect(result.pr_spec_corpus.map((e) => e.id).sort()).toEqual([
+        "pr#154",
+        "spec:story-001",
+      ]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/refine/git-attention.ts
+++ b/packages/cli/src/commands/refine/git-attention.ts
@@ -1,0 +1,465 @@
+/**
+ * @slowcook 0.19.0-alpha.43 — git-history attention layer for the refine
+ * history-index.
+ *
+ * Motivated by the "Attention Is All You Need" thread (memory:
+ * project_bounded_attention_validation_2026_04_25): a brownfield repo IS
+ * the product of a sequential process (git commits). Versioning history
+ * — diffs, commit messages, PR descriptions, specs — is a strong signal
+ * for which existing components/props/tests/routes/migrations are most
+ * relevant to a new story, BUT raw commit history is noisy. We extract
+ * four narrower signals:
+ *
+ *   1. Rename chains       — `git log --follow` so look-ups don't miss
+ *                            historical names (e.g. ReactionsPage →
+ *                            MemberReactionsPage).
+ *   2. Change-coupling     — file pairs that co-change in the same
+ *                            commits; surfaces architectural couplings
+ *                            file-system layout misses.
+ *   3. Recent PRs per file — PR descriptions are higher-quality "Keys"
+ *                            than raw commit messages because they're
+ *                            intent-shaped, not change-shaped.
+ *   4. PR+spec corpus      — flat searchable index of PR descriptions
+ *                            and spec yaml summaries so downstream agents
+ *                            can keyword-retrieve prior intent before
+ *                            writing new code.
+ *
+ * Deliberately deterministic (no embeddings). Embedding upgrade is a
+ * future Phase 3 step; this lower-cost version ships the contract first.
+ *
+ * All four are graceful-degradation: missing git history, missing gh,
+ * unauthenticated gh, no PRs, no specs — each path returns an empty
+ * structure plus a warning string. The orchestrator NEVER throws.
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+
+export interface CoChangeEntry {
+  /** repo-relative path of the co-changing file */
+  file: string;
+  /** fraction of this file's co-change events that landed on `file` (0..1, 2dp) */
+  strength: number;
+}
+
+export interface PRRecord {
+  number: number;
+  title: string;
+  body: string;
+  merged_at: string | null;
+  files: string[];
+}
+
+export interface PRSpecCorpusEntry {
+  source: "pr" | "spec";
+  /** Stable id: "pr#123" or "spec:story-007". */
+  id: string;
+  title: string;
+  /** First ~500 chars of the body / spec summary. */
+  excerpt: string;
+  /** Files touched (empty for specs). */
+  files_touched: string[];
+  /** ISO date or "" if not applicable. */
+  date: string;
+  /** Lower-cased, stopword-stripped tokens for cheap keyword retrieval. */
+  tokens: string[];
+}
+
+export interface GitAttentionData {
+  enriched_at: string;
+  /** current_file -> historical paths it was renamed from, newest-first. */
+  rename_chains: Record<string, string[]>;
+  /** file -> top-K co-changing files (by frequency in same commits). */
+  co_changes: Record<string, CoChangeEntry[]>;
+  /** file -> last 5 PRs that touched it (newest-first; merged before open). */
+  recent_prs_by_file: Record<string, PRRecord[]>;
+  /** Flat searchable corpus of PR descriptions + spec yaml summaries. */
+  pr_spec_corpus: PRSpecCorpusEntry[];
+  /** Non-fatal degradation notices ("gh not installed", "git history shallow", etc.). */
+  warnings: string[];
+}
+
+export interface GitAttentionOptions {
+  repoRoot: string;
+  /** Files we want enrichment for (typically the union of components/api/tests/migrations from the history index). */
+  trackedFiles: string[];
+  /** Months of git log to consider for co-change. Default 6. */
+  coChangeWindowMonths?: number;
+  /** Skip commits with more files than this (mass refactor filter). Default 50. */
+  coChangeMaxFilesPerCommit?: number;
+  /** How many co-changes to keep per file. Default 5. */
+  coChangesPerFile?: number;
+  /** How many recent PRs to fetch from gh. Default 50. */
+  prsToFetch?: number;
+  /** Injectable for tests: override `git -C <root> ...` */
+  gitExec?: (cmd: string) => string;
+  /** Injectable for tests: override `gh ...` */
+  ghExec?: (cmd: string) => string;
+}
+
+export function computeGitAttention(opts: GitAttentionOptions): GitAttentionData {
+  const warnings: string[] = [];
+  const git = opts.gitExec ?? defaultGit(opts.repoRoot);
+  const gh = opts.ghExec ?? defaultGh();
+
+  let isRepo = true;
+  try {
+    git("rev-parse --git-dir");
+  } catch (e) {
+    isRepo = false;
+    warnings.push(`Not a git repo (${(e as Error).message.slice(0, 80)}); git-history signals skipped.`);
+  }
+
+  let rename_chains: Record<string, string[]> = {};
+  let co_changes: Record<string, CoChangeEntry[]> = {};
+
+  if (isRepo) {
+    try {
+      rename_chains = computeRenameChains(opts.trackedFiles, git);
+    } catch (e) {
+      warnings.push(`Rename detection failed: ${(e as Error).message.slice(0, 120)}`);
+    }
+    try {
+      co_changes = computeCoChanges(opts.trackedFiles, git, {
+        windowMonths: opts.coChangeWindowMonths ?? 6,
+        maxFilesPerCommit: opts.coChangeMaxFilesPerCommit ?? 50,
+        topPerFile: opts.coChangesPerFile ?? 5,
+      });
+    } catch (e) {
+      warnings.push(`Co-change matrix failed: ${(e as Error).message.slice(0, 120)}`);
+    }
+  }
+
+  let prs: PRRecord[] = [];
+  let recent_prs_by_file: Record<string, PRRecord[]> = {};
+  try {
+    prs = fetchRecentPRs(gh, opts.prsToFetch ?? 50);
+    recent_prs_by_file = indexPRsByFile(prs, opts.trackedFiles);
+  } catch (e) {
+    warnings.push(
+      `gh pr list failed (PR-as-Key signal skipped): ${(e as Error).message.slice(0, 120)}`
+    );
+  }
+
+  let pr_spec_corpus: PRSpecCorpusEntry[] = [];
+  try {
+    pr_spec_corpus = buildPRSpecCorpus(prs, opts.repoRoot);
+  } catch (e) {
+    warnings.push(`PR+spec corpus build failed: ${(e as Error).message.slice(0, 120)}`);
+  }
+
+  return {
+    enriched_at: new Date().toISOString(),
+    rename_chains,
+    co_changes,
+    recent_prs_by_file,
+    pr_spec_corpus,
+    warnings,
+  };
+}
+
+// ─── git/gh execution shims ─────────────────────────────────────────────
+
+function defaultGit(repoRoot: string) {
+  return (cmd: string) =>
+    execSync(`git -C "${repoRoot}" ${cmd}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 50 * 1024 * 1024,
+    });
+}
+
+function defaultGh() {
+  return (cmd: string) =>
+    execSync(`gh ${cmd}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 50 * 1024 * 1024,
+    });
+}
+
+// ─── rename chains ──────────────────────────────────────────────────────
+
+export function computeRenameChains(
+  files: string[],
+  git: (cmd: string) => string
+): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const file of files) {
+    if (file.includes('"') || file.includes("`")) continue; // refuse shell-injection candidates
+    let stdout = "";
+    try {
+      stdout = git(`log --follow --name-status -M --pretty=format:"" -- "${file}"`);
+    } catch {
+      continue; // per-file failures are fine (file may not be tracked)
+    }
+    const chain = parseRenameChain(stdout, file);
+    if (chain.length > 0) out[file] = chain;
+  }
+  return out;
+}
+
+/**
+ * Parse `git log --follow --name-status -M` output for a single file.
+ * Each rename is a line `R<score>\told\tnew`. Returns OLD paths in the
+ * order git reports them (newest commit first, so most-recent rename
+ * is index 0).
+ */
+export function parseRenameChain(stdout: string, currentFile: string): string[] {
+  const renames: string[] = [];
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (!line.startsWith("R")) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    const oldPath = parts[1]!;
+    if (oldPath === currentFile) continue;
+    if (renames.includes(oldPath)) continue;
+    renames.push(oldPath);
+  }
+  return renames;
+}
+
+// ─── co-change matrix ───────────────────────────────────────────────────
+
+export interface CoChangeBuildOptions {
+  windowMonths: number;
+  maxFilesPerCommit: number;
+  topPerFile: number;
+}
+
+export function computeCoChanges(
+  trackedFiles: string[],
+  git: (cmd: string) => string,
+  opts: CoChangeBuildOptions
+): Record<string, CoChangeEntry[]> {
+  const since = isoDaysAgo(opts.windowMonths * 30);
+  const stdout = git(`log --name-only --pretty=format:"COMMIT %H" --since="${since}"`);
+  const commits = parseLogIntoCommits(stdout);
+
+  const tracked = new Set(trackedFiles);
+  const counts = new Map<string, Map<string, number>>();
+  for (const file of trackedFiles) counts.set(file, new Map());
+
+  for (const commit of commits) {
+    if (commit.files.length === 0 || commit.files.length > opts.maxFilesPerCommit) continue;
+    if (!commit.files.some((f) => tracked.has(f))) continue;
+    for (const a of commit.files) {
+      if (!tracked.has(a)) continue;
+      const aMap = counts.get(a)!;
+      for (const b of commit.files) {
+        if (b === a) continue;
+        aMap.set(b, (aMap.get(b) ?? 0) + 1);
+      }
+    }
+  }
+
+  const out: Record<string, CoChangeEntry[]> = {};
+  for (const [file, others] of counts) {
+    if (others.size === 0) continue;
+    const total = Array.from(others.values()).reduce((s, n) => s + n, 0);
+    const sorted = Array.from(others.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, opts.topPerFile)
+      .map(([f, c]) => ({ file: f, strength: round2(c / Math.max(total, 1)) }));
+    out[file] = sorted;
+  }
+  return out;
+}
+
+export function parseLogIntoCommits(
+  stdout: string
+): Array<{ sha: string; files: string[] }> {
+  const commits: Array<{ sha: string; files: string[] }> = [];
+  let current: { sha: string; files: string[] } | null = null;
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("COMMIT ")) {
+      if (current) commits.push(current);
+      current = { sha: line.slice("COMMIT ".length), files: [] };
+    } else if (line.length > 0 && current) {
+      current.files.push(line);
+    }
+  }
+  if (current) commits.push(current);
+  return commits;
+}
+
+function isoDaysAgo(days: number): string {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}
+
+// ─── recent PRs via gh ──────────────────────────────────────────────────
+
+export function fetchRecentPRs(
+  gh: (cmd: string) => string,
+  limit: number
+): PRRecord[] {
+  const stdout = gh(`pr list --state all --limit ${limit} --json number,title,body,mergedAt,files`);
+  return parseGhPRList(stdout);
+}
+
+export function parseGhPRList(stdout: string): PRRecord[] {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+  const out: PRRecord[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const o = item as Record<string, unknown>;
+    const filesField = o.files;
+    const files: string[] = Array.isArray(filesField)
+      ? filesField
+          .map((f) =>
+            f && typeof f === "object"
+              ? ((f as Record<string, unknown>).path as unknown)
+              : null
+          )
+          .filter((p): p is string => typeof p === "string")
+      : [];
+    out.push({
+      number: typeof o.number === "number" ? o.number : 0,
+      title: typeof o.title === "string" ? o.title : "",
+      body: typeof o.body === "string" ? o.body : "",
+      merged_at: typeof o.mergedAt === "string" ? o.mergedAt : null,
+      files,
+    });
+  }
+  return out;
+}
+
+export function indexPRsByFile(
+  prs: PRRecord[],
+  files: string[]
+): Record<string, PRRecord[]> {
+  const out: Record<string, PRRecord[]> = {};
+  const tracked = new Set(files);
+  for (const pr of prs) {
+    for (const f of pr.files) {
+      if (!tracked.has(f)) continue;
+      (out[f] ??= []).push(pr);
+    }
+  }
+  for (const key of Object.keys(out)) {
+    out[key]!.sort((a, b) => {
+      if (a.merged_at === b.merged_at) return b.number - a.number;
+      if (!a.merged_at) return -1; // open PRs first
+      if (!b.merged_at) return 1;
+      return a.merged_at < b.merged_at ? 1 : -1;
+    });
+    out[key] = out[key]!.slice(0, 5);
+  }
+  return out;
+}
+
+// ─── PR + spec corpus ───────────────────────────────────────────────────
+
+const STOPWORDS = new Set([
+  "the","and","for","with","that","this","from","into","over","under",
+  "when","where","what","how","why","not","but","you","your","our","its",
+  "are","was","were","has","have","had","can","may","might","will","would",
+  "should","could","does","did","done","than","then","also","just","like",
+  "use","using","used","make","made","get","got","set","new","old","add",
+  "added","fix","fixed","update","updated","remove","removed","pull",
+  "request","merge","branch","commit","file","files","code","main","alpha",
+  "beta","wip","tbd","docs","doc","feat","chore","refactor","src","test","tests",
+]);
+
+/**
+ * Lowercase, stopword-stripped, deduped token list capped at 60. Cheap
+ * substitute for embeddings — agents can intersect query tokens with
+ * each corpus entry's `tokens` to rank relevance without an LLM call.
+ *
+ * Embedding upgrade is Phase 3 (slowcook 0.14.0+, evidence-gated). Until
+ * then this is what we ship.
+ */
+export function tokeniseForCorpus(text: string): string[] {
+  const raw = text.toLowerCase().match(/[a-z][a-z0-9_-]{2,}/g) ?? [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tok of raw) {
+    if (STOPWORDS.has(tok)) continue;
+    if (seen.has(tok)) continue;
+    seen.add(tok);
+    out.push(tok);
+    if (out.length >= 60) break;
+  }
+  return out;
+}
+
+export function buildPRSpecCorpus(
+  prs: PRRecord[],
+  repoRoot: string
+): PRSpecCorpusEntry[] {
+  const out: PRSpecCorpusEntry[] = [];
+  for (const pr of prs) {
+    out.push({
+      source: "pr",
+      id: `pr#${pr.number}`,
+      title: pr.title,
+      excerpt: trimExcerpt(pr.body, 500),
+      files_touched: pr.files,
+      date: pr.merged_at ?? "",
+      tokens: tokeniseForCorpus(`${pr.title}\n${pr.body}\n${pr.files.join(" ")}`),
+    });
+  }
+  const specsDir = join(repoRoot, "specs");
+  if (existsSync(specsDir)) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(specsDir)
+        .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+        .sort();
+    } catch {
+      return out;
+    }
+    for (const name of entries) {
+      const full = join(specsDir, name);
+      let raw = "";
+      try {
+        raw = readFileSync(full, "utf8");
+      } catch {
+        continue;
+      }
+      let title = "";
+      let summary = "";
+      try {
+        const parsed = YAML.parse(raw) as Record<string, unknown> | null;
+        if (parsed && typeof parsed === "object") {
+          title = typeof parsed.title === "string" ? parsed.title : "";
+          summary = typeof parsed.summary === "string" ? parsed.summary : "";
+        }
+      } catch {
+        // malformed yaml — index raw text anyway
+      }
+      out.push({
+        source: "spec",
+        id: `spec:${name.replace(/\.(yaml|yml)$/, "")}`,
+        title,
+        excerpt: summary || trimExcerpt(raw, 500),
+        files_touched: [],
+        date: "",
+        tokens: tokeniseForCorpus(`${title}\n${summary}\n${raw}`),
+      });
+    }
+  }
+  return out;
+}
+
+function trimExcerpt(text: string, limit: number): string {
+  const trimmed = (text || "").trim();
+  if (trimmed.length <= limit) return trimmed;
+  return trimmed.slice(0, limit) + " …";
+}

--- a/packages/cli/src/commands/refine/history-index.ts
+++ b/packages/cli/src/commands/refine/history-index.ts
@@ -20,6 +20,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import type { GitAttentionData } from "./git-attention.js";
 
 export interface ComponentEntry {
   /** PascalCase component name (the default-export or first named export). */
@@ -103,6 +104,12 @@ export interface HistoryIndex {
   test_files: TestFileEntry[];
   /** 0.19.0-α.23 — mock surface (design source-of-truth). */
   mock_surface: MockEntry[];
+  /**
+   * 0.19.0-α.43 — git-history attention layer. Set when enrichment ran
+   * (refine emits with it on by default; pure-filesystem callers / tests
+   * may leave it undefined). See git-attention.ts for the four sub-signals.
+   */
+  git_attention?: GitAttentionData;
 }
 
 interface BuildOptions {

--- a/packages/cli/src/commands/refine/index.ts
+++ b/packages/cli/src/commands/refine/index.ts
@@ -303,6 +303,11 @@ export async function refine(argv: string[], cliVersion: string): Promise<void> 
           `Change-of-mind accepted; will supersede ${outcome.supersedes.join(", ")}.`
         );
         break;
+      case "multifurcation-proposed":
+        console.log(
+          `Multifurcation proposal posted (comment ${outcome.commentId}): ${outcome.subIssueCount} sub-issues. Awaiting PM split decision.`
+        );
+        break;
       case "noop":
         console.log(`Noop: ${outcome.reason}.`);
         break;

--- a/packages/cli/src/commands/refine/index.ts
+++ b/packages/cli/src/commands/refine/index.ts
@@ -10,7 +10,8 @@ import {
   type RefineContext,
   type ResubmitContext,
 } from "./agent.js";
-import { buildHistoryIndex } from "./history-index.js";
+import { buildHistoryIndex, type HistoryIndex } from "./history-index.js";
+import { computeGitAttention } from "./git-attention.js";
 
 interface RefineArgs {
   /** Issue-driven refine (the original 0.5+ path). Required unless --pr is set. */
@@ -203,17 +204,9 @@ export async function refine(argv: string[], cliVersion: string): Promise<void> 
 
       // 0.17.0 — refresh history-index for the resubmit path too;
       // brownfield context may have changed since the last refine.
-      try {
-        const idx = buildHistoryIndex({ repoRoot: args.repoRoot });
-        const indexPath = join(args.repoRoot, ".brewing/history-index.json");
-        mkdirSync(dirname(indexPath), { recursive: true });
-        writeFileSync(indexPath, JSON.stringify(idx, null, 2), "utf8");
-        console.log(
-          `  history-index: ${idx.components.length} components · ${idx.api_routes.length} api routes · ${idx.migrations.length} migrations`
-        );
-      } catch (e) {
-        console.warn(`  (history-index emit failed: ${(e as Error).message})`);
-      }
+      // 0.19.0-α.43 — also enrich with git-history attention (renames,
+      // co-changes, recent PRs, PR+spec corpus).
+      emitHistoryIndex(args.repoRoot);
 
       const outcome = await runResubmitRefinement(ctx);
       switch (outcome.kind) {
@@ -254,17 +247,8 @@ export async function refine(argv: string[], cliVersion: string): Promise<void> 
     // 0.17.0 — emit history-index.json for downstream agents (vibe,
     // testgen, brew, recon) to consume. Pure mechanical scan; no LLM.
     // The agent will read this in its prompt to be brownfield-aware.
-    try {
-      const idx = buildHistoryIndex({ repoRoot: args.repoRoot });
-      const indexPath = join(args.repoRoot, ".brewing/history-index.json");
-      mkdirSync(dirname(indexPath), { recursive: true });
-      writeFileSync(indexPath, JSON.stringify(idx, null, 2), "utf8");
-      console.log(
-        `  history-index: ${idx.components.length} components · ${idx.api_routes.length} api routes · ${idx.migrations.length} migrations · ${idx.test_helpers.length} test helpers · ${idx.test_files.length} test files`
-      );
-    } catch (e) {
-      console.warn(`  (history-index emit failed; refine will run without it: ${(e as Error).message})`);
-    }
+    // 0.19.0-α.43 — also enrich with git-history attention layer.
+    emitHistoryIndex(args.repoRoot);
 
     let outcome;
     try {
@@ -329,5 +313,75 @@ export async function refine(argv: string[], cliVersion: string): Promise<void> 
       console.error(e);
     }
     process.exit(2);
+  }
+}
+
+/**
+ * 0.19.0-α.43 — single source for emitting `.brewing/history-index.json`
+ * with both the filesystem scan AND the git-history attention layer.
+ *
+ * Failure-class handling:
+ *   - filesystem scan fails → log + skip the whole emit (the refine agent
+ *     can run without it, just with degraded brownfield awareness).
+ *   - git enrichment fails → emit the index without `git_attention`; the
+ *     warnings already log inside computeGitAttention.
+ *
+ * Both refine paths (issue + resubmit) call this; one site of truth.
+ */
+function emitHistoryIndex(repoRoot: string): void {
+  let idx: HistoryIndex;
+  try {
+    idx = buildHistoryIndex({ repoRoot });
+  } catch (e) {
+    console.warn(`  (history-index emit failed; refine will run without it: ${(e as Error).message})`);
+    return;
+  }
+
+  // 0.19.0-α.43 — collect tracked files from every entry that has a file
+  // path. Refine's git-attention is keyed by these. Excludes mock surface
+  // by design — mock files are design artifacts, not the brownfield
+  // history we want to attend to.
+  const trackedFiles = [
+    ...idx.components.map((c) => c.file),
+    ...idx.api_routes.map((r) => r.file),
+    ...idx.test_helpers.map((h) => h.file),
+    ...idx.test_files.map((t) => t.file),
+  ];
+  // Migrations are listed by basename in the index; reconstruct the
+  // most-likely full path (we don't know which migration dir was used,
+  // so include them via supabase/migrations/ which is the default scan
+  // path). The git-attention layer will silently drop ones that aren't
+  // tracked by git.
+  for (const m of idx.migrations) {
+    trackedFiles.push(`supabase/migrations/${m.file}`);
+  }
+
+  try {
+    idx.git_attention = computeGitAttention({
+      repoRoot,
+      trackedFiles: Array.from(new Set(trackedFiles)),
+    });
+    if (idx.git_attention.warnings.length > 0) {
+      for (const w of idx.git_attention.warnings) {
+        console.warn(`  (git-attention: ${w})`);
+      }
+    }
+  } catch (e) {
+    console.warn(`  (git-attention enrichment failed; emitting index without it: ${(e as Error).message})`);
+  }
+
+  try {
+    const indexPath = join(repoRoot, ".brewing/history-index.json");
+    mkdirSync(dirname(indexPath), { recursive: true });
+    writeFileSync(indexPath, JSON.stringify(idx, null, 2), "utf8");
+    const ga = idx.git_attention;
+    const gaLine = ga
+      ? ` · git-attention: ${Object.keys(ga.rename_chains).length} renames · ${Object.keys(ga.co_changes).length} co-change buckets · ${Object.keys(ga.recent_prs_by_file).length} files with PRs · corpus ${ga.pr_spec_corpus.length}`
+      : "";
+    console.log(
+      `  history-index: ${idx.components.length} components · ${idx.api_routes.length} api routes · ${idx.migrations.length} migrations · ${idx.test_helpers.length} test helpers · ${idx.test_files.length} test files${gaLine}`
+    );
+  } catch (e) {
+    console.warn(`  (history-index write failed: ${(e as Error).message})`);
   }
 }

--- a/packages/cli/src/commands/refine/multifurcate.test.ts
+++ b/packages/cli/src/commands/refine/multifurcate.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
+import type { Spec } from "@slowcook-ai/core";
 import {
   parseMultifurcationJson,
   multifurcationCommentBody,
   hasExistingMultifurcationComment,
+  buildMultifurcationUserMessage,
+  digestActiveSpecs,
 } from "./multifurcate.js";
 
 describe("parseMultifurcationJson", () => {
@@ -159,5 +162,236 @@ describe("hasExistingMultifurcationComment", () => {
 
   it("returns false on empty comment list", () => {
     expect(hasExistingMultifurcationComment([])).toBe(false);
+  });
+});
+
+describe("parseMultifurcationJson — overlap annotation (α.45)", () => {
+  it("captures existing_spec_id when the model sets it", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "split + one overlap",
+        sub_issues: [
+          { title: "fresh", summary: "a new slice" },
+          {
+            title: "patient login wired",
+            summary: "covered already",
+            existing_spec_id: "002",
+          },
+        ],
+      })
+    );
+    expect(v.kind).toBe("many");
+    if (v.kind === "many") {
+      expect(v.sub_issues[0]!.existing_spec_id).toBeUndefined();
+      expect(v.sub_issues[1]!.existing_spec_id).toBe("002");
+    }
+  });
+
+  it("normalises 'story-002' prefix variants the model might emit", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "x", existing_spec_id: "story-007" },
+          { title: "b", summary: "y", covered_by_story: "Story-013" },
+        ],
+      })
+    );
+    expect(v.kind).toBe("many");
+    if (v.kind === "many") {
+      expect(v.sub_issues[0]!.existing_spec_id).toBe("007");
+      expect(v.sub_issues[1]!.existing_spec_id).toBe("013");
+    }
+  });
+
+  it("leaves existing_spec_id undefined when the model omits it", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "x" },
+          { title: "b", summary: "y" },
+        ],
+      })
+    );
+    expect(v.kind).toBe("many");
+    if (v.kind === "many") {
+      expect(v.sub_issues.every((s) => s.existing_spec_id === undefined)).toBe(true);
+    }
+  });
+});
+
+describe("multifurcationCommentBody — overlap badge (α.45)", () => {
+  it("renders 'already covered by story-NNN' next to overlapping sub-issues", () => {
+    const body = multifurcationCommentBody(
+      {
+        rationale: "two slices, one overlap",
+        sub_issues: [
+          { title: "Patient login uses real auth", summary: "s1", existing_spec_id: "002" },
+          { title: "Patient appointment list", summary: "s2" },
+        ],
+      },
+      { issueTitle: "x" }
+    );
+    expect(body).toContain("already covered by story-002");
+    // Sub-issue 1's title line carries the badge; sub-issue 2's does not.
+    const subATitleLine = body
+      .split("\n")
+      .find((l) => l.startsWith("**1.")) ?? "";
+    const subBTitleLine = body
+      .split("\n")
+      .find((l) => l.startsWith("**2.")) ?? "";
+    expect(subATitleLine).toContain("already covered by story-002");
+    expect(subBTitleLine).not.toContain("already covered");
+  });
+
+  it("counts overlaps in the section header", () => {
+    const body = multifurcationCommentBody(
+      {
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "x", existing_spec_id: "001" },
+          { title: "b", summary: "y", existing_spec_id: "002" },
+          { title: "c", summary: "z" },
+        ],
+      },
+      { issueTitle: "x" }
+    );
+    expect(body).toContain("Proposed sub-issues (3, 2 overlap existing specs)");
+  });
+
+  it("omits the overlap counter when there are no overlaps", () => {
+    const body = multifurcationCommentBody(
+      {
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "x" },
+          { title: "b", summary: "y" },
+        ],
+      },
+      { issueTitle: "x" }
+    );
+    expect(body).toContain("Proposed sub-issues (2)");
+    expect(body).not.toContain("overlap existing");
+  });
+
+  it("escapes story id in the badge", () => {
+    const body = multifurcationCommentBody(
+      {
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "x", existing_spec_id: "<bad>" },
+          { title: "b", summary: "y" },
+        ],
+      },
+      { issueTitle: "x" }
+    );
+    expect(body).toContain("already covered by story-&lt;bad&gt;");
+  });
+});
+
+describe("buildMultifurcationUserMessage — active-specs context (α.45)", () => {
+  it("omits the Active specs section entirely when none provided", () => {
+    const msg = buildMultifurcationUserMessage({
+      issueTitle: "x",
+      issueBody: "y",
+    });
+    expect(msg).not.toContain("Active specs");
+    expect(msg).toContain("### Title\nx");
+    expect(msg).toContain("### Body\ny");
+  });
+
+  it("lists active specs + reminder to use existing_spec_id when overlap is real", () => {
+    const msg = buildMultifurcationUserMessage({
+      issueTitle: "everything per mock",
+      issueBody: "wire mock to backend",
+      activeSpecs: [
+        { story_id: "002", title: "Auth + role registration", summary: "OTP login flow" },
+        { story_id: "007", title: "Pinned strip", summary: "" },
+      ],
+    });
+    expect(msg).toContain("## Active specs in this repo");
+    expect(msg).toContain("**story-002** \"Auth + role registration\" — OTP login flow");
+    expect(msg).toContain("**story-007** \"Pinned strip\"");
+    expect(msg).toContain("existing_spec_id");
+    expect(msg).toMatch(/Do NOT silently omit/);
+  });
+
+  it("falls back gracefully when summary is empty (no trailing em dash)", () => {
+    const msg = buildMultifurcationUserMessage({
+      issueTitle: "x",
+      issueBody: "y",
+      activeSpecs: [{ story_id: "001", title: "No summary", summary: "" }],
+    });
+    expect(msg).toContain("**story-001** \"No summary\"\n");
+    expect(msg).not.toContain("No summary — ");
+  });
+});
+
+describe("digestActiveSpecs", () => {
+  function makeSpec(over: Partial<Spec>): Spec {
+    return {
+      story_id: "001",
+      title: "t",
+      status: "active",
+      created_at: "2026-05-24T00:00:00Z",
+      supersedes: [],
+      superseded_by: null,
+      actors: [],
+      preconditions: [],
+      invariants: [],
+      acceptance_scenarios: [],
+      non_goals: [],
+      ...over,
+    } as Spec;
+  }
+
+  it("uses the first acceptance scenario when present", () => {
+    const out = digestActiveSpecs([
+      makeSpec({
+        story_id: "002",
+        title: "Auth",
+        acceptance_scenarios: [
+          "Given a user with valid OTP, when they submit, then session created.",
+          "Given an expired OTP …",
+        ],
+        invariants: ["one session per user"],
+      }),
+    ]);
+    expect(out).toEqual([
+      {
+        story_id: "002",
+        title: "Auth",
+        summary: "Given a user with valid OTP, when they submit, then session created.",
+      },
+    ]);
+  });
+
+  it("falls back to invariants then non_goals then empty", () => {
+    expect(
+      digestActiveSpecs([
+        makeSpec({ story_id: "003", title: "Inv", invariants: ["X must hold"] }),
+      ])[0]!.summary
+    ).toBe("X must hold");
+    expect(
+      digestActiveSpecs([
+        makeSpec({ story_id: "004", title: "Ng", non_goals: ["No editing"] }),
+      ])[0]!.summary
+    ).toBe("No editing");
+    expect(digestActiveSpecs([makeSpec({ story_id: "005", title: "Empty" })])[0]!.summary).toBe(
+      ""
+    );
+  });
+
+  it("collapses whitespace + truncates at 150 chars", () => {
+    const longText = "a".repeat(200);
+    const out = digestActiveSpecs([
+      makeSpec({ acceptance_scenarios: [`Given\n${longText}\twhen`] }),
+    ]);
+    expect(out[0]!.summary.length).toBeLessThanOrEqual(150);
+    expect(out[0]!.summary).not.toMatch(/\n|\t/);
   });
 });

--- a/packages/cli/src/commands/refine/multifurcate.test.ts
+++ b/packages/cli/src/commands/refine/multifurcate.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMultifurcationJson,
+  multifurcationCommentBody,
+  hasExistingMultifurcationComment,
+} from "./multifurcate.js";
+
+describe("parseMultifurcationJson", () => {
+  it("parses a clean ONE verdict", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({ verdict: "one", rationale: "Single bounded outcome." })
+    );
+    expect(v).toEqual({ kind: "one", rationale: "Single bounded outcome." });
+  });
+
+  it("parses a clean MANY verdict + sub-issues", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "Two apps, two roles, multiple flows.",
+        sub_issues: [
+          { title: "Patient login uses real auth", summary: "Members can log into the patient app." },
+          {
+            title: "Patient appointment list shows real bookings",
+            summary: "Patients see their actual bookings.",
+            depends_on: ["Patient login uses real auth"],
+          },
+        ],
+      })
+    );
+    expect(v.kind).toBe("many");
+    if (v.kind === "many") {
+      expect(v.sub_issues).toHaveLength(2);
+      expect(v.sub_issues[1]!.depends_on).toEqual(["Patient login uses real auth"]);
+    }
+  });
+
+  it("strips ```json fences", () => {
+    const wrapped = '```json\n{"verdict":"one","rationale":"yes"}\n```';
+    const v = parseMultifurcationJson(wrapped);
+    expect(v).toEqual({ kind: "one", rationale: "yes" });
+  });
+
+  it("falls back to ONE when MANY produces fewer than 2 valid sub-issues", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "x",
+        sub_issues: [{ title: "only one" /* no summary */ }],
+      })
+    );
+    expect(v.kind).toBe("one");
+    expect((v as { rationale: string }).rationale).toMatch(/parser fallback/);
+  });
+
+  it("falls back to ONE on malformed JSON", () => {
+    expect(parseMultifurcationJson("not json at all").kind).toBe("one");
+    expect(parseMultifurcationJson("").kind).toBe("one");
+  });
+
+  it("tolerates leading prose before the JSON object", () => {
+    const v = parseMultifurcationJson(
+      `Here is my verdict:\n{"verdict": "one", "rationale": "ok"}\nThanks!`
+    );
+    expect(v).toEqual({ kind: "one", rationale: "ok" });
+  });
+
+  it("drops sub-issues with empty title or summary, then re-checks the >=2 floor", () => {
+    const v = parseMultifurcationJson(
+      JSON.stringify({
+        verdict: "many",
+        rationale: "x",
+        sub_issues: [
+          { title: "a", summary: "first" },
+          { title: "", summary: "no title" },
+          { title: "b", summary: "" },
+        ],
+      })
+    );
+    // Only 1 valid sub-issue → falls back to ONE
+    expect(v.kind).toBe("one");
+  });
+});
+
+describe("multifurcationCommentBody", () => {
+  const proposal = {
+    rationale: "Two apps + a data layer = many tracks.",
+    sub_issues: [
+      {
+        title: "Patient login shows real backend errors",
+        summary: "Patients see auth failures from the real auth service.",
+      },
+      {
+        title: "Therapist appointment list shows real bookings",
+        summary: "Therapists see today's actual appointments.",
+        depends_on: ["Patient login shows real backend errors"],
+      },
+    ],
+  };
+
+  it("includes the slowcook:multifurcation sentinel comment", () => {
+    const body = multifurcationCommentBody(proposal, { issueTitle: "Everything per mock" });
+    expect(body).toContain("<!-- slowcook:multifurcation -->");
+  });
+
+  it("lists each sub-issue with title + summary + depends_on", () => {
+    const body = multifurcationCommentBody(proposal, { issueTitle: "x" });
+    expect(body).toContain("**1. Patient login shows real backend errors**");
+    expect(body).toContain("Patients see auth failures from the real auth service.");
+    expect(body).toContain("**2. Therapist appointment list shows real bookings**");
+    expect(body).toContain('_Depends on: "Patient login shows real backend errors"_');
+  });
+
+  it("folds rationale into a <details> block (not the lead)", () => {
+    const body = multifurcationCommentBody(proposal, { issueTitle: "x" });
+    const detailsIdx = body.indexOf("<details>");
+    const firstSubIdx = body.indexOf("**1.");
+    expect(firstSubIdx).toBeGreaterThan(-1);
+    expect(detailsIdx).toBeGreaterThan(firstSubIdx);
+    expect(body).toContain("Two apps + a data layer = many tracks.");
+  });
+
+  it("escapes HTML-y characters in title + summary", () => {
+    const body = multifurcationCommentBody(
+      {
+        rationale: "x",
+        sub_issues: [
+          { title: "Patient <admin> page", summary: "with <em>emphasis</em>" },
+          { title: "Therapist page", summary: "fine" },
+        ],
+      },
+      { issueTitle: "Issue with <html>" }
+    );
+    expect(body).toContain("Patient &lt;admin&gt; page");
+    expect(body).toContain("with &lt;em&gt;emphasis&lt;/em&gt;");
+    expect(body).toContain("Issue with &lt;html&gt;");
+    expect(body).not.toContain("Patient <admin> page");
+  });
+});
+
+describe("hasExistingMultifurcationComment", () => {
+  it("returns true when the sentinel is present in any comment body", () => {
+    expect(
+      hasExistingMultifurcationComment([
+        { body: "looks great" },
+        { body: "<!-- slowcook:multifurcation -->\n### slowcook" },
+      ])
+    ).toBe(true);
+  });
+
+  it("returns false when no comment carries the sentinel", () => {
+    expect(
+      hasExistingMultifurcationComment([
+        { body: "looks great" },
+        { body: "did we split this?" },
+      ])
+    ).toBe(false);
+  });
+
+  it("returns false on empty comment list", () => {
+    expect(hasExistingMultifurcationComment([])).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/refine/multifurcate.ts
+++ b/packages/cli/src/commands/refine/multifurcate.ts
@@ -1,0 +1,242 @@
+/**
+ * @slowcook 0.19.0-α.44 — multifurcation pre-step.
+ *
+ * Some GitHub issues are not stories. They are programs of work disguised
+ * as tickets ("everything according to mock", "rewrite the patient app",
+ * "wire X to Y" where X and Y are whole subsystems). Forcing those
+ * through refine produces a fuzzy mega-spec that no downstream agent can
+ * reasonably implement.
+ *
+ * This module runs a cheap LLM pass BEFORE refine's relationship +
+ * refinement calls. It returns either:
+ *
+ *   - { kind: "one", rationale } — refine proceeds normally
+ *   - { kind: "many", sub_issues, rationale } — refine posts a
+ *     PM-facing proposal listing the proposed sub-issues + halts; the
+ *     PM decides whether to file the split. The original issue is
+ *     marked `slowcook-multifurcation-proposed` so refine doesn't loop.
+ *
+ * Sub-issue titles + summaries are PM-style by contract (see prompt
+ * rules): intent-shaped, no file paths or pipeline names, ≤ 80 char
+ * titles, 1-3 sentence summaries. Quality of the proposal is the
+ * PM's call — the comment template makes editing easy.
+ */
+
+import type { LlmClient } from "@slowcook-ai/core";
+import { MULTIFURCATION_SYSTEM } from "@slowcook-ai/llm-anthropic";
+
+export interface MultifurcationSubIssue {
+  title: string;
+  summary: string;
+  /** Optional — titles of OTHER sub-issues this one depends on landing first. */
+  depends_on?: string[];
+}
+
+export type MultifurcationVerdict =
+  | { kind: "one"; rationale: string }
+  | { kind: "many"; rationale: string; sub_issues: MultifurcationSubIssue[] };
+
+export interface MultifurcationInputs {
+  issueTitle: string;
+  issueBody: string;
+}
+
+export interface MultifurcationResult {
+  verdict: MultifurcationVerdict;
+  costUsd: number;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  };
+}
+
+export async function assessMultifurcation(
+  inputs: MultifurcationInputs,
+  opts: { llm: LlmClient; model: string }
+): Promise<MultifurcationResult> {
+  const userMessage = `## Issue under review\n\n### Title\n${inputs.issueTitle}\n\n### Body\n${inputs.issueBody || "(empty body)"}\n\nReturn the JSON verdict per the system prompt.`;
+
+  const response = await opts.llm.complete({
+    system: MULTIFURCATION_SYSTEM,
+    cacheSystem: false,
+    model: opts.model,
+    messages: [{ role: "user", content: userMessage }],
+    maxTokens: 2048,
+  });
+
+  return {
+    verdict: parseMultifurcationJson(response.text),
+    costUsd: response.costUsd,
+    usage: response.usage,
+  };
+}
+
+/**
+ * Parse the JSON verdict. Tolerant of leading/trailing prose (some
+ * models still wrap JSON in fences despite the prompt). Defaults to
+ * `{ kind: "one", rationale: "(parser fallback — model output unparseable)" }`
+ * so that an LLM hiccup never blocks refine.
+ */
+export function parseMultifurcationJson(text: string): MultifurcationVerdict {
+  const json = extractJsonBlob(text);
+  if (!json) {
+    return {
+      kind: "one",
+      rationale: "(parser fallback — model output unparseable, treating as single story)",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return {
+      kind: "one",
+      rationale: "(parser fallback — JSON parse failed)",
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return { kind: "one", rationale: "(parser fallback — non-object verdict)" };
+  }
+  const o = raw as Record<string, unknown>;
+  const verdict = typeof o.verdict === "string" ? o.verdict.toLowerCase() : "";
+  const rationale = typeof o.rationale === "string" ? o.rationale.trim() : "";
+
+  if (verdict === "one") {
+    return { kind: "one", rationale: rationale || "(no rationale provided)" };
+  }
+  if (verdict === "many") {
+    const subRaw = Array.isArray(o.sub_issues) ? o.sub_issues : [];
+    const sub_issues: MultifurcationSubIssue[] = [];
+    for (const entry of subRaw) {
+      if (!entry || typeof entry !== "object") continue;
+      const e = entry as Record<string, unknown>;
+      const title = typeof e.title === "string" ? e.title.trim() : "";
+      const summary = typeof e.summary === "string" ? e.summary.trim() : "";
+      if (!title || !summary) continue;
+      const depRaw = Array.isArray(e.depends_on) ? e.depends_on : [];
+      const depends_on = depRaw
+        .filter((d): d is string => typeof d === "string" && d.trim().length > 0)
+        .map((d) => d.trim());
+      const item: MultifurcationSubIssue = { title, summary };
+      if (depends_on.length > 0) item.depends_on = depends_on;
+      sub_issues.push(item);
+    }
+    // Guardrail: if the model said "many" but failed to produce ≥2 valid
+    // sub-issues, fall back to "one" rather than emit a broken proposal.
+    // Always tag the rationale so downstream logs reveal the downgrade.
+    if (sub_issues.length < 2) {
+      const prefix =
+        "(parser fallback — verdict was many but fewer than 2 valid sub-issues parsed)";
+      return {
+        kind: "one",
+        rationale: rationale ? `${prefix} · original rationale: ${rationale}` : prefix,
+      };
+    }
+    return {
+      kind: "many",
+      rationale: rationale || "(no rationale provided)",
+      sub_issues,
+    };
+  }
+  return {
+    kind: "one",
+    rationale: rationale || `(parser fallback — unknown verdict "${verdict}")`,
+  };
+}
+
+/**
+ * Extract the first balanced { ... } JSON blob from raw model text.
+ * Strips common decorations: leading prose, ```json fences, trailing
+ * commentary. Returns null if no balanced object is found.
+ */
+function extractJsonBlob(text: string): string | null {
+  const fenced = text.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+  if (fenced && fenced[1]) return fenced[1];
+
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * PM-facing comment body listing the proposed sub-issues. The template
+ * mirrors the refine "questions-first" layout — proposal up top, agent's
+ * rationale folded into a <details> block, action prompts at the bottom.
+ *
+ * The HTML comment `<!-- slowcook:multifurcation -->` is a sentinel
+ * future refine runs grep for to skip re-proposing on the same issue.
+ */
+export function multifurcationCommentBody(
+  proposal: { rationale: string; sub_issues: MultifurcationSubIssue[] },
+  opts: { issueTitle: string }
+): string {
+  const lines: string[] = [];
+  lines.push("<!-- slowcook:multifurcation -->");
+  lines.push("### slowcook · refinement agent 🍲");
+  lines.push("");
+  lines.push(
+    `This issue looks like **more than one story** to me. Before I produce a spec, please confirm the split below — refine ships one PR per story, and a single mega-spec usually misses the things that matter at each user-facing slice.`
+  );
+  lines.push("");
+  lines.push(`#### Proposed sub-issues (${proposal.sub_issues.length})`);
+  lines.push("");
+  for (let i = 0; i < proposal.sub_issues.length; i++) {
+    const s = proposal.sub_issues[i]!;
+    lines.push(`**${i + 1}. ${escapeMd(s.title)}**`);
+    lines.push("");
+    lines.push(escapeMd(s.summary));
+    if (s.depends_on && s.depends_on.length > 0) {
+      lines.push("");
+      lines.push(`_Depends on: ${s.depends_on.map((d) => `"${d}"`).join(", ")}_`);
+    }
+    lines.push("");
+  }
+  lines.push("<details><summary>Why I think this should split</summary>");
+  lines.push("");
+  lines.push(proposal.rationale);
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+  lines.push("#### What to do");
+  lines.push("");
+  lines.push(
+    "- 👍 **Looks right** → file each sub-issue, then close this one (or remove `needs-refinement` from it). Each sub-issue runs through refine independently."
+  );
+  lines.push(
+    "- ✏️ **Needs tweaking** → reply with the edited list (edit titles, drop or add entries). Remove the `slowcook-multifurcation-proposed` label and I'll re-propose."
+  );
+  lines.push(
+    "- 👎 **Keep as one** → reply \"keep as one\" and remove both labels (`slowcook-multifurcation-proposed` and `needs-refinement`, then re-add `needs-refinement`). I'll proceed with a single spec."
+  );
+  lines.push("");
+  lines.push(
+    `_For context, the original title was: **${escapeMd(opts.issueTitle)}**_`
+  );
+  return lines.join("\n");
+}
+
+function escapeMd(s: string): string {
+  return s.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Detect whether a multifurcation proposal has already been posted on
+ * an issue's comment thread. Used by the agent to skip re-running the
+ * LLM pass when the PM is still deciding.
+ */
+export function hasExistingMultifurcationComment(
+  comments: Array<{ body: string }>
+): boolean {
+  return comments.some((c) => c.body.includes("<!-- slowcook:multifurcation -->"));
+}

--- a/packages/cli/src/commands/refine/multifurcate.ts
+++ b/packages/cli/src/commands/refine/multifurcate.ts
@@ -22,14 +22,36 @@
  * PM's call — the comment template makes editing easy.
  */
 
-import type { LlmClient } from "@slowcook-ai/core";
+import type { LlmClient, Spec } from "@slowcook-ai/core";
 import { MULTIFURCATION_SYSTEM } from "@slowcook-ai/llm-anthropic";
+
+/**
+ * One existing spec the model needs to be aware of when proposing a
+ * split, so it can mark sub-issues that overlap with active scope
+ * INSTEAD of silently omitting them. The PM needs to see the full
+ * picture, not a hidden side-channel.
+ *
+ * Built from `listActiveSpecs(repoRoot)` — a single line of Spec.
+ */
+export interface ActiveSpecDigest {
+  story_id: string;
+  title: string;
+  summary: string;
+}
 
 export interface MultifurcationSubIssue {
   title: string;
   summary: string;
   /** Optional — titles of OTHER sub-issues this one depends on landing first. */
   depends_on?: string[];
+  /**
+   * cli α.45 — set when the proposed sub-issue's scope is already covered
+   * by an active spec. The PM still sees the sub-issue (so the parent
+   * issue's full scope is visible), but the comment renders an "Already
+   * covered by story-NNN" annotation and the PM can fold it into the
+   * existing story rather than opening a duplicate.
+   */
+  existing_spec_id?: string;
 }
 
 export type MultifurcationVerdict =
@@ -39,6 +61,16 @@ export type MultifurcationVerdict =
 export interface MultifurcationInputs {
   issueTitle: string;
   issueBody: string;
+  /**
+   * cli α.45 — list of currently active specs in this repo. The
+   * multifurcation prompt uses them to annotate sub-issues that
+   * overlap with existing scope (story_id is the PM-visible
+   * reference; title + summary give the model enough context to
+   * decide whether overlap is real).
+   *
+   * Empty array is fine — model just won't tag anything.
+   */
+  activeSpecs?: ActiveSpecDigest[];
 }
 
 export interface MultifurcationResult {
@@ -56,8 +88,7 @@ export async function assessMultifurcation(
   inputs: MultifurcationInputs,
   opts: { llm: LlmClient; model: string }
 ): Promise<MultifurcationResult> {
-  const userMessage = `## Issue under review\n\n### Title\n${inputs.issueTitle}\n\n### Body\n${inputs.issueBody || "(empty body)"}\n\nReturn the JSON verdict per the system prompt.`;
-
+  const userMessage = buildMultifurcationUserMessage(inputs);
   const response = await opts.llm.complete({
     system: MULTIFURCATION_SYSTEM,
     cacheSystem: false,
@@ -71,6 +102,52 @@ export async function assessMultifurcation(
     costUsd: response.costUsd,
     usage: response.usage,
   };
+}
+
+/**
+ * Compose the user-side message. Exported for tests so the snapshot can
+ * assert active-specs context lands where the model expects it.
+ */
+export function buildMultifurcationUserMessage(inputs: MultifurcationInputs): string {
+  const sections: string[] = [];
+  sections.push("## Issue under review");
+  sections.push(`### Title\n${inputs.issueTitle}`);
+  sections.push(`### Body\n${inputs.issueBody || "(empty body)"}`);
+
+  const specs = inputs.activeSpecs ?? [];
+  if (specs.length > 0) {
+    sections.push("## Active specs in this repo");
+    sections.push(
+      "If any proposed sub-issue's scope is ALREADY covered by one of these, " +
+        "set `existing_spec_id` to that story_id in the sub-issue object. " +
+        "Still include the sub-issue in the proposal — the PM needs the full picture, " +
+        "the annotation tells them this slice is already on the ratchet. " +
+        "Do NOT silently omit overlapping sub-issues."
+    );
+    for (const s of specs) {
+      const summary = s.summary && s.summary.length > 0 ? ` — ${s.summary}` : "";
+      sections.push(`- **story-${s.story_id}** "${s.title}"${summary}`);
+    }
+  }
+
+  sections.push("Return the JSON verdict per the system prompt.");
+  return sections.join("\n\n");
+}
+
+/**
+ * Compact a Spec list down to the digest shape the multifurcation
+ * prompt consumes. Summary is the first ~150 chars of the first
+ * acceptance scenario (the most spec-like prose); falls back to a
+ * non_goal or empty string.
+ */
+export function digestActiveSpecs(specs: Spec[]): ActiveSpecDigest[] {
+  return specs.map((s) => {
+    const firstScenario = s.acceptance_scenarios[0] ?? "";
+    const firstInvariant = s.invariants[0] ?? "";
+    const raw = firstScenario || firstInvariant || s.non_goals[0] || "";
+    const summary = raw.replace(/\s+/g, " ").trim().slice(0, 150);
+    return { story_id: s.story_id, title: s.title, summary };
+  });
 }
 
 /**
@@ -121,6 +198,16 @@ export function parseMultifurcationJson(text: string): MultifurcationVerdict {
         .map((d) => d.trim());
       const item: MultifurcationSubIssue = { title, summary };
       if (depends_on.length > 0) item.depends_on = depends_on;
+      // cli α.45 — overlap annotation. Accept variants the model may
+      // emit (existing_spec_id, story_id, covered_by_story) and
+      // normalize to plain digit-suffix form ("002" not "story-002").
+      const rawId =
+        (typeof e.existing_spec_id === "string" && e.existing_spec_id) ||
+        (typeof e.covered_by_story === "string" && e.covered_by_story) ||
+        (typeof e.story_id === "string" && e.story_id) ||
+        "";
+      const normalised = rawId.trim().replace(/^story-/i, "");
+      if (normalised.length > 0) item.existing_spec_id = normalised;
       sub_issues.push(item);
     }
     // Guardrail: if the model said "many" but failed to produce ≥2 valid
@@ -189,11 +276,17 @@ export function multifurcationCommentBody(
     `This issue looks like **more than one story** to me. Before I produce a spec, please confirm the split below — refine ships one PR per story, and a single mega-spec usually misses the things that matter at each user-facing slice.`
   );
   lines.push("");
-  lines.push(`#### Proposed sub-issues (${proposal.sub_issues.length})`);
+  const overlapCount = proposal.sub_issues.filter((s) => s.existing_spec_id).length;
+  lines.push(
+    `#### Proposed sub-issues (${proposal.sub_issues.length}${overlapCount > 0 ? `, ${overlapCount} overlap existing specs` : ""})`
+  );
   lines.push("");
   for (let i = 0; i < proposal.sub_issues.length; i++) {
     const s = proposal.sub_issues[i]!;
-    lines.push(`**${i + 1}. ${escapeMd(s.title)}**`);
+    const overlapBadge = s.existing_spec_id
+      ? ` _(already covered by story-${escapeMd(s.existing_spec_id)})_`
+      : "";
+    lines.push(`**${i + 1}. ${escapeMd(s.title)}**${overlapBadge}`);
     lines.push("");
     lines.push(escapeMd(s.summary));
     if (s.depends_on && s.depends_on.length > 0) {
@@ -211,10 +304,10 @@ export function multifurcationCommentBody(
   lines.push("#### What to do");
   lines.push("");
   lines.push(
-    "- 👍 **Looks right** → file each sub-issue, then close this one (or remove `needs-refinement` from it). Each sub-issue runs through refine independently."
+    "- 👍 **Looks right** → file each sub-issue that DOESN'T have an _already covered by_ tag. For tagged ones, decide per row whether to fold them into the existing story (comment on that story) or skip. Then close this one or remove `needs-refinement` from it."
   );
   lines.push(
-    "- ✏️ **Needs tweaking** → reply with the edited list (edit titles, drop or add entries). Remove the `slowcook-multifurcation-proposed` label and I'll re-propose."
+    "- ✏️ **Needs tweaking** → reply with the edited list (edit titles, drop or add entries, change overlap calls). Remove the `slowcook-multifurcation-proposed` label and I'll re-propose."
   );
   lines.push(
     "- 👎 **Keep as one** → reply \"keep as one\" and remove both labels (`slowcook-multifurcation-proposed` and `needs-refinement`, then re-add `needs-refinement`). I'll proceed with a single spec."

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.16",
+  "version": "0.16.0-alpha.17",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.14",
+  "version": "0.16.0-alpha.16",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/index.ts
+++ b/packages/llm-anthropic/src/index.ts
@@ -45,6 +45,9 @@ export {
   SIDE_EFFECTS_AUDIT_SYSTEM,
   BROWNFIELD_ANSWER_SYSTEM,
   AMENDMENT_SYSTEM,
+  // cli α.44 — multifurcation pass that detects "this issue is actually
+  // many stories" before refine wastes a heavy-reasoning call.
+  MULTIFURCATION_SYSTEM,
 } from "./prompts/refine.js";
 // 0.10.0 — vibe agent (0.15 plate-pipeline α.1) — design-first mockup
 // generator. Reads spec + brownfield extracts + code-map; emits a

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -1,14 +1,16 @@
 /**
  * System prompts for the refinement agent.
  *
- * Two distinct calls:
- *   1. RELATIONSHIP_ANALYST — classifies a new issue against existing specs.
- *   2. REFINEMENT_ANALYST   — runs the clarifying-question loop and emits
+ * Distinct calls:
+ *   1. MULTIFURCATION       — classifies a new issue as ONE story or
+ *                              MANY (cli α.44).
+ *   2. RELATIONSHIP_ANALYST — classifies a new issue against existing specs.
+ *   3. REFINEMENT_ANALYST   — runs the clarifying-question loop and emits
  *                              the final spec YAML.
  *
- * Both are designed for Claude Opus 4.7 as the default. The relationship
- * analyst can run on Sonnet to keep costs down; refinement proper benefits
- * from Opus-level reasoning.
+ * Designed for Claude Opus 4.7 as the default. Relationship + multifurcation
+ * can run on Sonnet to keep costs down; refinement proper benefits from
+ * Opus-level reasoning.
  */
 
 export const SPEC_CHECKLIST_MD = `
@@ -21,6 +23,77 @@ A complete, testable spec covers ALL of these items. If any are missing or ambig
 5. **UI behavior** per relevant viewport × color scheme — what the user sees and how they interact, at minimum: desktop_light, mobile_light, and mobile_dark
 6. **Acceptance scenarios** — concrete Given/When/Then examples that an engineer can turn into tests. Aim for 3-6, covering happy path AND edge cases.
 7. **Non-goals** — what is explicitly out of scope for this story? (e.g., "editing reactions is a separate story")
+`;
+
+export const MULTIFURCATION_SYSTEM = `You are a senior product manager reviewing a freshly-filed GitHub issue and deciding whether it describes ONE bounded story or MANY.
+
+Slowcook ships ONE story per PR. If an issue secretly contains 5 stories, forcing it through refine produces a fuzzy mega-spec nobody can implement cleanly. Your job is to spot that shape and propose a split BEFORE refine wastes a heavy-reasoning call.
+
+## What ONE story looks like
+
+- One user-facing outcome a PM could verify by clicking through the app
+- Lands in a single PR by a small team in roughly 1-3 days of focused work
+- Touches a bounded surface — one screen, one flow, one endpoint family
+- Reads as a single sentence of PM intent ("members can pin one reaction per rewo")
+
+## What MANY stories looks like
+
+- "Wire X to Y" where X is a whole app and Y is a whole backend
+- "Apply the mock everywhere" or "redesign the patient app"
+- A list of disparate user journeys joined by "and" / "also"
+- One PM sentence that, if you tried to test it, would need 30+ acceptance scenarios
+- A program of work disguised as a ticket
+
+When in doubt, prefer ONE. Splitting a real single story into fake sub-stories adds tracking overhead. Splitting a real program into stories adds clarity. Be honest about which you're looking at.
+
+## Sub-issue proposal rules (when verdict is "many")
+
+PM voice, not engineer voice. The PM will read this in a comment and decide whether to file the sub-issues.
+
+1. **Title** — what a PM would write at the top of a fresh GitHub issue. ≤ 80 chars. Intent-shaped ("Patient appointment list shows real bookings"), not implementation-shaped ("Replace MockAppointmentRepository with PostgresAppointmentRepository").
+2. **Summary** — 1-3 sentences in PM voice. Describe the user-visible change and why it matters. NO file paths, NO function/class names, NO API contracts, NO database table names. If you find yourself naming a slowcook agent (refine, vibe, plate, testgen, brew, recon, chef), rewrite without it. The PM does not think about pipelines; they think about features.
+3. **3-10 sub-issues**. If you'd need more, group them under fewer parents. If you have fewer than 3, this is probably ONE story after all — say "one" instead.
+4. **Dependencies** — note when one sub-issue MUST land before another can be tested. Optional; only include if real.
+5. **Ordering** — list the sub-issues in the order a PM would naturally tackle them (foundations first, polish last). Same order the PM would file them.
+
+## Output format
+
+Strict JSON. No prose preamble, no markdown fence. Just the object.
+
+ONE story:
+{
+  "verdict": "one",
+  "rationale": "one or two sentences explaining why this is one bounded story"
+}
+
+MANY stories:
+{
+  "verdict": "many",
+  "rationale": "one or two sentences naming the dimensions you split along",
+  "sub_issues": [
+    {
+      "title": "<PM-style title, ≤ 80 chars>",
+      "summary": "<1-3 sentences in PM voice; no technical terms>",
+      "depends_on": ["<title of another sub-issue>"]
+    }
+  ]
+}
+
+The "depends_on" key is optional per sub-issue; omit if there are no real dependencies.
+
+## What to ignore
+
+- The slowcook pipeline stages — never mention refine, vibe, plate, testgen, brew, recon, navigator, chef
+- Internal naming conventions, file layouts, package names
+- Whether the project is greenfield or brownfield — that affects HOW each sub-issue lands, not whether the issue is one or many
+- Test coverage, eval gates, CI — also pipeline concerns
+
+## What to attend to
+
+- The verbs the PM used. "Wire" + "replace" + "redesign" stacked together is a strong "many" signal.
+- The nouns. If the issue names multiple apps, multiple user roles, or multiple feature areas, it's almost always many.
+- Implicit fan-out. "Apply the mock everywhere" implies one sub-issue per page; "wire patient app to backend" implies one per data domain.
+- Whether the smallest meaningful slice — what a PM could approve in a single sprint — is the whole issue or a piece of it.
 `;
 
 export const RELATIONSHIP_ANALYST_SYSTEM = `You are a careful spec analyst for the slowcook brewing harness.

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -55,6 +55,7 @@ PM voice, not engineer voice. The PM will read this in a comment and decide whet
 3. **3-10 sub-issues**. If you'd need more, group them under fewer parents. If you have fewer than 3, this is probably ONE story after all — say "one" instead.
 4. **Dependencies** — note when one sub-issue MUST land before another can be tested. Optional; only include if real.
 5. **Ordering** — list the sub-issues in the order a PM would naturally tackle them (foundations first, polish last). Same order the PM would file them.
+6. **Overlap with active specs — INCLUDE, ANNOTATE, DON'T OMIT.** The user message may list active specs ("Active specs in this repo"). If a sub-issue's scope is ALREADY covered by one of those specs, set its \`existing_spec_id\` field to that story id (digits only, e.g. \`"002"\`) and STILL list the sub-issue. The PM needs to see the parent issue's full scope; the annotation tells them "this slice is already on the ratchet — fold it in or skip." Silently dropping overlapping slices hides scope from the PM and is a hard failure. When in doubt about overlap, lean toward annotating — the PM can untag if it's wrong, but they can't un-omit something they never saw.
 
 ## Output format
 
@@ -74,12 +75,13 @@ MANY stories:
     {
       "title": "<PM-style title, ≤ 80 chars>",
       "summary": "<1-3 sentences in PM voice; no technical terms>",
-      "depends_on": ["<title of another sub-issue>"]
+      "depends_on": ["<title of another sub-issue>"],
+      "existing_spec_id": "<digit-only story id of an active spec this overlaps with; omit if not applicable>"
     }
   ]
 }
 
-The "depends_on" key is optional per sub-issue; omit if there are no real dependencies.
+The "depends_on" and "existing_spec_id" keys are both optional per sub-issue; omit when not applicable. Do NOT use "existing_spec_id" speculatively — only when the active-specs list in the user message names a spec whose scope genuinely covers the sub-issue.
 
 ## What to ignore
 


### PR DESCRIPTION
## Summary

Three additive commits, none of which alter existing flows:

- **α.43** — new `git_attention` field on `.brewing/history-index.json` carrying rename chains, change-coupling matrix, recent PRs per file, and a deterministic PR+spec corpus. Refine's context digest surfaces all four in the agent prompt.
- **α.44** — refine multifurcation pre-step. Cheap LLM pass on the relationship model classifies an issue as ONE story vs MANY before the heavy refinement call. On `many`, posts a PM-facing proposal listing 3-10 PM-style sub-issues + halts with a new `multifurcation-proposed` outcome.
- **α.45** — multifurcation surfaces overlap rather than omitting it. Active specs are now passed into the model; sub-issues whose scope overlaps existing scope are tagged with `existing_spec_id` and rendered with an "(already covered by story-NNN)" badge in the comment.

## Why

dogfooding context: delgoosh/monorepo#640 ("everything according to mock") is the canonical multi-story issue. The α.41 flow hit overlap → blocked path immediately. α.44 alone would've silently dropped overlapping slices; α.45 corrects that by making overlap visible-in-the-proposal instead of blocking.

## Test plan

- [x] 27/27 multifurcate tests (parser, comment template, active-specs digest)
- [x] 18/18 git-attention tests (parser, orchestrator graceful-degradation)
- [x] 220/220 refine suite
- [x] 999/999 full cli suite
- [x] typecheck clean
- [ ] real-issue dogfood on delgoosh#640 after merge (which is why we're merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)