### PR TITLE
α.64 — upsert-agent-docs: AGENTS.md managed block + README + .gitignore

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.63",
+  "version": "0.19.0-alpha.64",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ import { runMock } from "./commands/run-mock/index.js";
 import { dispatch } from "./commands/dispatch/index.js";
 import { fixtures } from "./commands/fixtures/index.js";
 import { refreshKnowledge } from "./commands/refresh-knowledge.js";
+import { upsertAgentDocs } from "./commands/upsert-agent-docs.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
 import { budget } from "./commands/budget/index.js";
@@ -138,6 +139,9 @@ async function main(): Promise<void> {
       return;
     case "refresh-knowledge":
       await refreshKnowledge(args.slice(1));
+      return;
+    case "upsert-agent-docs":
+      await upsertAgentDocs(args.slice(1));
       return;
     case "on-spec-merged":
       await onSpecMerged(args.slice(1));

--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -1,0 +1,301 @@
+/**
+ * `slowcook upsert-agent-docs` — α.64
+ *
+ * Writes (or refreshes) a marker-delimited "managed block" inside the
+ * consumer's agent-pointer doc(s) so that ANY visiting AI agent —
+ * Claude Code, Cursor, OpenAI Codex, Windsurf, etc. — discovers the
+ * slowcook methodology + the `.brewing/repo-knowledge/curated/`
+ * goldmine on first read.
+ *
+ * Strategy:
+ *   1. Scan for existing agent-pointer files:
+ *        AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, GEMINI.md,
+ *        .github/copilot-instructions.md
+ *      For each that exists → upsert the managed block (markers below).
+ *   2. If NONE exist → create AGENTS.md as the canonical home.
+ *   3. README.md: add a one-line pointer to AGENTS.md if not present.
+ *   4. .gitignore: ensure `.brewing/repo-knowledge/auto/` is ignored
+ *      and `.brewing/repo-knowledge/curated/` is NOT (auto = derived,
+ *      curated = tracked organizational memory).
+ *
+ * The block is delimited with HTML comments humans wouldn't write by
+ * hand:
+ *   <!-- BEGIN: managed by slowcook upsert-agent-docs — edit outside markers -->
+ *   ...
+ *   <!-- END: managed by slowcook upsert-agent-docs -->
+ *
+ * Idempotent: re-running on a file with the block already present
+ * just refreshes the content between the markers. Content outside is
+ * never touched.
+ *
+ * Called from `slowcook init` automatically AND as a standalone
+ * command for repos that already ran `init` and want to refresh the
+ * block when the canonical content evolves.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const BEGIN_MARKER = "<!-- BEGIN: managed by slowcook upsert-agent-docs — edit outside markers -->";
+const END_MARKER = "<!-- END: managed by slowcook upsert-agent-docs -->";
+
+/** Agent-pointer files we know about. Order matters — first existing
+ *  one is treated as the canonical home; absent → create AGENTS.md. */
+const AGENT_POINTER_PATHS = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".cursorrules",
+  ".windsurfrules",
+  "GEMINI.md",
+  ".github/copilot-instructions.md",
+];
+
+export function buildManagedBlock(): string {
+  return `## Agent methodology + knowledge goldmine
+
+This repo uses [slowcook](https://github.com/aminazar/slowcook) pipeline conventions (refine → testgen → vibe → plate → brew → chef). **You don't need to be a slowcook agent to work here** — these conventions apply to any AI agent doing meaningful work on this repo, including Claude Code, Cursor, OpenAI Codex, Aider, Copilot, and Windsurf.
+
+### Read this BEFORE writing any code
+
+Look in \`.brewing/repo-knowledge/\` — it's the durable organizational memory of this codebase:
+
+#### \`.brewing/repo-knowledge/curated/\` (tracked in git, durable)
+
+Mined from git history + appended by agents over time:
+
+| File | What it gives you |
+|---|---|
+| \`commit-conventions.md\` | active type:scope prefixes used in this repo |
+| \`co-changes.md\` | files that historically change together (temporal coupling the type system can't see) |
+| \`ownership.md\` | top author per top-level directory |
+| \`fix-recipe-seeds.md\` | files with multiple \`fix(*)\` commits — known-fragile hotspots |
+| \`issue-traceability.md\` | \`#N\` → commits map for PM-intent lookup |
+| \`chef-known-fixes.md\` | fix-class catalog written by chef-agent runs (populated as the codebase ages) |
+| \`test-patterns.md\` | preferred testing conventions, observed mock isolation + helper-naming patterns |
+| \`design-conventions.md\` | design-system + token decisions, written by vibe-agent runs |
+
+Treat curated content as **soft signal**: entries carry evidence trails (\`PR #N\`, file path, date) but staleness is for review, not auto-invalidation. An insight like "vitest/config not found means deps missing" stays valid even if vitest.config.ts moves — the insight is about a CLASS of problem, not a snapshot.
+
+#### \`.brewing/repo-knowledge/auto/\` (gitignored, regenerated fresh)
+
+Deterministic extractions of the codebase shape — backend entities, HTTP routes, enums, mock TypeScript types, brand-token vocabulary, migrations, route inventory. Rebuilt by \`slowcook refresh-knowledge\`.
+
+### Methodology TL;DR
+
+| Stage | What it produces |
+|---|---|
+| **refine** | YAML spec from a PM issue (clarifying questions if needed) |
+| **testgen** | Failing integration tests against the spec contract |
+| **vibe** | Mock-UI page that matches the spec's PM intent |
+| **plate** | Reconciliation of mock + tests for the data-layer seam |
+| **brew** | Iterates code until tests pass (with optional pair-brew navigator) |
+| **chef** | Surgical fixes on test infra / drift / brew halts |
+
+The slowcook pipeline opens one branch per stage (\`slowcook/<kind>/story-N\`). You don't have to use slowcook to work on this repo, but conform to the conventions in \`.brewing/repo-knowledge/curated/\` so the agents downstream of you don't have to re-derive them.
+
+### Branch discipline
+
+- **Never push directly to \`main\`.** Branch protection blocks it anyway. Cut a branch, open a PR.
+- Slowcook agents stay on \`slowcook/<kind>/story-N\` branches; non-slowcook agents should use \`<your-name>/<short-description>\`.
+- Don't \`--force-push\` to shared branches. The human PM holds admin bypass for emergencies; agents don't.
+
+### Refreshing the goldmine
+
+Run when you've made structural changes that other agents will need to know about:
+
+\`\`\`bash
+slowcook refresh-knowledge              # rebuilds auto/ + curated/ (~2s on a 1k-commit repo)
+slowcook refresh-knowledge --mine-history  # curated/ only (faster delta-mining)
+slowcook refresh-knowledge --auto       # auto/ only
+\`\`\`
+
+### Contributing back
+
+When you discover a non-obvious convention, fix recipe, or temporal coupling worth recording:
+
+\`\`\`bash
+slowcook knowledge add <your-agent-name> "<one-line claim>" --evidence-pr <N> --evidence-file <path>
+\`\`\`
+
+Or (if you're not running slowcook) edit \`.brewing/repo-knowledge/curated/<topic>.md\` directly with:
+
+\`\`\`
+- (<your-name> · PR #<N> · YYYY-MM-DD) <one-line claim>
+\`\`\`
+
+Knowledge entries are soft signal — agents reading them weight by recency and evidence, not by exact matching. \`slowcook knowledge verify\` flags [PRECARIOUS] entries whose evidence file has moved (but never auto-deletes).
+`;
+}
+
+function upsertBlockInFile(repoRoot: string, relPath: string, blockBody: string, dryRun: boolean): "created" | "refreshed" | "unchanged" {
+  const abs = join(repoRoot, relPath);
+  const wrappedBlock = `${BEGIN_MARKER}\n${blockBody.trim()}\n${END_MARKER}`;
+
+  if (!existsSync(abs)) {
+    if (dryRun) return "created";
+    mkdirSync(dirname(abs), { recursive: true });
+    const header = `# ${basenameStem(relPath)}\n\nDoc for AI coding agents working in this repo.\n\n${wrappedBlock}\n`;
+    writeFileSync(abs, header, "utf8");
+    return "created";
+  }
+
+  const existing = readFileSync(abs, "utf8");
+  if (existing.includes(BEGIN_MARKER) && existing.includes(END_MARKER)) {
+    // Refresh the existing block in place.
+    const before = existing.split(BEGIN_MARKER)[0]!;
+    const after = existing.split(END_MARKER)[1] ?? "";
+    const next = `${before}${wrappedBlock}${after}`;
+    if (next === existing) return "unchanged";
+    if (dryRun) return "refreshed";
+    writeFileSync(abs, next, "utf8");
+    return "refreshed";
+  }
+
+  // No marker yet — append at end (with a divider for clarity).
+  const trailing = existing.endsWith("\n") ? "" : "\n";
+  const next = `${existing}${trailing}\n---\n\n${wrappedBlock}\n`;
+  if (dryRun) return "refreshed";
+  writeFileSync(abs, next, "utf8");
+  return "refreshed";
+}
+
+function basenameStem(relPath: string): string {
+  const fname = relPath.split("/").pop() ?? relPath;
+  return fname.replace(/\.[^.]+$/, "");
+}
+
+const README_POINTER_LINE = "> **AI agents working in this repo:** read [`AGENTS.md`](./AGENTS.md) first.";
+
+function upsertReadmePointer(repoRoot: string, dryRun: boolean): "added" | "already-present" | "no-readme" {
+  const candidates = ["README.md", "Readme.md", "readme.md"];
+  let readmePath: string | null = null;
+  for (const c of candidates) {
+    if (existsSync(join(repoRoot, c))) { readmePath = c; break; }
+  }
+  if (!readmePath) return "no-readme";
+  const abs = join(repoRoot, readmePath);
+  const body = readFileSync(abs, "utf8");
+  if (body.includes("AI agents working in this repo") || body.includes("read [`AGENTS.md`]") || body.includes("[`AGENTS.md`](./AGENTS.md)")) {
+    return "already-present";
+  }
+  if (dryRun) return "added";
+  // Insert after the first `# heading` line (right under the title) so it's visible immediately.
+  const lines = body.split("\n");
+  let inserted = false;
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    out.push(lines[i]!);
+    if (!inserted && /^#\s+/.test(lines[i]!) && i < 3) {
+      out.push("");
+      out.push(README_POINTER_LINE);
+      inserted = true;
+    }
+  }
+  if (!inserted) {
+    // No top heading — prepend
+    out.unshift(README_POINTER_LINE, "");
+  }
+  writeFileSync(abs, out.join("\n"), "utf8");
+  return "added";
+}
+
+function upsertGitignore(repoRoot: string, dryRun: boolean): "added" | "already-present" | "no-gitignore" {
+  const path = join(repoRoot, ".gitignore");
+  if (!existsSync(path)) return "no-gitignore";
+  const body = readFileSync(path, "utf8");
+  // Want: auto/ ignored; curated/ NOT ignored.
+  // If the user has a broad `.brewing/` ignore, leave it; just append
+  // an explicit allowlist for curated/.
+  const needsAuto = !body.includes(".brewing/repo-knowledge/auto/");
+  const needsCuratedAllow = !body.includes("!.brewing/repo-knowledge/curated/");
+  if (!needsAuto && !needsCuratedAllow) return "already-present";
+  if (dryRun) return "added";
+  const block = [
+    "",
+    "# slowcook 0.19.0-α.64 — repo-knowledge layer",
+    "# auto/ is derived (cheap to regenerate); curated/ is durable",
+    "# organizational memory tracked in git.",
+    ".brewing/repo-knowledge/auto/",
+    "!.brewing/repo-knowledge/curated/",
+    "",
+  ].join("\n");
+  const next = body.endsWith("\n") ? body + block : body + "\n" + block;
+  writeFileSync(path, next, "utf8");
+  return "added";
+}
+
+export interface UpsertAgentDocsResult {
+  filesUpserted: Array<{ path: string; action: "created" | "refreshed" | "unchanged" }>;
+  readme: "added" | "already-present" | "no-readme";
+  gitignore: "added" | "already-present" | "no-gitignore";
+}
+
+export function upsertAgentDocsCore(repoRoot: string, opts: { dryRun?: boolean } = {}): UpsertAgentDocsResult {
+  const dryRun = opts.dryRun ?? false;
+  const block = buildManagedBlock();
+
+  const existing = AGENT_POINTER_PATHS.filter((p) => existsSync(join(repoRoot, p)));
+  const filesUpserted: UpsertAgentDocsResult["filesUpserted"] = [];
+
+  if (existing.length === 0) {
+    // No agent doc — create AGENTS.md.
+    const action = upsertBlockInFile(repoRoot, "AGENTS.md", block, dryRun);
+    filesUpserted.push({ path: "AGENTS.md", action });
+  } else {
+    for (const p of existing) {
+      const action = upsertBlockInFile(repoRoot, p, block, dryRun);
+      filesUpserted.push({ path: p, action });
+    }
+  }
+
+  const readme = upsertReadmePointer(repoRoot, dryRun);
+  const gitignore = upsertGitignore(repoRoot, dryRun);
+
+  return { filesUpserted, readme, gitignore };
+}
+
+// --- CLI entry ---
+
+export async function upsertAgentDocs(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  if (args.help) { printHelp(); return; }
+  const result = upsertAgentDocsCore(args.repoRoot, { dryRun: args.dryRun });
+  console.log(`slowcook upsert-agent-docs · ${args.repoRoot}${args.dryRun ? " (dry-run)" : ""}`);
+  for (const f of result.filesUpserted) {
+    console.log(`  ${f.action.padEnd(10)}  ${f.path}`);
+  }
+  console.log(`  README.md   ${result.readme}`);
+  console.log(`  .gitignore  ${result.gitignore}`);
+}
+
+function parseArgs(argv: string[]): { repoRoot: string; dryRun: boolean; help: boolean } {
+  let repoRoot = process.cwd();
+  let dryRun = false;
+  let help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === "--cwd" && next) { repoRoot = next; i++; }
+    else if (a === "--dry-run") { dryRun = true; }
+    else if (a === "--help" || a === "-h") { help = true; }
+  }
+  return { repoRoot, dryRun, help };
+}
+
+function printHelp(): void {
+  console.log(`
+slowcook upsert-agent-docs — write/refresh AGENTS.md managed block
+
+Usage:
+  slowcook upsert-agent-docs [--cwd <path>] [--dry-run]
+
+Detects existing agent-pointer files (AGENTS.md / CLAUDE.md /
+.cursorrules / etc.) and inserts a marker-delimited managed block
+pointing at .brewing/repo-knowledge/curated/. README.md gets a
+one-line pointer to AGENTS.md if missing. .gitignore is updated to
+ignore auto/ but track curated/.
+
+Idempotent: re-running refreshes content inside the markers; outside
+content is never touched.
+`);
+}


### PR DESCRIPTION
Marker-delimited managed block points all AI agents (slowcook or not — Cursor, Claude Code, Copilot, …) at the .brewing/repo-knowledge/curated/ goldmine. Idempotent on existing AGENTS.md (validated on delgoosh: no hand-authored content trampled).