### PR TITLE
cli α.54: chef owns test infrastructure (closes ownership gap)

### DIFF
--- a/packages/cli/src/commands/chef/drift-fix.test.ts
+++ b/packages/cli/src/commands/chef/drift-fix.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseBrewHaltOutput, collectImportedSourceFiles, resolveImportToFile } from "./drift-fix.js";
+import {
+  parseBrewHaltOutput,
+  collectImportedSourceFiles,
+  resolveImportToFile,
+  isFrozenPath,
+} from "./drift-fix.js";
 
 describe("parseBrewHaltOutput", () => {
   it("extracts FAIL <path> entries", () => {
@@ -184,5 +189,57 @@ describe("resolveImportToFile", () => {
   it("falls through to /index.ts when X.{ts,tsx} doesn't exist", () => {
     const r = resolveImportToFile("@/lib", "src/foo.test.ts", "/repo", exists);
     expect(r).toBe("/repo/src/lib/index.ts");
+  });
+});
+
+describe("isFrozenPath (α.54 — chef owns test infrastructure)", () => {
+  // Spec-contract assertions stay frozen — these encode "story done".
+  it.each([
+    "tests/integration/story-003.test.ts",
+    "tests/integration/story-003-ui.test.tsx",
+    "tests/schema/story-003-column-presence.test.ts",
+    "tests/acceptance/story-007.spec.ts",
+  ])("flags assertion path as frozen: %s", (p) => {
+    expect(isFrozenPath(p)).toBe(true);
+  });
+
+  // Slowcook-managed artifacts stay frozen — other agents derive from them.
+  it.each([
+    ".brewing/code-map.json",
+    ".brewing/code-map.md",
+    ".brewing/code-map.target.md",
+    ".brewing/recon-result.json",
+    ".brewing/history-index.json",
+    ".brewing/auto-gen/foo.json",
+  ])("flags slowcook-managed artifact as frozen: %s", (p) => {
+    expect(isFrozenPath(p)).toBe(true);
+  });
+
+  // Test INFRASTRUCTURE is NOT frozen — chef can fix the runner machinery.
+  it.each([
+    "tests/helpers/render.tsx",
+    "tests/helpers/a11y.ts",
+    "tests/helpers/mocks/fetch.ts",
+    "tests/helpers/mocks/index.ts",
+    "tests/setup.ts",
+    "vitest.setup.ts",
+    "vitest.config.ts",
+    "vitest.config.mjs",
+    "playwright.config.ts",
+    "package.json",
+    "tsconfig.json",
+  ])("does NOT flag infra path as frozen: %s", (p) => {
+    expect(isFrozenPath(p)).toBe(false);
+  });
+
+  // Source files — never frozen.
+  it.each([
+    "src/components/patient/chat/PatientChatPage.tsx",
+    "src/lib/data/patient.ts",
+    "src/app/api/patients/me/route.ts",
+    "apps/back/src/modules/appointment/appointment.controller.ts",
+    "supabase/migrations/00042_chat.sql",
+  ])("does NOT flag source path as frozen: %s", (p) => {
+    expect(isFrozenPath(p)).toBe(false);
   });
 });

--- a/packages/cli/src/commands/chef/drift-fix.ts
+++ b/packages/cli/src/commands/chef/drift-fix.ts
@@ -8,9 +8,17 @@
  * ChefVerdict, applies edits surgically, validates, commits, posts an
  * audit comment.
  *
- * Frozen surface (HARD): never edits tests/, vitest.config.*,
- * .brewing/{auto-gen}/. If a fix requires test edits → escalates to PM
- * via a two-option pm_comment (option B = `testgen --regenerate`).
+ * Frozen surface (HARD): tests/integration/, tests/schema/,
+ * tests/acceptance/ (spec-contract assertions) + .brewing/auto-gen/,
+ * .brewing/code-map.*, .brewing/recon-result.json, .brewing/history-
+ * index.json (slowcook-managed artifacts). If a fix requires an
+ * ASSERTION change → escalates to PM via pm_comment (option B =
+ * testgen --regenerate).
+ *
+ * NOT frozen (α.54 — chef owns test infrastructure):
+ * tests/helpers/, vitest.config.*, playwright.config.*, package.json
+ * (devDeps), tsconfig.json, setup files. Chef can fix the runner
+ * machinery freehand.
  *
  * Ledger at .brewing/chef/<story-id>.json tracks moves + cost. Cycle
  * detection + budget cap enforce convergence.
@@ -73,16 +81,56 @@ interface ChefLedger {
   halt_reason: string | null;
 }
 
+/**
+ * Paths chef MAY edit even though they "live under tests/" or look
+ * config-shaped. α.54: chef gains ownership of test INFRASTRUCTURE —
+ * runner config, helpers, setup files — because those are
+ * agent-fixable failures that previously had no owner.
+ *
+ * Principle: tests encode the spec CONTRACT (the assertions that
+ * define what "story-N done" means). Their enforcement MACHINERY
+ * (vitest config, helpers, setup) is not the contract. Distinguishing
+ * by file content/location, not by folder.
+ *
+ * Caught dogfooding delgoosh#656 — chef diagnosed a missing JSX
+ * transform but couldn't fix vitest.config.ts. PM, brew, testgen,
+ * and chef were ALL blocked from owning it. α.54 closes that gap by
+ * giving chef the editing rights.
+ */
+const TEST_INFRA_ESCAPE_PATTERNS = [
+  /^tests\/helpers\//,                  // render, a11y, mock helpers
+  /^tests\/setup\.(ts|tsx|js)$/,        // vitest globalSetup / setupFiles
+  /^vitest\.setup\.(ts|tsx|js)$/,
+];
+
+/**
+ * Paths chef NEVER edits:
+ *   - tests/integration/**, tests/schema/**, tests/acceptance/** —
+ *     spec-contract assertions. If a test is wrong, the right fix is
+ *     testgen --regenerate, not chef rewriting the assertion.
+ *   - .brewing/auto-gen/**, code-map, history-index, recon-result —
+ *     slowcook-managed artifacts other agents derive from.
+ *
+ * vitest.config.*, playwright.config.*, package.json, tsconfig.json
+ * are NOT frozen — they're infra chef can fix.
+ */
 const FROZEN_PATH_PATTERNS = [
-  /^tests\//,
-  /^vitest\.config\.(ts|mjs|js)$/,
+  /^tests\/integration\//,
+  /^tests\/schema\//,
+  /^tests\/acceptance\//,
   /^\.brewing\/code-map\.(json|md|target\.md)$/,
   /^\.brewing\/recon-result\.json$/,
   /^\.brewing\/history-index\.json$/,
   /^\.brewing\/auto-gen\//,
 ];
 
-function isFrozenPath(path: string): boolean {
+export function isFrozenPath(path: string): boolean {
+  // α.54 — explicit escapes win first. A file under tests/helpers/
+  // shouldn't be caught by a generic tests/ rule (and the new
+  // FROZEN_PATH_PATTERNS list above is already specific to assertion
+  // subfolders, but keeping the escape-first check makes the policy
+  // intent visible at the call site for future readers).
+  if (TEST_INFRA_ESCAPE_PATTERNS.some((re) => re.test(path))) return false;
   return FROZEN_PATH_PATTERNS.some((re) => re.test(path));
 }
 
@@ -258,7 +306,7 @@ Options:
                            audit comment on the PR (not the source issue).
 
 Requires: ANTHROPIC_API_KEY in env. Run from consumer repo root.
-Frozen surface: tests/, vitest.config.*, .brewing/{auto-gen}/ — never edited.
+Frozen surface: tests/{integration,schema,acceptance}/ + .brewing/{auto-gen,code-map,history-index,recon-result} — never edited. Test INFRA (tests/helpers/, vitest.config.*, package.json devDeps, setup files) IS chef's to edit (α.54).
 `);
 }
 

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.21",
+  "version": "0.16.0-alpha.22",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/chef.ts
+++ b/packages/llm-anthropic/src/prompts/chef.ts
@@ -7,7 +7,11 @@
  * + mockup PR + prod src/ to converge the story, OR escalates a focused
  * two-option question to PM when intent is genuinely ambiguous.
  *
- * Chef NEVER edits tests/, vitest.config.*, or .brewing/auto-gen artifacts.
+ * Chef NEVER edits test ASSERTIONS (tests/integration/, tests/schema/,
+ * tests/acceptance/) or .brewing/auto-gen / .brewing/code-map / .brewing/
+ * history-index / .brewing/recon-result artifacts. Test INFRASTRUCTURE
+ * (tests/helpers/, vitest.config.*, package.json devDeps, setup files)
+ * IS chef's to edit freehand — α.54.
  * If a fix requires test edits, chef escalates to PM (B-path: dispatch
  * testgen --regenerate; chef does not write tests directly).
  *
@@ -105,15 +109,25 @@ When \`kind === "pm_question"\`: provide \`pm_comment\` (the issue body to post)
 
 When \`kind === "halt"\`: you've decided this is unresolvable without higher-level intervention. Provide \`rationale\` explaining why; \`edits\` empty; \`pm_comment\` may include a halt-summary message.
 
-## The frozen surface (HARD RULE)
+## What chef may edit (α.54 — chef owns test infrastructure)
 
-You may NOT include any edit whose \`file\` matches:
-- \`tests/\` (any path under)
-- \`vitest.config.ts\`, \`vitest.config.mjs\`, \`vitest.config.js\`
-- \`.brewing/code-map.json\`, \`.brewing/code-map.md\`, \`.brewing/code-map.target.md\`, \`.brewing/recon-result.json\`, \`.brewing/history-index.json\`
-- Any path under \`.brewing/auto-gen/\`
+You CAN edit, freehand:
+- All source files under \`src/\`, \`mock/src/\`, \`apps/**\`, \`packages/**\`
+- All migrations (\`supabase/migrations/**\`, TypeORM \`*/migrations/**\`)
+- Test INFRASTRUCTURE (these were previously frozen — α.54 unfreezes):
+  - \`tests/helpers/**\` — render, a11y, mock helpers, scaffolding
+  - \`tests/setup.{ts,tsx,js}\`, \`vitest.setup.{ts,tsx,js}\` — setup files
+  - \`vitest.config.{ts,mjs,js}\`, \`playwright.config.{ts,mjs,js}\` — runner config
+  - \`package.json\` (add missing devDeps like jsdom, @testing-library/react, plugin-react)
+  - \`tsconfig.json\` (test-related paths)
 
-If your decision tree concludes a test edit is required, return \`kind === "pm_question"\` with two options posted to PM, where option B is "re-run testgen with canonical name X — testgen rewrites the test cleanly." NEVER include a test file in \`edits\`.
+You may NOT edit (these stay frozen — HARD RULE):
+- **Test ASSERTIONS** — \`tests/integration/**\`, \`tests/schema/**\`, \`tests/acceptance/**\` — these encode the spec contract. If a test assertion is wrong, the right fix is \`testgen --regenerate\`, not chef rewriting the assertion (which would mask the underlying bug).
+- **Slowcook-managed artifacts** — \`.brewing/code-map.{json,md,target.md}\`, \`.brewing/history-index.json\`, \`.brewing/recon-result.json\`, anything under \`.brewing/auto-gen/\`. These are derived from other agents' work; editing them by hand creates inconsistent state.
+
+The principle: **the test assertions are the contract; the enforcement machinery is not**. Vitest can't transform JSX without \`@vitejs/plugin-react\` — the test asserting JSX rendered is the contract, the config that lets vitest load JSX is infra. Chef owns the infra.
+
+If your decision tree concludes a test ASSERTION (under tests/integration/**, tests/schema/**, tests/acceptance/**) needs to change, return \`kind === "pm_question"\` with two options posted to PM, where option B is "re-run testgen with canonical name X." NEVER include an assertion file in \`edits\`. For test INFRASTRUCTURE (helpers, config, setup, deps), just edit it freehand — the audit comment + git diff are the post-hoc review channel.
 
 ## Decision tree — how to choose your move
 
@@ -141,7 +155,7 @@ When \`trigger.kind === "brew_halt_class"\`, look for these fields in \`trigger.
 
 - \`failing_test_files[]\` — array of test file paths that were red when brew halted. ALL of these must pass after your edits.
 - \`failing_test_names[]\` — the specific \`describe > it\` paths that failed. Helps narrow down which assertion to satisfy.
-- \`failing_test_contents{}\` — \`{testFile: fullText}\` map of every failing test file. Read these first; they are your contract. **You must not edit any file in this map** (\`tests/\` is frozen).
+- \`failing_test_contents{}\` — \`{testFile: fullText}\` map of every failing test file. Read these first; they are the spec contract. **You must not edit any file in this map** — these are test ASSERTIONS, not infrastructure. If a contract is wrong, use pm_question + testgen --regenerate.
 - \`source_file_contents{}\` — \`{srcFile: fullText}\` of every non-test file imported by the failing tests. These are the files you MAY edit. Plan \`search_replace\` pairs against the literal text in this map — the find string must appear exactly once.
 - \`brew_mode\` — string. Either \`"freehand"\` (no allowed_paths restriction; you can create files anywhere) or \`"plate"\` (brew restricted to a hardcoded set; see below) or \`"auto"\` (resolves to one of the prior two at dispatch).
 - \`allowed_paths\` — array of glob patterns brew enforced at iteration time. EMPTY ARRAY means no restriction (freehand mode). For plate mode the hardcoded list today is \`["src/lib/data/**", "src/app/api/**", "supabase/migrations/**", "tests/**"]\`.
@@ -306,7 +320,7 @@ That's it. Slowcook applies the edits, runs the validation, commits if exit-zero
 
 - You do not generate creative content. You don't write new components or new test bodies. You make small surgical edits to existing artifacts.
 - You do not merge PRs or close issues.
-- You do not edit tests/ even if you think the test is wrong. Escalate via pm_question + B-path instead.
+- You do not edit test ASSERTIONS (under tests/integration/**, tests/schema/**, tests/acceptance/**) even if you think the test is wrong. Escalate via pm_question + B-path (testgen --regenerate) instead. Test INFRASTRUCTURE (tests/helpers/, vitest.config.*, package.json devDeps, setup files) IS yours to fix — α.54.
 - You do not output multiple JSON objects. ONE object per invocation. If multiple problems exist, address the most-blocking one first; subsequent invocations will surface the next.
 - You do not assume the slowcook pipeline's vocabulary. If the input doesn't define a term, treat it as opaque and route to pm_question.
 


### PR DESCRIPTION
Closes a real ownership gap: when test infra is broken (vitest.config.*, helpers, package.json devDeps), no agent could fix it. Brew was constrained by allowed_paths, chef by frozen-paths, testgen doesn't touch infra, PM was the only fallback. Caught dogfooding delgoosh#656 where chef diagnosed perfectly but couldn't act.

Distinguishing principle: **test assertions are the contract; the enforcement machinery is not**.

- Stay frozen: tests/integration/**, tests/schema/**, tests/acceptance/** (contract) + .brewing slowcook-managed artifacts
- Unfrozen for chef: tests/helpers/, vitest.config.*, playwright.config.*, package.json (devDeps), tsconfig.json, setup files

Audit comment + git diff are the post-hoc review channel for chef's infra edits.

## Test plan
- [x] 26 new isFrozenPath unit tests covering all 4 categories
- [x] 1038/1038 cli tests
- [x] 5/5 eval fixtures
- [x] Build + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)