### PR TITLE
α.57 — halt artifact carries brew_branch

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.56",
+  "version": "0.19.0-alpha.57",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/brew/agent.ts
+++ b/packages/cli/src/commands/brew/agent.ts
@@ -2450,6 +2450,9 @@ async function haltFor(ctx: BrewContext, args: HaltArgs): Promise<BrewOutcome> {
     // advice instead of hallucinating spec fields.
     brew_mode: ctx.mode,
     allowed_paths: ctx.allowedPaths,
+    // α.57 — branch chef-on-brew-halt should checkout to see brew's
+    // in-progress src/ checkpoints. Without this chef sees only main.
+    brew_branch: ctx.branchName,
     iteration_diffs: iterationDiffs.length > 0 ? iterationDiffs : undefined,
     last_agent_rationale: lastRationale,
     suggested_actions: defaultSuggestedActions(args.reason, {

--- a/packages/cli/src/commands/brew/halt.ts
+++ b/packages/cli/src/commands/brew/halt.ts
@@ -32,6 +32,18 @@ export interface HaltReport {
   brew_mode?: "auto" | "plate" | "freehand";
   /** The `allowedPaths` array brew enforced. Empty array = no restriction. */
   allowed_paths?: string[];
+  /**
+   * α.57 — name of the branch brew committed checkpoints onto + pushed.
+   * Without this, downstream chef-on-brew-halt can't tell which branch
+   * holds the in-progress src/ files; chef checks out main (the
+   * default-branch checkout that chef's workflow performs), then can't
+   * find the files the failing tests import, then HALLUCINATES contents.
+   * Caught 2026-05-26 dogfood: delgoosh#003 chef-drift logged
+   * "brew-halt enriched: 2 failing test file(s), 0 source file(s)" —
+   * source-file resolver couldn't see files that only exist on the
+   * brew branch.
+   */
+  brew_branch?: string;
   /** Full per-iteration diffs. Carries every iteration brewing ran, not just the last few,
    * so post-hoc diagnosis of a stuck loop doesn't lose iters 1..N-3. */
   iteration_diffs?: IterationDiff[];


### PR DESCRIPTION
## Summary
- Halt artifact gains `brew_branch` so downstream chef-on-brew-halt knows which branch carries brew's in-progress src/ files
- Without it, chef sees default-branch state and hallucinates target file contents

## Test plan
- [ ] Pair with delgoosh PR that checks out `brew_branch` in chef-on-brew-halt; verify chef logs N>0 source files + matched search_replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)