### PR TITLE
cli α.47: testgen stage skips empty-content degraded outputs (fixes dogfood block)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.46",
+  "version": "0.19.0-alpha.47",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/testgen/agent.ts
+++ b/packages/cli/src/commands/testgen/agent.ts
@@ -240,13 +240,20 @@ export async function runTestgen(ctx: TestgenContext): Promise<TestgenOutcome> {
   }
 
   // Git: branch, stage, commit, push
+  //
+  // Stage only what was actually written to disk. The graceful-degrade
+  // path (sc#65) can produce records where testPath/uiTestPath stays
+  // truthy but fileContents/uiFileContents is empty because the LLM
+  // omitted that block — the write guards on lines ~212 / ~223 skip
+  // those, and stage must mirror or git-add fails with pathspec-not-
+  // found (caught in delgoosh dogfood 2026-05-24 / run 26372101538).
   await ctx.forge.git.createBranch(ctx.branchName);
   for (const g of generated) {
-    if (g.testPath) await ctx.forge.git.stage(g.testPath);
+    if (g.testPath && g.fileContents) await ctx.forge.git.stage(g.testPath);
     await ctx.forge.git.stage(join(MANIFESTS_DIR, `story-${g.spec.story_id}.json`));
     for (const stub of g.stubs) await ctx.forge.git.stage(stub.path);
     for (const helper of g.helpers) await ctx.forge.git.stage(helper.path);
-    if (g.uiTestPath) await ctx.forge.git.stage(g.uiTestPath);
+    if (g.uiTestPath && g.uiFileContents) await ctx.forge.git.stage(g.uiTestPath);
     for (const stub of g.uiStubs) await ctx.forge.git.stage(stub.path);
     for (const extra of g.extraTestFiles) await ctx.forge.git.stage(extra.path);
   }


### PR DESCRIPTION
## Summary

When testgen's LLM emit is missing one of the `<test_file>` / `<ui_test_file>` blocks, sc#65 graceful-degrade keeps the path truthy but empties the contents. The **write** side checks both fields and skips; the **stage** side only checks the path and calls git-add on a file that was never written → `fatal: pathspec did not match any files`, testgen exits 2.

One-line fix: mirror the write guard on the stage path.

## Repro

Real GHA run on delgoosh — [run 26372101538](https://github.com/delgoosh/monorepo/actions/runs/26372101538) blocked the spec-merged → testgen → brew chain after spec PR #665 landed for delgoosh#656. Two stale-shaped specs (story-002 missing UI block, story-003 missing handler block) hit the bug back-to-back.

## Test plan

- [x] Existing 999 cli tests still green
- [x] Typecheck clean
- [ ] **Dogfood validation**: re-trigger testgen on delgoosh main after this lands → expect a clean testgen PR opened against delgoosh

A unit test for the stage-call sequence needs a forge.git mock the existing test file doesn't scaffold. Filed as follow-up; fix-then-dogfood-validate is the immediate unblock path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)