### PR TITLE
cli α.52: rename --mode legacy → freehand + default navigator on in freehand

### DIFF
--- a/packages/cli/eval/fixtures/chef-no-allowed-paths-spec-hallucination/fixture.json
+++ b/packages/cli/eval/fixtures/chef-no-allowed-paths-spec-hallucination/fixture.json
@@ -1,11 +1,11 @@
 {
   "id": "chef-no-allowed-paths-spec-hallucination",
   "agent": "chef",
-  "description": "Chef MUST NOT hallucinate an `allowed_paths` field on the spec yaml. When the brew halt was caused by an iter outcome of rejected-overflow / rejected-frozen-path, chef must recommend re-dispatching brew with `--mode legacy` (the actual mechanism) instead of editing a non-existent spec field. The Spec type in core/src/spec.ts has no `allowed_paths`; suggesting the PM add one produces no-op advice that wastes a re-run.",
+  "description": "Chef MUST NOT hallucinate an `allowed_paths` field on the spec yaml. When the brew halt was caused by an iter outcome of rejected-overflow / rejected-frozen-path, chef must recommend re-dispatching brew with `--mode freehand` (the actual mechanism) instead of editing a non-existent spec field. The Spec type in core/src/spec.ts has no `allowed_paths`; suggesting the PM add one produces no-op advice that wastes a re-run.",
   "captured_from": {
     "pr": null,
     "date": "2026-05-25",
-    "context": "Dogfooded chef-on-brew-halt on delgoosh#656 / story-003. Brew halted AGENT_STALLED_NO_EDITS after iter-1 rejected-overflow on a page-route file. chef-drift correctly diagnosed the cause but its PM comment said 'Edit specs/story-003.yaml to add src/app/(main)/** under allowed_paths' — that field doesn't exist; the PM following the advice would change nothing. Real mechanism: dispatch brew with --mode legacy (or maintainer-side: widen plate-mode hardcoded list)."
+    "context": "Dogfooded chef-on-brew-halt on delgoosh#656 / story-003. Brew halted AGENT_STALLED_NO_EDITS after iter-1 rejected-overflow on a page-route file. chef-drift correctly diagnosed the cause but its PM comment said 'Edit specs/story-003.yaml to add src/app/(main)/** under allowed_paths' — that field doesn't exist; the PM following the advice would change nothing. Real mechanism: dispatch brew with --mode freehand (or maintainer-side: widen plate-mode hardcoded list)."
   },
   "input": {
     "storyId": "003",
@@ -38,7 +38,7 @@
   },
   "expected_prompt_includes": [
     "allowed_paths violations — DO NOT hallucinate spec fields",
-    "--mode legacy",
+    "--mode freehand",
     "does **not** include an `allowed_paths` field",
     "Suggesting the PM edit a non-existent field",
     "brew_mode",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.51",
+  "version": "0.19.0-alpha.52",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/brew/agent.ts
+++ b/packages/cli/src/commands/brew/agent.ts
@@ -91,7 +91,7 @@ export interface BrewContext {
   /**
    * 0.15.0-α.4 — execution mode.
    *
-   * `legacy`: today's behavior. Brew has wide allowed_paths and writes
+   * `freehand`: wide-scope. Brew has wide allowed_paths and writes
    *   implementation from empty stubs. Used for backend-only stories
    *   and any story where the plate track was skipped.
    *
@@ -103,7 +103,7 @@ export interface BrewContext {
    *   MOCKUP_DESIGN_CONFLICT when a test cannot be satisfied without
    *   editing a frozen UI file.
    */
-  mode?: "legacy" | "plate";
+  mode?: "freehand" | "plate";
   /**
    * 0.19.0-alpha.4 — pair-brew navigator hook (production wiring of
    * the validated pair-sim experiment). Fires AFTER the iteration's

--- a/packages/cli/src/commands/brew/halt.ts
+++ b/packages/cli/src/commands/brew/halt.ts
@@ -23,13 +23,13 @@ export interface HaltReport {
    * brew/agent.ts from BrewContext.allowedPaths + the dispatched
    * --mode flag. Chef reads this to know whether
    * "rejected-overflow" iteration outcomes are due to `--mode plate`
-   * (hardcoded restrictive paths) vs `--mode legacy` (no
+   * (hardcoded restrictive paths) vs `--mode freehand` (no
    * restriction — would be a code bug if scope-rejected) vs explicit
    * `allowed_paths` config. Without this, chef hallucinates that
    * `allowed_paths` is a spec yaml field (it is not) and gives PM
    * advice that has no effect (delgoosh#656 dogfood 2026-05-25).
    */
-  brew_mode?: "auto" | "plate" | "legacy";
+  brew_mode?: "auto" | "plate" | "freehand";
   /** The `allowedPaths` array brew enforced. Empty array = no restriction. */
   allowed_paths?: string[];
   /** Full per-iteration diffs. Carries every iteration brewing ran, not just the last few,

--- a/packages/cli/src/commands/brew/index.ts
+++ b/packages/cli/src/commands/brew/index.ts
@@ -21,17 +21,32 @@ interface BrewArgs {
   wallClockMs: number;
   model: string;
   baseBranch: string;
-  /** "auto" detects from spec + mockup-PR state. "plate" or "legacy" force the mode. */
-  mode: "auto" | "plate" | "legacy";
   /**
-   * 0.19.0-alpha.9 — opt into pair-brew. When set, brew constructs a
-   * default Anthropic-backed NavigatorHook and injects it into ctx.
-   * Each iteration's would-be checkpoint passes through the navigator
-   * for review; on `block` verdict the iter reverts + concerns fold
-   * into next iter's prompt. Adds ~$0.01-0.05 per iter on top of
-   * driver spend.
+   * "auto" detects from spec + mockup-PR state. "plate" or "freehand"
+   * force the mode.
+   *
+   * cli α.52 — renamed `legacy` → `freehand`. The old name signalled
+   * "deprecated" on a tool that's only a few months old, which was
+   * misleading: freehand is a first-class mode for stories that need
+   * wide-scope edits (UI + data + migrations in one brew). The rename
+   * has no back-compat alias — `--mode legacy` now errors with a
+   * pointer to `--mode freehand`.
    */
-  withNavigator: boolean;
+  mode: "auto" | "plate" | "freehand";
+  /**
+   * 0.19.0-alpha.9 — pair-brew NavigatorHook injection.
+   *
+   * `undefined` = use the mode-aware default (true when resolved mode
+   * is `freehand`, false when `plate`). The user can force either way
+   * via `--with-navigator` / `--without-navigator`.
+   *
+   * cli α.52: freehand defaults navigator ON because wide-scope edits
+   * across UI + data carry more drift risk; the navigator's job is to
+   * catch shape-gaming + cross-story regressions before they checkpoint.
+   * plate keeps it opt-in — plate's hardcoded allowed_paths is itself
+   * a guardrail.
+   */
+  withNavigator: boolean | undefined;
   navigatorModel: string;
 }
 
@@ -45,7 +60,7 @@ function parseArgs(argv: string[]): BrewArgs {
     model: "claude-sonnet-4-6",
     baseBranch: "main",
     mode: "auto",
-    withNavigator: false,
+    withNavigator: undefined,
     navigatorModel: "claude-sonnet-4-5-20250929",
   };
   for (let i = 0; i < argv.length; i++) {
@@ -61,14 +76,24 @@ function parseArgs(argv: string[]): BrewArgs {
     else if (arg === "--model" && next) { args.model = next; i++; }
     else if (arg === "--base" && next) { args.baseBranch = next; i++; }
     else if (arg === "--mode" && next) {
-      if (next !== "auto" && next !== "plate" && next !== "legacy") {
-        console.error(`--mode must be one of: auto, plate, legacy. Got: ${next}`);
+      if (next === "legacy") {
+        // cli α.52 — hard error, no silent alias. The old name was
+        // misleading on a young tool. Point operators at the new name.
+        console.error(
+          `--mode legacy was renamed to --mode freehand in cli α.52. ` +
+            `Re-dispatch with --mode freehand.`
+        );
         process.exit(64);
       }
-      args.mode = next as "auto" | "plate" | "legacy";
+      if (next !== "auto" && next !== "plate" && next !== "freehand") {
+        console.error(`--mode must be one of: auto, plate, freehand. Got: ${next}`);
+        process.exit(64);
+      }
+      args.mode = next as "auto" | "plate" | "freehand";
       i++;
     }
     else if (arg === "--with-navigator") { args.withNavigator = true; }
+    else if (arg === "--without-navigator") { args.withNavigator = false; }
     else if (arg === "--navigator-model" && next) { args.navigatorModel = next; i++; }
     else if (arg === "--help" || arg === "-h") {
       printHelp();
@@ -105,11 +130,17 @@ Options:
   --wall-clock-minutes <n>   Wall-clock cap in minutes (default: 60)
   --model <id>               LLM model (default: claude-sonnet-4-6; override with --model claude-opus-4-7 for harder stories)
   --base <branch>            Base branch for PRs (default: main)
-  --with-navigator           (0.19.0-α.9) Run pair-brew — each iteration's would-be checkpoint passes
-                             through a navigator review (design fidelity / responsive / cross-story risk
-                             / etc.). On block, iter reverts + concerns fold into next iter's prompt.
-                             Adds ~$0.01-0.05 per iter on top of driver spend.
-  --navigator-model <id>     (with --with-navigator) Navigator LLM model id. Default: claude-sonnet-4-5-20250929.
+  --with-navigator           Force pair-brew on (overrides mode-aware default).
+  --without-navigator        Force pair-brew off (overrides mode-aware default).
+                             Default behavior (cli α.52): navigator ON when resolved mode is
+                             freehand (wide-scope edits — drift risk justifies the navigator
+                             cost), OFF when plate (plate's hardcoded allowed_paths is itself
+                             a guardrail; navigator opt-in if needed).
+                             Pair-brew: each iteration's would-be checkpoint passes through a
+                             navigator review (design fidelity / responsive / cross-story risk
+                             / etc.). On block, iter reverts + concerns fold into next iter's
+                             prompt. Adds ~$0.01-0.05 per iter on top of driver spend.
+  --navigator-model <id>     Navigator LLM model id. Default: claude-sonnet-4-5-20250929.
   --help, -h                 Show this help
 
 Environment:
@@ -126,28 +157,28 @@ Exit codes:
 /**
  * 0.15.0-α.4 — resolve brew's execution mode.
  *
- * `requested === "plate"` or `"legacy"` → return as-is.
+ * `requested === "plate"` or `"freehand"` → return as-is.
  *
  * `requested === "auto"` → detect from spec + GitHub state:
  *   plate-mode requires BOTH (a) the spec has at least one populated
  *   `proposals.fixtures.by_domain.<domain>` entry (UI surface), AND (b)
  *   a slowcook-mockup PR for this story has been merged on the repo.
- *   If either condition is unmet → legacy.
+ *   If either condition is unmet → freehand.
  *
  * GitHub check uses `gh pr list` to look for closed PRs whose head
  * branch matches `slowcook/mockup/story-<id>`. Cheaper than fetching
  * a single PR by branch name (which 404s instead of returning empty).
  */
 async function resolveBrewMode(args: {
-  requested: "auto" | "plate" | "legacy";
+  requested: "auto" | "plate" | "freehand";
   repoRoot: string;
   storyId: string;
   owner: string;
   repo: string;
   githubToken: string;
-}): Promise<"plate" | "legacy"> {
+}): Promise<"plate" | "freehand"> {
   if (args.requested === "plate") return "plate";
-  if (args.requested === "legacy") return "legacy";
+  if (args.requested === "freehand") return "freehand";
 
   // auto path
   const specPath = join(args.repoRoot, "specs", `story-${args.storyId}.yaml`);
@@ -155,20 +186,20 @@ async function resolveBrewMode(args: {
   try {
     specYaml = require("node:fs").readFileSync(specPath, "utf8") as string;
   } catch {
-    return "legacy";
+    return "freehand";
   }
   // Same hasUiSurface heuristic as the vibe command.
   const proposalsIdx = specYaml.search(/^proposals\s*:\s*$/m);
-  if (proposalsIdx < 0) return "legacy";
+  if (proposalsIdx < 0) return "freehand";
   const tail = specYaml.slice(proposalsIdx);
   const fixturesMatch = tail.match(/^(\s+)fixtures\s*:\s*$/m);
-  if (!fixturesMatch) return "legacy";
+  if (!fixturesMatch) return "freehand";
   const fixturesBlockStart =
     tail.indexOf(fixturesMatch[0]) + fixturesMatch[0].length;
   const byDomainMatch = tail
     .slice(fixturesBlockStart)
     .match(/^(\s+)by_domain\s*:\s*$/m);
-  if (!byDomainMatch) return "legacy";
+  if (!byDomainMatch) return "freehand";
   const byDomainIndentLen = byDomainMatch[1]!.length;
   const after = tail.slice(
     fixturesBlockStart +
@@ -179,7 +210,7 @@ async function resolveBrewMode(args: {
     `^( {${byDomainIndentLen + 1},}|\\t+)([a-z][a-z0-9_-]*)\\s*:\\s*$`,
     "m"
   );
-  if (!entryRe.test(after)) return "legacy";
+  if (!entryRe.test(after)) return "freehand";
 
   // Check for a merged slowcook-mockup PR.
   try {
@@ -196,16 +227,16 @@ async function resolveBrewMode(args: {
     const arr = JSON.parse(out) as Array<{ number: number }>;
     if (arr.length === 0) {
       console.log(
-        `(brew auto-detect: spec has fixtures but no merged slowcook-mockup PR for story-${args.storyId} found → legacy mode)`
+        `(brew auto-detect: spec has fixtures but no merged slowcook-mockup PR for story-${args.storyId} found → freehand mode)`
       );
-      return "legacy";
+      return "freehand";
     }
     return "plate";
   } catch (e) {
     console.warn(
-      `(brew auto-detect: gh pr list failed — ${(e as Error).message}; defaulting to legacy)`
+      `(brew auto-detect: gh pr list failed — ${(e as Error).message}; defaulting to freehand)`
     );
-    return "legacy";
+    return "freehand";
   }
 }
 
@@ -252,8 +283,8 @@ export async function brew(argv: string[], cliVersion: string): Promise<void> {
 
   // 0.15.0-α.4 — mode resolution. `auto` checks: does the spec have
   // `proposals.fixtures.by_domain.*` populated AND has a slowcook-mockup
-  // PR for this story merged? If both yes → plate. Otherwise → legacy.
-  // Force-modes (plate / legacy) skip the check.
+  // PR for this story merged? If both yes → plate. Otherwise → freehand.
+  // Force-modes (plate / freehand) skip the check.
   const resolvedMode = await resolveBrewMode({
     requested: args.mode,
     repoRoot: args.repoRoot,
@@ -271,7 +302,7 @@ export async function brew(argv: string[], cliVersion: string): Promise<void> {
 
   // Allowed paths. In plate-mode, restrict to data-layer + API + migrations
   // + tests. Frozen-paths guard then physically rejects any UI edit.
-  // In legacy mode, fall through to today's "wide allowed_paths" behavior.
+  // In freehand mode, fall through to today's "wide allowed_paths" behavior.
   const allowedPaths: string[] = resolvedMode === "plate"
     ? [
         "src/lib/data/**",   // brew rewrites .ts stub; .mock.ts protected by extension check
@@ -305,11 +336,18 @@ export async function brew(argv: string[], cliVersion: string): Promise<void> {
   console.log(`  branch: ${branchName}`);
   console.log(`  run log: ${runLogPath}\n`);
 
-  // 0.19.0-α.9 — opt-in pair-brew. When --with-navigator is set,
-  // construct a default Anthropic-backed NavigatorHook + inject it.
-  // The hook fires post-iter, pre-checkpoint (see brew/agent.ts).
+  // Pair-brew NavigatorHook injection.
+  //
+  // cli α.52 — mode-aware default: navigator ON when resolved mode is
+  // `freehand`, OFF when `plate`. Wide-scope freehand edits carry more
+  // drift risk; plate's hardcoded allowed_paths is itself a guardrail.
+  // Explicit `--with-navigator` / `--without-navigator` overrides.
+  const effectiveWithNavigator: boolean =
+    args.withNavigator !== undefined
+      ? args.withNavigator
+      : resolvedMode === "freehand";
   let navigatorHook: BrewContext["navigatorHook"] = undefined;
-  if (args.withNavigator) {
+  if (effectiveWithNavigator) {
     const { createPairNavigatorHook } = await import("./pair-navigator.js");
     const { PRICING_PER_M_TOKENS } = await import("@slowcook-ai/llm-anthropic");
     const navPricing = PRICING_PER_M_TOKENS[args.navigatorModel] ?? { input: 3, output: 15 };
@@ -358,7 +396,13 @@ export async function brew(argv: string[], cliVersion: string): Promise<void> {
         };
       },
     });
-    console.log(`  --with-navigator: enabled (model=${args.navigatorModel})`);
+    const navReason =
+      args.withNavigator === undefined
+        ? `mode=${resolvedMode} default`
+        : args.withNavigator === true
+          ? "explicit --with-navigator"
+          : "explicit --without-navigator (this branch shouldn't reach here)";
+    console.log(`  navigator: enabled (${navReason}, model=${args.navigatorModel})`);
   }
 
   const ctx: BrewContext = {

--- a/packages/cli/src/commands/chef/drift-fix.ts
+++ b/packages/cli/src/commands/chef/drift-fix.ts
@@ -777,7 +777,7 @@ export async function chefDrift(argv: string[], cliVersion: string): Promise<voi
         source_file_contents: sourceContents,
         enrichment_note:
           "cli-precomputed (chef has no read tools): failing_test_contents shows you each red test verbatim. source_file_contents gives you the full text of every source file imported by those tests. Plan search_replace pairs against source_file_contents — never edit failing_test_contents (tests/ is frozen). If the failure can only be fixed by changing a test, return pm_question instead.\n\n" +
-          "ALSO available straight from the halt JSON (already on trigger.raw): `brew_mode` (legacy | plate | auto) and `allowed_paths[]` (the runtime restriction brew enforced). If iteration_diffs show outcome=rejected-overflow, the fix is to widen brew's CLI --mode arg, NOT to edit the spec. `allowed_paths` is not a spec yaml field — see chef prompt §1.6.",
+          "ALSO available straight from the halt JSON (already on trigger.raw): `brew_mode` (freehand | plate | auto) and `allowed_paths[]` (the runtime restriction brew enforced). If iteration_diffs show outcome=rejected-overflow, the fix is to widen brew's CLI --mode arg, NOT to edit the spec. `allowed_paths` is not a spec yaml field — see chef prompt §1.6.",
       };
       console.log(`  brew-halt enriched: ${failingFiles.length} failing test file(s), ${Object.keys(sourceContents).length} source file(s) under test`);
     }

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.20",
+  "version": "0.16.0-alpha.21",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/brew.ts
+++ b/packages/llm-anthropic/src/prompts/brew.ts
@@ -301,7 +301,7 @@ The PM will read your halt + decide. Don't try to silently make the test less st
 
 ### Cost target
 
-Plate-mode runs are narrower; aim for $0.50–$2 per story (cheaper than legacy brew because the design space is fixed at port time). If you find yourself iterating widely on the data layer, you're probably misreading the spec — re-read \`api_contract\` more carefully before editing.
+Plate-mode runs are narrower; aim for $0.50–$2 per story (cheaper than freehand brew because the design space is fixed at port time). If you find yourself iterating widely on the data layer, you're probably misreading the spec — re-read \`api_contract\` more carefully before editing.
 `;
 
 export const BREW_TOOLS = [

--- a/packages/llm-anthropic/src/prompts/chef.ts
+++ b/packages/llm-anthropic/src/prompts/chef.ts
@@ -143,8 +143,8 @@ When \`trigger.kind === "brew_halt_class"\`, look for these fields in \`trigger.
 - \`failing_test_names[]\` — the specific \`describe > it\` paths that failed. Helps narrow down which assertion to satisfy.
 - \`failing_test_contents{}\` — \`{testFile: fullText}\` map of every failing test file. Read these first; they are your contract. **You must not edit any file in this map** (\`tests/\` is frozen).
 - \`source_file_contents{}\` — \`{srcFile: fullText}\` of every non-test file imported by the failing tests. These are the files you MAY edit. Plan \`search_replace\` pairs against the literal text in this map — the find string must appear exactly once.
-- \`brew_mode\` — string. Either \`"legacy"\` (no allowed_paths restriction; you can create files anywhere) or \`"plate"\` (brew restricted to a hardcoded set; see below) or \`"auto"\` (resolves to one of the prior two at dispatch).
-- \`allowed_paths\` — array of glob patterns brew enforced at iteration time. EMPTY ARRAY means no restriction (legacy mode). For plate mode the hardcoded list today is \`["src/lib/data/**", "src/app/api/**", "supabase/migrations/**", "tests/**"]\`.
+- \`brew_mode\` — string. Either \`"freehand"\` (no allowed_paths restriction; you can create files anywhere) or \`"plate"\` (brew restricted to a hardcoded set; see below) or \`"auto"\` (resolves to one of the prior two at dispatch).
+- \`allowed_paths\` — array of glob patterns brew enforced at iteration time. EMPTY ARRAY means no restriction (freehand mode). For plate mode the hardcoded list today is \`["src/lib/data/**", "src/app/api/**", "supabase/migrations/**", "tests/**"]\`.
 - \`enrichment_note\` — directive on how to combine the above.
 
 Brew-halt rule of thumb: read each failing test, identify the missing/wrong behavior in \`source_file_contents\`, and propose a minimal \`search_replace\` that adds/changes ONLY what the test asserts. If the only way to make a test pass is to weaken or change the test itself, return \`pm_question\` — do not edit the test.
@@ -153,7 +153,7 @@ Brew-halt rule of thumb: read each failing test, identify the missing/wrong beha
 
 If \`iteration_diffs[].outcome\` includes \`"rejected-overflow"\` OR \`"rejected-frozen-path"\`, the iteration's edit was rejected because brew's runtime guard blocked the path. The mechanism behind that guard is **slowcook's brew CLI \`--mode\` argument**, NOT a field on the spec yaml. To widen brew's allowed_paths:
 
-- **Correct PM advice**: re-dispatch brew with \`--mode legacy\` (allows all paths), OR if the consumer specifically needs UI-and-data brew together, ask slowcook maintainers to widen the plate-mode hardcoded list.
+- **Correct PM advice**: re-dispatch brew with \`--mode freehand\` (allows all paths), OR if the consumer specifically needs UI-and-data brew together, ask slowcook maintainers to widen the plate-mode hardcoded list.
 - **Incorrect PM advice (do not generate)**: "edit \`allowed_paths\` in \`specs/story-XXX.yaml\`". The slowcook spec schema (see \`packages/cli/src/commands/refine/spec-yaml.ts\` for the canonical Spec type) does **not** include an \`allowed_paths\` field. Suggesting the PM edit a non-existent field gives no-op advice and wastes a re-run.
 
 Canonical spec yaml fields (use these names exactly when referencing the spec in PM comments): \`story_id\`, \`title\`, \`status\`, \`actors\`, \`preconditions\`, \`invariants\`, \`api_contract\`, \`ui_behavior\`, \`acceptance_scenarios\`, \`non_goals\`, \`related_specs\`, \`proposals\`, \`supersedes\`, \`superseded_by\`. If a field you want to reference isn't in that list, you are about to hallucinate — pause and rephrase the advice as a CLI / workflow action instead.

--- a/packages/llm-anthropic/src/prompts/plate.test.ts
+++ b/packages/llm-anthropic/src/prompts/plate.test.ts
@@ -16,12 +16,12 @@ describe("PLATE_AMENDMENT_SYSTEM shape branching (sc#82)", () => {
     expect(out).toContain("No `'use client'`");
   });
 
-  it("Vite override warns the model that legacy Hard Rules below don't apply", () => {
+  it("Vite override warns the model that preceding nextjs Hard Rules below don't apply", () => {
     const out = PLATE_AMENDMENT_SYSTEM("(ctx)", "vite");
     expect(out).toContain("describe the LEGACY shape and do NOT apply here");
   });
 
-  it("nextjs shape leaves the legacy conventions visible", () => {
+  it("nextjs shape leaves the Hard Rules visible", () => {
     const out = PLATE_AMENDMENT_SYSTEM("(ctx)", "nextjs");
     expect(out).toContain("@slowcook-ai/mock-runtime");
   });


### PR DESCRIPTION
Two changes:

1. **`legacy` → `freehand` rename** (clean, no back-compat). `--mode legacy` hard-errors pointing at the new name. The old name suggested "deprecated" on a tool that's only a few months old; `freehand` honestly describes the mode (wide-scope edits in one brew session).

2. **Navigator-default-on when mode=freehand**. Wide scope = more drift risk. Plate keeps opt-in (plate's hardcoded allowed_paths is its own guardrail). New `--without-navigator` flag for budget-constrained opt-out.

## Test plan

- [x] 1012/1012 cli tests
- [x] 5/5 eval fixtures
- [x] Build + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)