### PR TITLE
cli α.50 + forge-github 0.12.2: guard advisory for non-brew PRs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.49",
+  "version": "0.19.0-alpha.50",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/forge-github/package.json
+++ b/packages/forge-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/forge-github",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "GitHub ForgeAdapter implementation for slowcook",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/forge-github/src/templates.ts
+++ b/packages/forge-github/src/templates.ts
@@ -116,14 +116,28 @@ ${RESOLVE_PIN_STEP}
 ${installStep(pm)}
 
       - name: Guard — frozen paths
+        # Always RUN (so the report shows what was touched) — only HARD-
+        # FAIL on brew PRs. Non-brew PRs fall back to advisory mode by
+        # default; the explicit \`override-freeze\` label still flips
+        # advisory on for an emergency brew PR. Rationale: brew's own
+        # internal frozen-paths check is the authoritative gate during
+        # iteration. The CI guard's job is to catch a bad brew output
+        # before merge — that's brew-PR-scoped by definition. Human PRs
+        # legitimately edit test infra (e.g. adding jsdom, tweaking
+        # vitest.config) and shouldn't be blocked by the same enforcement.
+        # (cli α.50 default; was hard-fail-always pre-α.50.)
         env:
-          HAS_OVERRIDE: \${{ contains(github.event.pull_request.labels.*.name, 'override-freeze') }}
+          HAS_OVERRIDE: \${{ contains(github.event.pull_request.labels.*.name, 'override-freeze') || !startsWith(github.head_ref, 'slowcook/brew/') }}
         run: |
           set -eu
           ARGS="--base origin/\${{ github.base_ref }} --head HEAD"
           if [ "$HAS_OVERRIDE" = "true" ]; then
             ARGS="$ARGS --override"
-            echo "::notice::'override-freeze' label present — guard runs in advisory mode."
+            if [ "\${{ contains(github.event.pull_request.labels.*.name, 'override-freeze') }}" = "true" ]; then
+              echo "::notice::'override-freeze' label present — guard runs in advisory mode."
+            else
+              echo "::notice::Non-brew PR — guard runs in advisory mode. Brew PRs hard-fail on violations; this PR will surface violations as warnings only."
+            fi
           fi
           npx --yes "$SLOWCOOK_CLI" guard $ARGS
 


### PR DESCRIPTION
Same change as delgoosh PR #673, ported upstream into the workflow template so future consumers ship the right default.

Guard always runs (preserves report visibility) but hard-fails only on PRs from `slowcook/brew/*` branches. Human PRs run advisory. `override-freeze` label still works for emergency cases.

## Test plan

- [x] 1012/1012 cli tests green
- [x] forge-github + cli build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)