### PR TITLE
α.56 — chef-drift enriches from iteration_diffs when runner_output absent

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.53",
+  "version": "0.19.0-alpha.56",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/brew/agent.ts
+++ b/packages/cli/src/commands/brew/agent.ts
@@ -159,6 +159,11 @@ export interface NavigatorHookInput {
   gainedTests: string[];
   /** Repo root, so the hook can read additional context if needed. */
   repoRoot: string;
+  /**
+   * α.55 — the test id the iteration was targeting. Navigator scopes
+   * concerns to this target; non-target concerns are warn-only.
+   */
+  targetTestId?: string;
 }
 
 export interface NavigatorHookVerdict {
@@ -1065,6 +1070,8 @@ export async function runBrew(ctx: BrewContext): Promise<BrewOutcome> {
         rationale: turnResult.rationale,
         gainedTests: gains,
         repoRoot: ctx.repoRoot,
+        // α.55 — scope navigator's concerns to the iteration target.
+        targetTestId: currentTarget ?? undefined,
       });
       const navDecision = decideNavigatorAction(navVerdict);
       spendUsd += navDecision.costUsd;

--- a/packages/cli/src/commands/brew/index.ts
+++ b/packages/cli/src/commands/brew/index.ts
@@ -387,12 +387,34 @@ export async function brew(argv: string[], cliVersion: string): Promise<void> {
         const specYaml = existsSync(specYamlPath) ? readFileSync(specYamlPath, "utf8") : undefined;
         const apiContract = (spec as unknown as { api_contract?: Array<{ method: string; path: string; description?: string }> })
           .api_contract;
+        // α.55 — give navigator a bounded list of source files that
+        // exist right now so it can presence-check claims about absence
+        // instead of hallucinating. Bounded to src/ + mock/src/ tsx/ts
+        // files to keep the prompt reasonable.
+        const knownSourceFiles: string[] = [];
+        const collectKnown = (dir: string, rel: string): void => {
+          if (!existsSync(dir)) return;
+          for (const name of readdirSync(dir)) {
+            const abs = join(dir, name);
+            const r = rel ? `${rel}/${name}` : name;
+            const st = statSync(abs);
+            if (st.isDirectory()) {
+              if (name === "node_modules" || name.startsWith(".")) continue;
+              collectKnown(abs, r);
+            } else if (/\.(tsx?|jsx?)$/.test(name)) {
+              knownSourceFiles.push(r);
+            }
+          }
+        };
+        collectKnown(join(args.repoRoot, "src"), "src");
+        collectKnown(join(args.repoRoot, "mock/src"), "mock/src");
         return {
           mockFiles,
           codeMapDigest,
           storyTestIds: [],
           apiContract,
           specYaml,
+          knownSourceFiles,
         };
       },
     });

--- a/packages/cli/src/commands/brew/pair-navigator.ts
+++ b/packages/cli/src/commands/brew/pair-navigator.ts
@@ -97,6 +97,13 @@ export interface PairNavigatorOptions {
     apiContract?: NavigatorPromptArgs["apiContract"];
     crossStoryFiles?: string[];
     specYaml?: string;
+    /**
+     * α.55 — list of source-file paths present in the repo at the
+     * time of this iteration. Navigator uses this to ground absence
+     * claims (must NOT assert a path is absent unless it's missing
+     * from this list AND the diff doesn't create it).
+     */
+    knownSourceFiles?: string[];
     priorVerdicts?: NavigatorPromptArgs["priorVerdicts"];
   } | null>;
 }
@@ -151,9 +158,13 @@ export function createPairNavigatorHook(options: PairNavigatorOptions): Navigato
         mockFiles: context.mockFiles ?? [],
         codeMapDigest: context.codeMapDigest ?? "",
         storyTestIds: context.storyTestIds ?? [],
+        // α.55 — scope concerns to the current iteration's target.
+        targetTestId: input.targetTestId,
         apiContract: context.apiContract,
         crossStoryFiles: context.crossStoryFiles,
         specYaml: context.specYaml,
+        // α.55 — let navigator presence-check files it might claim absent.
+        knownSourceFiles: context.knownSourceFiles,
         priorVerdicts: context.priorVerdicts,
       };
       const prompt = buildNavigatorPrompt(promptArgs);

