### PR TITLE
cli α.48: recon resolveImport handles relative paths

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.47",
+  "version": "0.19.0-alpha.48",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/recon/index.test.ts
+++ b/packages/cli/src/commands/recon/index.test.ts
@@ -100,6 +100,87 @@ describe("resolveImport (regression: rewo issue #149 false-positive 'clean')", (
   });
 });
 
+describe("resolveImport — relative imports (α.48 regression: delgoosh#656)", () => {
+  // Recon used to return null for any non-`@/` import → relative
+  // imports like `import { x } from "../helpers/mocks"` were always
+  // flagged missing_component, halting brew-auto even when the file
+  // was on disk. Burned 3 brew-auto attempts on delgoosh story-003
+  // before the bug was caught.
+  it("resolves '../helpers/mocks' to tests/helpers/mocks/index.ts (directory + index)", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      mkdirSync(join(r, "tests/helpers/mocks"), { recursive: true });
+      writeFileSync(join(r, "tests/helpers/mocks/index.ts"), "export const resetMocks = () => {};", "utf8");
+      const got = resolveImport(r, "../helpers/mocks", "tests/integration/story-003.test.ts");
+      expect(got).toBe("tests/helpers/mocks/index.ts");
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves './foo' to a sibling .ts file with extension", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      writeFileSync(join(r, "tests/integration/sib.ts"), "export {};", "utf8");
+      const got = resolveImport(r, "./sib", "tests/integration/story.test.ts");
+      expect(got).toBe("tests/integration/sib.ts");
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves './foo' to .tsx when both options exist (prefers .ts)", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      writeFileSync(join(r, "tests/integration/foo.ts"), "export {};", "utf8");
+      writeFileSync(join(r, "tests/integration/foo.tsx"), "export {};", "utf8");
+      const got = resolveImport(r, "./foo", "tests/integration/story.test.ts");
+      expect(got).toBe("tests/integration/foo.ts");
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a relative import to a non-existent file", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      const got = resolveImport(r, "./does-not-exist", "tests/integration/story.test.ts");
+      expect(got).toBeNull();
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a relative import when sourceFileRel is omitted (back-compat)", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/helpers"), { recursive: true });
+      writeFileSync(join(r, "tests/helpers/mocks.ts"), "export {};", "utf8");
+      // No third arg → relative resolution can't anchor → null.
+      expect(resolveImport(r, "../helpers/mocks")).toBeNull();
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("does not return a directory match — only files", () => {
+    const r = mkdtempSync(join(tmpdir(), "slowcook-recon-rel-"));
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      mkdirSync(join(r, "tests/helpers/mocks"), { recursive: true });
+      // Directory exists but no index file inside → don't claim resolved.
+      const got = resolveImport(r, "../helpers/mocks", "tests/integration/story.test.ts");
+      expect(got).toBeNull();
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("srcPathToAliasImport (#75 v2 helper)", () => {
   it("converts src/<rel>.tsx to @/<rel>", async () => {
     const { srcPathToAliasImport } = await import("./shape-preserve.js");

--- a/packages/cli/src/commands/recon/index.ts
+++ b/packages/cli/src/commands/recon/index.ts
@@ -236,7 +236,7 @@ export async function recon(argv: string[], cliVersion: string): Promise<void> {
 
     // Check 1: every test import → file exists somewhere reachable
     for (const imp of imports) {
-      const resolved = resolveImport(args.repoRoot, imp);
+      const resolved = resolveImport(args.repoRoot, imp, testRel);
       if (!resolved) {
         // Not in src/ or mock/ — it's a missing component
         // Search history-index for a near-match by name
@@ -415,7 +415,23 @@ export function extractTestids(body: string): string[] {
   return [...new Set(out)];
 }
 
-export function resolveImport(repoRoot: string, imp: string): string | null {
+export function resolveImport(
+  repoRoot: string,
+  imp: string,
+  /**
+   * Repo-relative path of the file that emits this import. Required for
+   * relative imports (./ or ../) so they can be resolved against the
+   * source file's directory. `@/` imports ignore this argument.
+   *
+   * Optional + nullable for back-compat with callers that only ever
+   * pass `@/`-style imports. cli α.48: any caller passing a `.`-prefixed
+   * import MUST supply this — without it relative resolution returns
+   * null and recon falsely flags missing_component (delgoosh#656 dogfood
+   * 2026-05-24 / runs 26372728345 + 26373548396 burned 3 brew-auto
+   * attempts on this exact gap before α.48).
+   */
+  sourceFileRel?: string,
+): string | null {
   // The `@/*` alias in the consumer's top-level tsconfig points at `./src/*`
   // ONLY — `mock/src/*` lives behind the mock's separate tsconfig. Resolving
   // `@/foo` against `mock/src/foo` here gives a false-positive "clean" gate:
@@ -433,7 +449,35 @@ export function resolveImport(repoRoot: string, imp: string): string | null {
     for (const c of candidates) {
       if (existsSync(join(repoRoot, c))) return c;
     }
+    return null;
   }
+
+  // cli α.48 — relative imports. `extractImports` already filters to
+  // `@/` + `./...` so any other shape (e.g. bare module specifiers) is
+  // not reachable here, but we defend with the leading-dot guard anyway.
+  if (imp.startsWith(".") && sourceFileRel) {
+    const sourceDir = dirname(sourceFileRel);
+    const baseRel = join(sourceDir, imp).replace(/\\/g, "/");
+    const candidates = [
+      baseRel,
+      `${baseRel}.ts`,
+      `${baseRel}.tsx`,
+      `${baseRel}/index.ts`,
+      `${baseRel}/index.tsx`,
+    ];
+    for (const c of candidates) {
+      if (existsSync(join(repoRoot, c))) {
+        // Don't return a directory as "resolved" — only files.
+        try {
+          if (statSync(join(repoRoot, c)).isFile()) return c;
+        } catch {
+          continue;
+        }
+      }
+    }
+    return null;
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Recon was flagging perfectly-resolvable relative imports as missing_component → brew-auto's recon gate escalated → brew never dispatched. Burned 3 brew-auto runs on delgoosh story-003 before the gap was understood.

Fix: resolveImport now takes the importing file's path as a 3rd arg + resolves `./...` / `../...` imports against its dirname. Tries bare / .ts / .tsx / /index.ts / /index.tsx. Directory matches without an index file are NOT resolved (avoids false-positive clean on empty dirs).

Tests: 6 new regression cases. 1005/1005 cli suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)