### PR TITLE
cli α.51 + llm-anthropic α.20: chef stops hallucinating spec.allowed_paths

### DIFF
--- a/packages/cli/eval/fixtures/chef-no-allowed-paths-spec-hallucination/fixture.json
+++ b/packages/cli/eval/fixtures/chef-no-allowed-paths-spec-hallucination/fixture.json
@@ -1,0 +1,49 @@
+{
+  "id": "chef-no-allowed-paths-spec-hallucination",
+  "agent": "chef",
+  "description": "Chef MUST NOT hallucinate an `allowed_paths` field on the spec yaml. When the brew halt was caused by an iter outcome of rejected-overflow / rejected-frozen-path, chef must recommend re-dispatching brew with `--mode legacy` (the actual mechanism) instead of editing a non-existent spec field. The Spec type in core/src/spec.ts has no `allowed_paths`; suggesting the PM add one produces no-op advice that wastes a re-run.",
+  "captured_from": {
+    "pr": null,
+    "date": "2026-05-25",
+    "context": "Dogfooded chef-on-brew-halt on delgoosh#656 / story-003. Brew halted AGENT_STALLED_NO_EDITS after iter-1 rejected-overflow on a page-route file. chef-drift correctly diagnosed the cause but its PM comment said 'Edit specs/story-003.yaml to add src/app/(main)/** under allowed_paths' — that field doesn't exist; the PM following the advice would change nothing. Real mechanism: dispatch brew with --mode legacy (or maintainer-side: widen plate-mode hardcoded list)."
+  },
+  "input": {
+    "storyId": "003",
+    "trigger": {
+      "kind": "brew_halt_class",
+      "detail": "Brew halted AGENT_STALLED_NO_EDITS after 3 iters; iter 1 rejected-overflow on src/app/(main)/patient/chat/page.tsx.",
+      "raw": {
+        "halt_reason": "AGENT_STALLED_NO_EDITS",
+        "brew_mode": "plate",
+        "allowed_paths": ["src/lib/data/**", "src/app/api/**", "supabase/migrations/**", "tests/**"],
+        "iteration_diffs": [
+          {
+            "iteration": 1,
+            "target_test_id": "story-003-page > page file exists",
+            "outcome": "rejected-overflow",
+            "note": "agent wrote outside allowed_paths: src/app/(main)/patient/chat/page.tsx"
+          }
+        ]
+      }
+    },
+    "storyState": {
+      "issueNumber": 656,
+      "specPath": "specs/story-003.yaml",
+      "specYaml": "story_id: \"003\"\ntitle: Patient chat\n",
+      "openPrs": []
+    },
+    "historyIndex": {},
+    "navigatorHistory": null,
+    "priorChefMoves": []
+  },
+  "expected_prompt_includes": [
+    "allowed_paths violations — DO NOT hallucinate spec fields",
+    "--mode legacy",
+    "does **not** include an `allowed_paths` field",
+    "Suggesting the PM edit a non-existent field",
+    "brew_mode",
+    "rejected-overflow",
+    "Canonical spec yaml fields"
+  ],
+  "expected_prompt_excludes": []
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.50",
+  "version": "0.19.0-alpha.51",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/brew/agent.ts
+++ b/packages/cli/src/commands/brew/agent.ts
@@ -2439,6 +2439,10 @@ async function haltFor(ctx: BrewContext, args: HaltArgs): Promise<BrewOutcome> {
     budget_usd: ctx.budgetUsd,
     model: ctx.model,
     summary_plain_english: args.summary,
+    // α.51 — surface brew runtime config so chef can give accurate PM
+    // advice instead of hallucinating spec fields.
+    brew_mode: ctx.mode,
+    allowed_paths: ctx.allowedPaths,
     iteration_diffs: iterationDiffs.length > 0 ? iterationDiffs : undefined,
     last_agent_rationale: lastRationale,
     suggested_actions: defaultSuggestedActions(args.reason, {

--- a/packages/cli/src/commands/brew/halt.ts
+++ b/packages/cli/src/commands/brew/halt.ts
@@ -18,6 +18,20 @@ export interface HaltReport {
   budget_usd: number;
   model: string;
   summary_plain_english: string;
+  /**
+   * α.51 — brew mode in effect when the halt fired. Populated by
+   * brew/agent.ts from BrewContext.allowedPaths + the dispatched
+   * --mode flag. Chef reads this to know whether
+   * "rejected-overflow" iteration outcomes are due to `--mode plate`
+   * (hardcoded restrictive paths) vs `--mode legacy` (no
+   * restriction — would be a code bug if scope-rejected) vs explicit
+   * `allowed_paths` config. Without this, chef hallucinates that
+   * `allowed_paths` is a spec yaml field (it is not) and gives PM
+   * advice that has no effect (delgoosh#656 dogfood 2026-05-25).
+   */
+  brew_mode?: "auto" | "plate" | "legacy";
+  /** The `allowedPaths` array brew enforced. Empty array = no restriction. */
+  allowed_paths?: string[];
   /** Full per-iteration diffs. Carries every iteration brewing ran, not just the last few,
    * so post-hoc diagnosis of a stuck loop doesn't lose iters 1..N-3. */
   iteration_diffs?: IterationDiff[];

--- a/packages/cli/src/commands/chef/drift-fix.ts
+++ b/packages/cli/src/commands/chef/drift-fix.ts
@@ -776,7 +776,8 @@ export async function chefDrift(argv: string[], cliVersion: string): Promise<voi
         imported_source_files_per_test: importedSourcesMap,
         source_file_contents: sourceContents,
         enrichment_note:
-          "cli-precomputed (chef has no read tools): failing_test_contents shows you each red test verbatim. source_file_contents gives you the full text of every source file imported by those tests. Plan search_replace pairs against source_file_contents — never edit failing_test_contents (tests/ is frozen). If the failure can only be fixed by changing a test, return pm_question instead.",
+          "cli-precomputed (chef has no read tools): failing_test_contents shows you each red test verbatim. source_file_contents gives you the full text of every source file imported by those tests. Plan search_replace pairs against source_file_contents — never edit failing_test_contents (tests/ is frozen). If the failure can only be fixed by changing a test, return pm_question instead.\n\n" +
+          "ALSO available straight from the halt JSON (already on trigger.raw): `brew_mode` (legacy | plate | auto) and `allowed_paths[]` (the runtime restriction brew enforced). If iteration_diffs show outcome=rejected-overflow, the fix is to widen brew's CLI --mode arg, NOT to edit the spec. `allowed_paths` is not a spec yaml field — see chef prompt §1.6.",
       };
       console.log(`  brew-halt enriched: ${failingFiles.length} failing test file(s), ${Object.keys(sourceContents).length} source file(s) under test`);
     }

--- a/packages/cli/src/commands/eval/index.ts
+++ b/packages/cli/src/commands/eval/index.ts
@@ -35,6 +35,7 @@ import {
   REFINEMENT_ANALYST_SYSTEM,
   BROWNFIELD_ANSWER_SYSTEM,
   MULTIFURCATION_SYSTEM,
+  CHEF_SYSTEM,
 } from "@slowcook-ai/llm-anthropic";
 
 export interface Fixture {
@@ -65,7 +66,12 @@ export interface FixtureResult {
  * concatenated text for the substring check.
  */
 const BUILDERS: Record<string, (args: unknown) => string> = {
-  chef: (args) => buildChefPrompt(args as Parameters<typeof buildChefPrompt>[0]),
+  // Chef eval asserts on the FULL prompt (system + user) — most chef
+  // rules (no-allowed-paths-hallucination, search_replace-only, PM
+  // question template, etc.) live in CHEF_SYSTEM. Concatenating with a
+  // separator gives substring matchers a single body to grep.
+  chef: (args) =>
+    CHEF_SYSTEM + "\n\n---\n\n" + buildChefPrompt(args as Parameters<typeof buildChefPrompt>[0]),
   "chef-orchestrate": (args) =>
     buildChefOrchestratePrompt(args as Parameters<typeof buildChefOrchestratePrompt>[0]),
   investigate: (args) =>

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.19",
+  "version": "0.16.0-alpha.20",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/chef.ts
+++ b/packages/llm-anthropic/src/prompts/chef.ts
@@ -143,9 +143,20 @@ When \`trigger.kind === "brew_halt_class"\`, look for these fields in \`trigger.
 - \`failing_test_names[]\` — the specific \`describe > it\` paths that failed. Helps narrow down which assertion to satisfy.
 - \`failing_test_contents{}\` — \`{testFile: fullText}\` map of every failing test file. Read these first; they are your contract. **You must not edit any file in this map** (\`tests/\` is frozen).
 - \`source_file_contents{}\` — \`{srcFile: fullText}\` of every non-test file imported by the failing tests. These are the files you MAY edit. Plan \`search_replace\` pairs against the literal text in this map — the find string must appear exactly once.
+- \`brew_mode\` — string. Either \`"legacy"\` (no allowed_paths restriction; you can create files anywhere) or \`"plate"\` (brew restricted to a hardcoded set; see below) or \`"auto"\` (resolves to one of the prior two at dispatch).
+- \`allowed_paths\` — array of glob patterns brew enforced at iteration time. EMPTY ARRAY means no restriction (legacy mode). For plate mode the hardcoded list today is \`["src/lib/data/**", "src/app/api/**", "supabase/migrations/**", "tests/**"]\`.
 - \`enrichment_note\` — directive on how to combine the above.
 
 Brew-halt rule of thumb: read each failing test, identify the missing/wrong behavior in \`source_file_contents\`, and propose a minimal \`search_replace\` that adds/changes ONLY what the test asserts. If the only way to make a test pass is to weaken or change the test itself, return \`pm_question\` — do not edit the test.
+
+### Step 1.6: allowed_paths violations — DO NOT hallucinate spec fields
+
+If \`iteration_diffs[].outcome\` includes \`"rejected-overflow"\` OR \`"rejected-frozen-path"\`, the iteration's edit was rejected because brew's runtime guard blocked the path. The mechanism behind that guard is **slowcook's brew CLI \`--mode\` argument**, NOT a field on the spec yaml. To widen brew's allowed_paths:
+
+- **Correct PM advice**: re-dispatch brew with \`--mode legacy\` (allows all paths), OR if the consumer specifically needs UI-and-data brew together, ask slowcook maintainers to widen the plate-mode hardcoded list.
+- **Incorrect PM advice (do not generate)**: "edit \`allowed_paths\` in \`specs/story-XXX.yaml\`". The slowcook spec schema (see \`packages/cli/src/commands/refine/spec-yaml.ts\` for the canonical Spec type) does **not** include an \`allowed_paths\` field. Suggesting the PM edit a non-existent field gives no-op advice and wastes a re-run.
+
+Canonical spec yaml fields (use these names exactly when referencing the spec in PM comments): \`story_id\`, \`title\`, \`status\`, \`actors\`, \`preconditions\`, \`invariants\`, \`api_contract\`, \`ui_behavior\`, \`acceptance_scenarios\`, \`non_goals\`, \`related_specs\`, \`proposals\`, \`supersedes\`, \`superseded_by\`. If a field you want to reference isn't in that list, you are about to hallucinate — pause and rephrase the advice as a CLI / workflow action instead.
 
 ### Step 2: classify the failure
 


### PR DESCRIPTION
Chef's PM advice was suggesting the PM edit `allowed_paths` in the spec yaml. That field doesn't exist in slowcook's Spec type — following the advice changes nothing.

Caught dogfooding delgoosh#656 / story-003 where chef-on-brew-halt fired and produced misleading PM-facing advice (real run cost $0.036).

## Changes

1. **HaltReport schema** gains `brew_mode` + `allowed_paths` fields so chef reads the runtime config from the halt JSON.
2. **CHEF_SYSTEM prompt** §1.6 added: explicit "don't hallucinate spec fields" rule + canonical spec field list + correct mechanism (`--mode legacy`).
3. **chef-drift enrichment_note** points at the new trigger.raw fields.
4. **Eval fixture** `chef-no-allowed-paths-spec-hallucination` locks the §1.6 language.

## Test plan

- [x] 5/5 eval fixtures green
- [x] 1012/1012 cli tests green
- [x] Build + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)