--- a/packages/cli/src/commands/chef/drift-fix.ts
+++ b/packages/cli/src/commands/chef/drift-fix.ts
@@ -790,8 +790,36 @@ export async function chefDrift(argv: string[], cliVersion: string): Promise<voi
   // material it needs to write surgical search_replace pairs.
   if (args.triggerKind === "brew_halt_class") {
     const runnerOutput = (triggerRaw["runner_output"] as string | undefined) ?? args.triggerDetail;
+    // α.56 — when runner_output is absent (typical for AGENT_STALLED /
+    // ITERATION_CAP halts where there's no vitest failure to parse),
+    // derive failing-test files from iteration_diffs[].target_test_id.
+    // Format: "tests/path/file.test.ts > suite > name" — split on " > "
+    // and take part[0] as the test file path. The same enrichment then
+    // loads file contents + imported source files. Without this, chef
+    // hallucinates target file contents (seen 2026-05-26 dogfood:
+    // delgoosh#003 chef invented two different "stub" source bodies).
+    let failingFiles: string[] = [];
+    let failingTestNames: string[] = [];
     if (typeof runnerOutput === "string" && runnerOutput.length > 0) {
-      const { failingFiles, failingTestNames } = parseBrewHaltOutput(runnerOutput);
+      const parsed = parseBrewHaltOutput(runnerOutput);
+      failingFiles = parsed.failingFiles;
+      failingTestNames = parsed.failingTestNames;
+    } else if (Array.isArray(triggerRaw["iteration_diffs"])) {
+      const diffs = triggerRaw["iteration_diffs"] as Array<{ target_test_id?: string }>;
+      const filesSet = new Set<string>();
+      const namesSet = new Set<string>();
+      for (const d of diffs) {
+        const tid = d?.target_test_id;
+        if (typeof tid !== "string" || tid.length === 0) continue;
+        const parts = tid.split(" > ");
+        const file = parts[0]!.trim();
+        if (file) filesSet.add(file);
+        if (parts.length > 1) namesSet.add(parts.slice(1).join(" > "));
+      }
+      failingFiles = Array.from(filesSet);
+      failingTestNames = Array.from(namesSet);
+    }
+    if (failingFiles.length > 0) {
       const failingTestContents: Record<string, string> = {};
       for (const f of failingFiles) {
         const abs = join(args.repoRoot, f);

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0-alpha.22",
+  "version": "0.16.0-alpha.23",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/src/prompts/navigator.ts
+++ b/packages/llm-anthropic/src/prompts/navigator.ts
@@ -65,6 +65,26 @@ If you find no concerns, return \`{"axes": [], "overall": "approve", "rationale"
 
 Don't overuse blocking. Reserve for "this would ship something wrong." If unsure → warn.
 
+## Scope discipline (α.55 — load-bearing)
+
+You will receive a \`target_test_id\` (the specific test this iteration was trying to flip green) and \`story_test_ids\` (all tests in the story). Your concerns MUST be scoped to the target test:
+
+- A concern is **blocking** only when it pertains to satisfying the **target test** AND the driver's diff would fail that target test if landed.
+- A concern about a NON-target test in story_test_ids is at most **warn** — that target is for a future iteration; blocking this iter prevents the driver from ever reaching it.
+- If your only concerns are about non-target tests, return \`overall: "warn"\` or \`overall: "approve"\`, not \`block\`. The brew loop will iterate through other targets; your job is not to enforce them all at once.
+
+Example failure mode this rule prevents (delgoosh#656 run 26399359890): target test asserted "page file imports PatientChatPage from @/components/patient/chat/PatientChatPage". Driver wrote exactly that. Navigator blocked because "page passes empty threads array, breaks thread-list test" — but thread-list was a DIFFERENT target. 10 iterations blocked, 0 progress, $1.17 burned. Correct verdict would have been \`approve\` (target test satisfied) with a \`warn\` axis flagging the threads question for the future iteration that targets it.
+
+## Hallucination discipline (α.55)
+
+You DO NOT have file-existence tools. To assert a file is absent you MUST cite explicit evidence:
+- The file's path is NOT in the \`known_source_files\` list provided in the user message, AND
+- The diff does not create it.
+
+If neither condition holds, do not assert absence. Say "presence not verified by my inputs" if you must mention it at all, and downgrade the severity.
+
+False absence claims cascade — chef trusts navigator's claim, posts a misdiagnosis comment to PM, real bug stays hidden. Same delgoosh#656 run: 3 of 10 navigator concerns asserted \`PatientChatPage.tsx does not exist\`; it had been on main since the testgen merge.
+
 ## What to look at, by axis
 
 ### design_fidelity
@@ -232,14 +252,33 @@ export interface NavigatorPromptArgs {
   mockFiles: Array<{ path: string; content: string }>;
   /** Code-map digest of existing components / helpers / routes that may be relevant. */
   codeMapDigest: string;
-  /** Story's test ids (so navigator can predict pass/fail). */
+  /** Story's full test id list (manifest scope). */
   storyTestIds: string[];
+  /**
+   * α.55 — the test id the current iteration was targeting. Navigator
+   * concerns about OTHER tests in storyTestIds are out-of-scope for
+   * this iteration; downgrade them to warn or skip entirely. Without
+   * this scoping, navigator flags concerns about thread-list tests
+   * while the driver is correctly satisfying the page-integration
+   * test → blocks productive work (delgoosh#656 run 26399359890,
+   * 10/10 iters blocked).
+   */
+  targetTestId?: string;
   /** Spec's api_contract entries (for the api_contract axis). */
   apiContract?: Array<{ method: string; path: string; description?: string }>;
   /** Files used by other stories' tests (cross-story risk). */
   crossStoryFiles?: string[];
   /** Spec yaml text (so navigator can ground api_contract / acceptance claims). */
   specYaml?: string;
+  /**
+   * α.55 — paths of source files known to exist in the repo at the time
+   * of this iteration. Navigator MUST consult this before asserting a
+   * file is absent. Hallucinated absence claims were a major source of
+   * false blocks (delgoosh#656: navigator claimed
+   * `src/components/patient/chat/PatientChatPage.tsx` doesn't exist for
+   * 3 of 10 iters; it had been on main since the testgen merge).
+   */
+  knownSourceFiles?: string[];
   /** Navigator's own verdicts from prior iterations of this story (so it doesn't flip-flop). */
   priorVerdicts?: Array<{ iter: number; overall: NavigatorVerdict["overall"]; axes: Array<Pick<NavigatorAxis, "axis" | "severity" | "summary" | "recommendation">> }>;
 }
@@ -270,9 +309,36 @@ export function buildNavigatorPrompt(args: NavigatorPromptArgs): string {
     sections.push("");
   }
 
+  // α.55 — target test up front so the model anchors concerns to it.
+  if (args.targetTestId) {
+    sections.push("## This iteration's TARGET test\n");
+    sections.push(`\`${args.targetTestId}\``);
+    sections.push("");
+    sections.push(
+      "Your concerns must be scoped to this target. Concerns about other tests in the story manifest are AT MOST `warn` — see Scope discipline in the system prompt."
+    );
+    sections.push("");
+  }
+
   sections.push("## Driver's rationale this iteration\n");
   sections.push(args.driverRationale.trim() || "(none)");
   sections.push("");
+
+  // α.55 — known source files so the model doesn't hallucinate absence.
+  if (args.knownSourceFiles && args.knownSourceFiles.length > 0) {
+    sections.push("## Known source files (presence-verified at iteration start)\n");
+    sections.push(
+      "Each path below exists in the repo right now. Do NOT assert that any of these files are absent. To assert absence of a file NOT in this list, you must also confirm the diff does not create it."
+    );
+    sections.push("");
+    sections.push("```");
+    sections.push(args.knownSourceFiles.slice(0, 200).join("\n"));
+    if (args.knownSourceFiles.length > 200) {
+      sections.push(`# ... (${args.knownSourceFiles.length - 200} more not listed)`);
+    }
+    sections.push("```");
+    sections.push("");
+  }
 
   sections.push("## The iteration's diff\n");
   sections.push("```diff");


### PR DESCRIPTION
## Summary
- AGENT_STALLED / ITERATION_CAP halts don't carry `runner_output`; chef enrichment was no-op → chef hallucinated file contents
- Falls back to `iteration_diffs[].target_test_id` (split on " > ") to locate failing test files, then runs existing enrichment

## Test plan
- [ ] After merge, sync slowcook on delgoosh runner; redispatch brew; brew halts → chef sees `brew-halt enriched: N files` log + actual file contents in prompt + matched search_replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)