### PR TITLE
cli α.46: multifurcation granularity floor (3-6 scenarios + Actor+Verb+Object)

### DIFF
--- a/packages/cli/eval/fixtures/refine-multifurcation-granularity-floor/fixture.json
+++ b/packages/cli/eval/fixtures/refine-multifurcation-granularity-floor/fixture.json
@@ -1,0 +1,29 @@
+{
+  "id": "refine-multifurcation-granularity-floor",
+  "agent": "multifurcation",
+  "description": "The multifurcation system prompt MUST anchor 'one story' on the 3-6 acceptance-scenario floor and require an Actor+Verb+Object no-conjunctions title check before proposing any sub-issue. Without this anchor (α.44/α.45) the prompt over-split bounded inputs into per-field/per-axis sub-tasks. The prompt also MUST handle recursion: when the input body has a `Split from #N (slowcook multifurcation)` footer the model should lean toward 'one' unless the body still has 2+ distinct user outcomes meeting the floor.",
+  "captured_from": {
+    "pr": 640,
+    "date": "2026-05-24",
+    "context": "Dogfooded against delgoosh#640 → 7 sub-issues filed → 6 of 7 got re-multifurcated. PM-led review (docs/dogfood/2026-05-24-multifurcation-recursion.md) showed the depth-2 splits were correct given the epic-scale parent — but the prompt had no defined granularity floor, so a depth-3 attempt on a story-sized input like 'Patient can edit their name' would have continued to invent sub-tasks. α.46 codifies the floor + recursion-aware calibration."
+  },
+  "input": {},
+  "expected_prompt_includes": [
+    "granularity floor",
+    "3-6 acceptance scenarios",
+    "Actor + Verb + Object",
+    "NO conjunctions",
+    "Patient can edit their name",
+    "TASK",
+    "fold it back into its sibling",
+    "STOP",
+    "When the input was itself a multifurcation output",
+    "Split from",
+    "lean toward",
+    "existing_spec_id"
+  ],
+  "expected_prompt_excludes": [
+    "3-10 sub-issues",
+    "If you have fewer than 3, this is probably ONE story"
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.45",
+  "version": "0.19.0-alpha.46",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/eval/index.ts
+++ b/packages/cli/src/commands/eval/index.ts
@@ -34,6 +34,7 @@ import {
   buildVibeUserPrompt,
   REFINEMENT_ANALYST_SYSTEM,
   BROWNFIELD_ANSWER_SYSTEM,
+  MULTIFURCATION_SYSTEM,
 } from "@slowcook-ai/llm-anthropic";
 
 export interface Fixture {
@@ -98,6 +99,13 @@ const BUILDERS: Record<string, (args: unknown) => string> = {
     // assert on its required-rules surface (verbatim copy, source
     // citation, conservative-ambiguous, JSON output, etc.).
     return BROWNFIELD_ANSWER_SYSTEM;
+  },
+  multifurcation: () => {
+    // 0.19.0-α.44–α.46 — multifurcation pre-step. Static system prompt.
+    // Eval fixtures assert on the granularity-floor rule (3-6 scenario
+    // anchor + Actor+Verb+Object no-conjunctions check + recursion-
+    // aware "lean toward one when input has `Split from #N` footer").
+    return MULTIFURCATION_SYSTEM;
   },
 };
 

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.17",
+  "version": "0.16.0-alpha.18",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -29,33 +29,57 @@ export const MULTIFURCATION_SYSTEM = `You are a senior product manager reviewing
 
 Slowcook ships ONE story per PR. If an issue secretly contains 5 stories, forcing it through refine produces a fuzzy mega-spec nobody can implement cleanly. Your job is to spot that shape and propose a split BEFORE refine wastes a heavy-reasoning call.
 
+## The granularity floor — when to STOP splitting
+
+**A story is the smallest slice that produces 3-6 acceptance scenarios** in the spec testgen will turn into integration tests. Below that floor is a TASK (a developer-side breakdown of one story), not a sub-STORY.
+
+Concrete check before proposing any sub-issue:
+
+1. Write the proposed sub-issue's title as **Actor + Verb + Object** with NO conjunctions ("and", "with", "plus", commas).
+2. Imagine the spec testgen would emit. Could you list ≥3 distinct acceptance scenarios for it? (Happy path · validation error · edge case is a typical triplet.)
+3. If you needed conjunctions in the title, OR the scenario count is 0-1, the proposed sub-issue is a TASK — fold it back into its sibling. Don't propose it.
+
+Examples at the floor:
+- "Patient can edit their name" → scenarios: success-save, validation-empty, validation-too-long. 3 scenarios. **ONE STORY — STOP.**
+- "Patient profile pulls backend data" → scenarios: render fields, handle missing field, handle 401. 3 scenarios. **ONE STORY — STOP.**
+- "Patient sees a button" → 0-1 scenarios. **TASK — fold into the parent story.**
+- "Patient profile shows backend data and supports editing name, contact, and preferences" → conjunctions in the title, scope across 3 surfaces, 9+ scenarios. **MANY stories — SPLIT.**
+
 ## What ONE story looks like
 
 - One user-facing outcome a PM could verify by clicking through the app
+- Title fits the "Actor + Verb + Object, no conjunctions" form
+- Spec would have 3-6 acceptance scenarios
 - Lands in a single PR by a small team in roughly 1-3 days of focused work
 - Touches a bounded surface — one screen, one flow, one endpoint family
-- Reads as a single sentence of PM intent ("members can pin one reaction per rewo")
 
 ## What MANY stories looks like
 
 - "Wire X to Y" where X is a whole app and Y is a whole backend
 - "Apply the mock everywhere" or "redesign the patient app"
 - A list of disparate user journeys joined by "and" / "also"
-- One PM sentence that, if you tried to test it, would need 30+ acceptance scenarios
-- A program of work disguised as a ticket
+- One PM sentence that, if you tried to test it, would need >8 acceptance scenarios
+- A program of work disguised as a ticket — multiple screens, multiple endpoints, multiple roles
 
-When in doubt, prefer ONE. Splitting a real single story into fake sub-stories adds tracking overhead. Splitting a real program into stories adds clarity. Be honest about which you're looking at.
+When in doubt, prefer ONE. Splitting a real single story into fake sub-stories adds tracking overhead AND wastes brew time on stories so small that testgen invents most of their scenarios. Splitting a real program into stories adds clarity. Be honest about which you're looking at.
+
+## When the input was itself a multifurcation output
+
+If the issue body contains a footer like \`Split from #<N> (slowcook multifurcation)\`, the parent was already classified epic-scale and broken down once. The granularity floor doesn't move, but you should **lean toward "one"** unless the body still has 2+ distinct user outcomes that each meet the 3-6 scenario floor on their own. Most of the splitting work was done upstream; verify it actually still has multiple outcomes before splitting again.
+
+Concrete: if the issue's body parses as a single sentence describing a single screen with a single bounded flow, AND it has a \`Split from #N\` footer, the answer is almost certainly "one".
 
 ## Sub-issue proposal rules (when verdict is "many")
 
 PM voice, not engineer voice. The PM will read this in a comment and decide whether to file the sub-issues.
 
-1. **Title** — what a PM would write at the top of a fresh GitHub issue. ≤ 80 chars. Intent-shaped ("Patient appointment list shows real bookings"), not implementation-shaped ("Replace MockAppointmentRepository with PostgresAppointmentRepository").
+1. **Title** — what a PM would write at the top of a fresh GitHub issue. ≤ 80 chars. **Actor + Verb + Object, no conjunctions** (see granularity-floor rule above). Intent-shaped ("Patient can edit their name"), not implementation-shaped ("Replace MockUserRepository with PostgresUserRepository").
 2. **Summary** — 1-3 sentences in PM voice. Describe the user-visible change and why it matters. NO file paths, NO function/class names, NO API contracts, NO database table names. If you find yourself naming a slowcook agent (refine, vibe, plate, testgen, brew, recon, chef), rewrite without it. The PM does not think about pipelines; they think about features.
-3. **3-10 sub-issues**. If you'd need more, group them under fewer parents. If you have fewer than 3, this is probably ONE story after all — say "one" instead.
-4. **Dependencies** — note when one sub-issue MUST land before another can be tested. Optional; only include if real.
-5. **Ordering** — list the sub-issues in the order a PM would naturally tackle them (foundations first, polish last). Same order the PM would file them.
-6. **Overlap with active specs — INCLUDE, ANNOTATE, DON'T OMIT.** The user message may list active specs ("Active specs in this repo"). If a sub-issue's scope is ALREADY covered by one of those specs, set its \`existing_spec_id\` field to that story id (digits only, e.g. \`"002"\`) and STILL list the sub-issue. The PM needs to see the parent issue's full scope; the annotation tells them "this slice is already on the ratchet — fold it in or skip." Silently dropping overlapping slices hides scope from the PM and is a hard failure. When in doubt about overlap, lean toward annotating — the PM can untag if it's wrong, but they can't un-omit something they never saw.
+3. **Each sub-issue must meet the 3-6 acceptance-scenario floor.** If imagining its spec would yield only 0-1 scenarios, the proposed sub-issue is a TASK — fold it back into its sibling. This is a hard rule, not a soft preference.
+4. **2-10 sub-issues**. If you'd need more, group them under fewer parents. If only one passes the floor check, the parent is ONE story — say "one" instead.
+5. **Dependencies** — note when one sub-issue MUST land before another can be tested. Optional; only include if real.
+6. **Ordering** — list the sub-issues in the order a PM would naturally tackle them (foundations first, polish last). Same order the PM would file them.
+7. **Overlap with active specs — INCLUDE, ANNOTATE, DON'T OMIT.** The user message may list active specs ("Active specs in this repo"). If a sub-issue's scope is ALREADY covered by one of those specs, set its \`existing_spec_id\` field to that story id (digits only, e.g. \`"002"\`) and STILL list the sub-issue. The PM needs to see the parent issue's full scope; the annotation tells them "this slice is already on the ratchet — fold it in or skip." Silently dropping overlapping slices hides scope from the PM and is a hard failure. When in doubt about overlap, lean toward annotating — the PM can untag if it's wrong, but they can't un-omit something they never saw.
 
 ## Output format
 


### PR DESCRIPTION
## Summary

Defines a granularity floor for the multifurcation prompt so it has an observable STOP rule, not just model intuition.

- A story = the smallest slice that produces **3-6 acceptance scenarios**. Below that floor, the proposed sub-issue is a TASK (developer-side breakdown), not a sub-story.
- Hard check: sub-issue title must be **Actor + Verb + Object** with **no conjunctions** (and/with/plus/commas). If you need a conjunction, you have >1 outcome → split. If you don't AND the imagined spec has 0-1 scenarios → fold into sibling.
- Recursion-aware: if the input body has a `Split from #N (slowcook multifurcation)` footer, lean toward "one" unless the body still has 2+ distinct outcomes meeting the floor. The depth-2 multifurcation observed on delgoosh#640 → #642-#646 was *correct*; α.46 doesn't break that, it just prevents an inappropriate depth-3 on a story-sized input.

Replaces the soft "3-10 sub-issues; if fewer than 3 it's probably one" rule that was creating its own evidence (model invented axes to land just above the fan-out floor).

## Why now

[delgoosh#641-#647 dogfood](https://github.com/aminazar/slowcook/blob/findings/multifurcation-recursion-2026-05-24/docs/dogfood/2026-05-24-multifurcation-recursion.md) showed the prompt has no defined floor. PM-led review confirmed depth-2 splits were correct given the epic-scale parent — but α.45 would have happily kept splitting if a sub-issue had been re-labeled `needs-refinement` after creation. This locks the floor.

## Test plan

- [x] New eval fixture `refine-multifurcation-granularity-floor` asserts the floor language is present + the obsolete "3-10 sub-issues" rule is gone. Fails closed on future strip.
- [x] All 4 eval fixtures green
- [x] 999/999 cli unit tests green
- [x] Typecheck clean

## Follow-up

Tracked for α.47: testgen-side feedback channel (when emitted test count vs spec scenario count crosses thresholds, post a "story may have been under/over-multifurcated" comment on the spec PR). Designed in the findings doc; will RFC before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)