### PR TITLE
cli α.49: testgen import-closure validator (halt before recon catches the gap)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.48",
+  "version": "0.19.0-alpha.49",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/testgen/agent.test.ts
+++ b/packages/cli/src/commands/testgen/agent.test.ts
@@ -6,6 +6,8 @@ import {
   extractTestIdsFromFile,
   buildProjectContext,
   lintTierOneTest,
+  validateImportClosure,
+  formatImportClosureViolations,
   parseTestgenBundle,
   extractDdlColumnsFromInvariants,
   extractDdlColumnsFromSpec,
@@ -817,5 +819,141 @@ describe("buildPageLinkTestContent", () => {
     // deferred). Keep this assertion so a future "drop the skip" change
     // is caught here and the limitation is explicit.
     expect(r.contents).toContain('after.startsWith("${")');
+  });
+});
+
+describe("validateImportClosure (α.49 — delgoosh#656 regression)", () => {
+  function mkRepo(): string {
+    return mkdtempSync(join(tmpdir(), "slowcook-importclosure-"));
+  }
+
+  it("returns no violations when every relative import resolves on disk", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      mkdirSync(join(r, "tests/helpers/mocks"), { recursive: true });
+      writeFileSync(join(r, "tests/helpers/mocks/index.ts"), "export const resetMocks = () => {};", "utf8");
+      const src = `import { resetMocks } from "../helpers/mocks";\n`;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: [],
+      });
+      expect(v).toEqual([]);
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("returns no violations when the import resolves to a helper emitted in this turn", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      // No file on disk — but emit the helper this turn.
+      const src = `import { mockFetch } from "../helpers/mocks/fetch";\n`;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: ["tests/helpers/mocks/fetch.ts"],
+      });
+      expect(v).toEqual([]);
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("flags missing helper that is neither emitted nor on disk (the delgoosh#656 case)", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      const src = `import { resetMocks } from "../helpers/mocks";\n`;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: [],
+      });
+      expect(v).toHaveLength(1);
+      expect(v[0]).toEqual({
+        test: "tests/integration/story-3.test.ts",
+        importPath: "../helpers/mocks",
+        reason: "missing",
+      });
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("distinguishes 'directory exists but no index' from outright missing", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      mkdirSync(join(r, "tests/helpers/mocks"), { recursive: true });
+      // Directory exists but no index.ts inside.
+      const src = `import { resetMocks } from "../helpers/mocks";\n`;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: [],
+      });
+      expect(v).toHaveLength(1);
+      expect(v[0]!.reason).toBe("directory-without-index");
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-relative imports (@/, bare modules)", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      const src = `
+        import { vi } from "vitest";
+        import { Foo } from "@/components/Foo";
+        import { bar } from "@tests/helpers/bar";
+      `;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: [],
+      });
+      expect(v).toEqual([]);
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  it("formatImportClosureViolations gives PM-readable bullets with hints", () => {
+    const formatted = formatImportClosureViolations([
+      { test: "tests/integration/story-3.test.ts", importPath: "../helpers/mocks", reason: "missing" },
+      { test: "tests/integration/story-3.test.ts", importPath: "../helpers/db", reason: "directory-without-index" },
+    ]);
+    expect(formatted).toContain("../helpers/mocks");
+    expect(formatted).toContain("vi.clearAllMocks");
+    expect(formatted).toContain("../helpers/db");
+    expect(formatted).toContain("directory");
+    expect(formatted).toContain("emit a `<helper");
+  });
+
+  it("a stub emitted this turn also counts as resolved", () => {
+    const r = mkRepo();
+    try {
+      mkdirSync(join(r, "tests/integration"), { recursive: true });
+      const src = `import { handler } from "../../src/app/api/foo/route";\n`;
+      const v = validateImportClosure({
+        repoRoot: r,
+        testFilePath: "tests/integration/story-3.test.ts",
+        testContent: src,
+        emittedHelperPaths: [],
+        emittedStubPaths: ["src/app/api/foo/route.ts"],
+      });
+      expect(v).toEqual([]);
+    } finally {
+      rmSync(r, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/testgen/agent.ts
+++ b/packages/cli/src/commands/testgen/agent.ts
@@ -120,6 +120,43 @@ export async function runTestgen(ctx: TestgenContext): Promise<TestgenOutcome> {
       }
     }
 
+    // α.49 — import-closure validator. Catches the class of bug where
+    // the LLM imports a helper/stub from a relative path but doesn't
+    // emit it (and it isn't already on disk). Without this, recon
+    // escalates two stages later + burns a brew-auto dispatch cycle
+    // on the same gap (delgoosh story-003, 3 burned attempts).
+    const emittedHelperPaths = bundle.helpers.map((h) => h.path);
+    const emittedStubPaths = bundle.stubs.map((s) => s.path);
+    const handlerImportViolations =
+      mode !== "ui-only" && bundle.testContent
+        ? validateImportClosure({
+            repoRoot: ctx.repoRoot,
+            testFilePath: testPath,
+            testContent: bundle.testContent,
+            emittedHelperPaths,
+            emittedStubPaths,
+          })
+        : [];
+    const uiImportViolations =
+      mode !== "handler-only" && bundle.uiTestContent
+        ? validateImportClosure({
+            repoRoot: ctx.repoRoot,
+            testFilePath: uiTestPath,
+            testContent: bundle.uiTestContent,
+            emittedHelperPaths,
+            emittedStubPaths: [...emittedStubPaths, ...bundle.uiStubs.map((s) => s.path)],
+          })
+        : [];
+    const importViolations = [...handlerImportViolations, ...uiImportViolations];
+    if (importViolations.length > 0) {
+      throw new Error(
+        `testgen output for story-${spec.story_id} has ${importViolations.length} unresolved relative import(s):\n` +
+          formatImportClosureViolations(importViolations) +
+          `\n\nThe LLM emitted test files importing helpers/stubs it didn't write and that don't exist on disk. ` +
+          `Re-run testgen with a tighter prompt, or hand-emit the missing helper(s) and re-trigger.`
+      );
+    }
+
     // De-dupe stubs + helpers: skip anything whose target file exists and
     // isn't a @slowcook-stub (for stubs) or isn't empty (for helpers). This
     // lets testgen re-run safely without clobbering in-progress impls.
@@ -1490,6 +1527,87 @@ export function lintTierOneTest(filePath: string, source: string): TierOneViolat
     }
   }
   return violations;
+}
+
+// ----- α.49: import-closure validator -----
+//
+// Caught dogfooding delgoosh#656 / story-003 (real bot output). The LLM
+// emitted `import { resetMocks } from "../helpers/mocks"` in the test
+// file but did NOT emit a corresponding <helper path=...> block. The
+// helper didn't exist on disk either. Recon caught it at the next
+// stage (after we shipped α.48), but that's two re-runs late — the
+// failure is detectable at testgen-emit time with zero LLM cost.
+//
+// Rule: every relative import in an emitted test file must resolve to
+// either a helper emitted in THIS turn's bundle OR a file already on
+// disk. Otherwise testgen halts loudly + the maintainer can re-run with
+// a tighter prompt instead of burning a recon-escalate-fix cycle.
+
+export interface ImportClosureViolation {
+  test: string;
+  importPath: string;
+  reason: "missing" | "directory-without-index";
+}
+
+export function validateImportClosure(args: {
+  repoRoot: string;
+  testFilePath: string;          // repo-rel path the test file will be written at
+  testContent: string;            // raw test file source
+  emittedHelperPaths: string[];   // repo-rel paths of helpers emitted this turn
+  emittedStubPaths?: string[];    // repo-rel paths of stubs emitted this turn
+}): ImportClosureViolation[] {
+  const { repoRoot, testFilePath, testContent } = args;
+  const emitted = new Set<string>([
+    ...args.emittedHelperPaths,
+    ...(args.emittedStubPaths ?? []),
+  ]);
+  const violations: ImportClosureViolation[] = [];
+
+  const testDir = dirname(testFilePath);
+  const importRe = /import[^"']*from\s+["'](\.[^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = importRe.exec(testContent)) !== null) {
+    const imp = m[1];
+    if (!imp) continue;
+    const baseRel = join(testDir, imp).replace(/\\/g, "/");
+    const candidates = [
+      baseRel,
+      `${baseRel}.ts`,
+      `${baseRel}.tsx`,
+      `${baseRel}/index.ts`,
+      `${baseRel}/index.tsx`,
+    ];
+    const resolved = candidates.find((c) => {
+      if (emitted.has(c)) return true;
+      const abs = join(repoRoot, c);
+      try { return statSync(abs).isFile(); } catch { return false; }
+    });
+    if (!resolved) {
+      // Distinguish "the import points at a directory that exists but
+      // has no index file" from outright missing — the prompt advice
+      // differs (one wants a `<helper>` block emitting the index, the
+      // other wants either an emit OR a switch to inlining).
+      let dirExists = false;
+      try { dirExists = statSync(join(repoRoot, baseRel)).isDirectory(); } catch { /* ignore */ }
+      violations.push({
+        test: testFilePath,
+        importPath: imp,
+        reason: dirExists ? "directory-without-index" : "missing",
+      });
+    }
+  }
+  return violations;
+}
+
+export function formatImportClosureViolations(violations: ImportClosureViolation[]): string {
+  return violations
+    .map((v) => {
+      const hint = v.reason === "directory-without-index"
+        ? `directory \`${v.importPath}\` exists but has no index.ts — emit a \`<helper path="…/index.ts">\` block, OR inline the helper's contents.`
+        : `no helper, stub, or on-disk file at \`${v.importPath}\` — emit a \`<helper>\` / \`<stub>\` block for it, OR inline (e.g. \`vi.clearAllMocks()\` doesn't need a helper).`;
+      return `  - ${v.test} imports "${v.importPath}" — ${hint}`;
+    })
+    .join("\n");
 }
 
 /**

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.18",
+  "version": "0.16.0-alpha.19",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/testgen.ts
+++ b/packages/llm-anthropic/src/prompts/testgen.ts
@@ -260,6 +260,19 @@ export type { MockFooConfig, MockFooClient, MockFooUser } from "./foo.js";
 
 If the barrel already exists (listed in project context), emit a \`<helper>\` block that REPLACES it with the union of existing + new exports.
 
+### Import-closure rule (α.49 — hard signal)
+
+Every relative import in your emitted test files must resolve to either:
+- A \`<helper>\` block you emit in this same response, OR
+- A \`<stub>\` block you emit in this same response, OR
+- A file the project context lists as already existing on disk.
+
+If you import \`{ resetMocks } from "../helpers/mocks"\` but don't emit a \`<helper path="tests/helpers/mocks/index.ts">\` block, testgen will halt the run with an import-closure violation. The fix is one of:
+1. Emit the helper block alongside the test.
+2. Skip the helper entirely and inline what you needed — \`vi.clearAllMocks()\` doesn't justify a helper file. Don't import \`resetMocks\` if all it would do is call \`vi.clearAllMocks()\`.
+
+The validator is mechanical (zero LLM cost). Trust it: if it complains, the gap is real.
+
 ## UI test-file shape (when spec has \`ui_behavior\`)
 
 File path: \`tests/integration/story-<id>-ui.test.tsx\` (note the \`.tsx\` extension).


### PR DESCRIPTION
Halts testgen when LLM emits a test importing a relative helper/stub it didn't write and isn't on disk. Saves a recon-escalate cycle per occurrence.

Caught real on delgoosh#656 / story-003 — LLM imported resetMocks from ../helpers/mocks but never emitted the helper. Recon caught it at the next stage (and was itself bugged — also fixed in α.48). With α.49 the gap surfaces at testgen-emit time with zero LLM cost to re-prompt.

## Test plan

- [x] 6 new regression cases for the validator
- [x] 68/68 testgen tests green
- [x] 1006/1006 cli suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)