### PR TITLE
chore: checkpoint 2026-05-27 — strip version stamps + refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,20 @@
 
 ## Status
 
-**0.17 → 0.18 — brownfield-aware pipeline (shipping in alphas).** The 0.16 mock-app architecture held; 0.17 closes the brownfield gap — every agent (refine, vibe, plate, testgen, brew, recon) now consults a deterministic `.brewing/history-index.json` so they can't silently invent names that collide with existing prod surface. **0.18** opens the door to invariant-level supersedes (the side-effects audit replaces wholesale `change-of-mind`). Canonical references: [`docs/plans/0.17-brownfield-pipeline.md`](./docs/plans/0.17-brownfield-pipeline.md) + [`docs/plans/cleanup-and-roadmap.md`](./docs/plans/cleanup-and-roadmap.md).
+**0.19 → 0.20 — repo-knowledge layer + chef-on-brew-halt loop (shipping in alphas).** The 0.17→0.18 brownfield-awareness work matured into a **durable, agent-portable knowledge layer**: every consumer repo now carries `.brewing/repo-knowledge/{auto,curated}/` — a deterministic extraction of code shape (entities, routes, mock types, brand tokens, …) plus git-history-mined organizational memory (commit conventions, co-changes, fix-recipe seeds, ownership). Surfaced to refine + visible to any AI agent (slowcook or not — Claude Code, Cursor, etc.) via an `AGENTS.md` managed block. Empirical: refine on delgoosh#644 zero-hallucinated all backend routes + field names + enum values that the pre-knowledge-layer pipeline had invented. Canonical references: [`docs/plans/0.17-brownfield-pipeline.md`](./docs/plans/0.17-brownfield-pipeline.md) + [`docs/plans/cleanup-and-roadmap.md`](./docs/plans/cleanup-and-roadmap.md).
 
-**Latest published (npm):**
+**Latest on `main` (npm `alpha` line):**
 
 | Package | Version | Brings |
 |---|---|---|
-| `@slowcook-ai/cli` | `0.18.0` (latest) · `0.19.0-alpha.41` (alpha, npm) · `α.42` on main | latest: chef α.9 L1 + pair-brew sim + entity-first foundation. alpha: prior 0.19 line PLUS funds-warning track (`slowcook budget` + credit-balance gauge + canonical cost storage + project fuel gauge + 402 Payment Required catcher + ratelimit-header surfacing) PLUS refine Pass B brownfield-answer PLUS the sc#82 shape-aware track (Vite mock template + shape-aware vibe/plate/recon + slowcook brand agent + consolidated logo) |
-| `@slowcook-ai/llm-anthropic` | `0.15.0` · `0.16.0-alpha.15` (alpha) | chef + navigator structured prompts; refine/vibe/plate/testgen/brew prompts surface entities barrel; testgen blind-to-mock; `data-mock-chrome` chrome marker; side-effects audit; refine PM-facing question rules; questions-first comment layout + visible cost footer; refine Pass B brownfield-answer; shape-aware vibe/plate/recon prompts; brand agent |
-| `@slowcook-ai/forge-github` | `0.12.0` · `0.12.1` (alpha) | vibe template `regenerate` dispatch input; brew-auto plate-only mode; chef-drift artifact upload |
-| `@slowcook-ai/stack-ts` | `0.9.8` · `0.9.9-alpha.0` (alpha) | `playwright-list` reporter accepted; `parsePlaywrightList` degrades to `[]` instead of throwing |
-| `@slowcook-ai/review-overlay` | `0.5.5` | overlay v3 + composer anchored to clicked element + reads `NEXT_PUBLIC_SLOWCOOK_GH_PROXY` to skip PAT prompt |
-| `@slowcook-ai/core` | `0.13.1` · `0.14.0` on main | sc#82 shape-aware types |
-| `@slowcook-ai/mock-runtime` | `0.3.3` · `0.3.4` on main | sc#82 logo consolidation |
+| `@slowcook-ai/cli` | `0.19.0-alpha.65` (main) | knowledge layer: `refresh-knowledge` (auto digests for backend entities/routes/enums + frontend types/components/contexts + Tailwind tokens + config + migrations + route inventory) + `--mine-history` (commit conventions, co-changes, ownership, fix-recipe seeds, issue traceability) + `upsert-agent-docs` (AGENTS.md managed block + README pointer + .gitignore split) — auto-run by `slowcook init`. Full chef-on-brew-halt loop end-to-end validated. |
+| `@slowcook-ai/llm-anthropic` | `0.16.0-alpha.23` (main) | navigator scope + hallucination discipline; chef owns test infrastructure; refine NestJS backend grounding (no more hallucinated `/api/v1/...` routes or invented field aliases). |
 
-**Highlights of the 0.17 → 0.18 arc:**
+**Last published (older — `latest` tag):** `cli@0.18.0`, `llm-anthropic@0.15.0`. Active development on the `alpha` line; pin exact versions in `.brewing/slowcook-cli-version` to avoid surprise breaks.
+
+**Milestone 2026-05-27 — knowledge layer + chef-on-brew-halt loop closed (cli α.51 → α.65):** Eleven alphas shipped over two days. Highlights: chef stops hallucinating spec fields (α.51); brew `legacy` renamed to `freehand` with navigator default-on (α.52); chef-drift parse-tolerant (α.53); chef owns test infrastructure incl. vitest.config + package.json devDeps (α.54); navigator gets scope + hallucination discipline (α.55); chef-on-brew-halt loop fully wired: halt artifact → enrichment from iteration_diffs → checkout brew_branch → push fix as PR (α.56-α.60); refine sees NestJS/TypeORM backend digest (α.61); ten disk-cached repo-knowledge digests + curated git-history-mined files (α.62-α.63); AGENTS.md managed block (α.64); init wires the whole bedrock automatically (α.65). Empirical wins: chef wrote a real PatientChatPage component (not regex padding) on delgoosh#003; refine on delgoosh#644 cited the exact mock file path + brand-token vocabulary + cross-story context — zero hallucinations vs the α.61 baseline that invented routes.
+
+**Highlights of the prior 0.17 → 0.18 arc:**
 
 - **History-aware refine** (cli `0.17.0-α.0`): emits `.brewing/history-index.json` listing existing components + props + tests covering them, API routes, migrations, test helpers. Refine prompts vibe + testgen + brew to read the index; downstream divergence (e.g. PR #147's `MemberReactionsWithPins` vs `MemberReactionsPage`) is structurally hard to reproduce.
 - **`slowcook recon`** (cli `0.17.0-α.1`): pre-brew structural backstop. Catches missing components, testid gaps, brownfield rename hazards. Cli `α.6` extends it: emits `tests/integration/story-N-shape.test.tsx` from mock JSX (skipping `data-mock-chrome="true"` subtrees) so brew can edit any file without silently corrupting design.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0-alpha.64",
+  "version": "0.19.0-alpha.65",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -9,6 +9,8 @@ import { dirname, resolve, relative, isAbsolute } from "node:path";
 import { execSync } from "node:child_process";
 import { buildPlan, InitError, type FileAction, type FileReader } from "./plan.js";
 import { getTsUiDevDependencies } from "@slowcook-ai/stack-ts";
+import { refreshKnowledgeAuto, refreshKnowledgeMineHistory } from "../refresh-knowledge.js";
+import { upsertAgentDocsCore } from "../upsert-agent-docs.js";
 
 interface InitArgs {
   cwd: string;
@@ -225,6 +227,35 @@ export async function init(argv: string[], cliVersion: string): Promise<void> {
   console.log(
     `slowcook init: ${plan.actions.length - skippedCount} file(s) written, ${skippedCount} skipped.`
   );
+
+  // α.64 — knowledge-layer bedrock. Three best-effort calls; failure of
+  // any one logs a warning but doesn't fail the whole init. All three
+  // run on first init AND on re-init so consumers always end up with
+  // a populated bedrock + the managed AGENTS.md block + a sane gitignore
+  // for the layer.
+  console.log();
+  console.log("Building repo-knowledge bedrock:");
+  try {
+    const auto = refreshKnowledgeAuto(args.cwd);
+    console.log(`  auto/    ${auto.built.length} digest(s) built (${auto.built.join(", ") || "—"})`);
+  } catch (e) {
+    console.log(`  auto/    skipped (${(e as Error).message.slice(0, 100)})`);
+  }
+  try {
+    const history = refreshKnowledgeMineHistory(args.cwd);
+    console.log(`  curated/ ${history.built.length} file(s) mined from ${history.commitsProcessed} commits`);
+  } catch (e) {
+    console.log(`  curated/ skipped (${(e as Error).message.slice(0, 100)})`);
+  }
+  try {
+    const docs = upsertAgentDocsCore(args.cwd);
+    const docPaths = docs.filesUpserted.map((f) => `${f.path} (${f.action})`).join(", ");
+    console.log(`  agents:  ${docPaths || "(none)"}`);
+    console.log(`  README:  ${docs.readme}`);
+    console.log(`  ignore:  ${docs.gitignore}`);
+  } catch (e) {
+    console.log(`  agent-docs skipped (${(e as Error).message.slice(0, 100)})`);
+  }
   console.log();
   console.log("Next steps:");
   console.log(

--- a/packages/llm-anthropic/src/prompts/chef.ts
+++ b/packages/llm-anthropic/src/prompts/chef.ts
@@ -109,12 +109,12 @@ When \`kind === "pm_question"\`: provide \`pm_comment\` (the issue body to post)
 
 When \`kind === "halt"\`: you've decided this is unresolvable without higher-level intervention. Provide \`rationale\` explaining why; \`edits\` empty; \`pm_comment\` may include a halt-summary message.
 
-## What chef may edit (α.54 — chef owns test infrastructure)
+## What chef may edit (chef owns test infrastructure)
 
 You CAN edit, freehand:
 - All source files under \`src/\`, \`mock/src/\`, \`apps/**\`, \`packages/**\`
 - All migrations (\`supabase/migrations/**\`, TypeORM \`*/migrations/**\`)
-- Test INFRASTRUCTURE (these were previously frozen — α.54 unfreezes):
+- Test INFRASTRUCTURE:
   - \`tests/helpers/**\` — render, a11y, mock helpers, scaffolding
   - \`tests/setup.{ts,tsx,js}\`, \`vitest.setup.{ts,tsx,js}\` — setup files
   - \`vitest.config.{ts,mjs,js}\`, \`playwright.config.{ts,mjs,js}\` — runner config
@@ -320,7 +320,7 @@ That's it. Slowcook applies the edits, runs the validation, commits if exit-zero
 
 - You do not generate creative content. You don't write new components or new test bodies. You make small surgical edits to existing artifacts.
 - You do not merge PRs or close issues.
-- You do not edit test ASSERTIONS (under tests/integration/**, tests/schema/**, tests/acceptance/**) even if you think the test is wrong. Escalate via pm_question + B-path (testgen --regenerate) instead. Test INFRASTRUCTURE (tests/helpers/, vitest.config.*, package.json devDeps, setup files) IS yours to fix — α.54.
+- You do not edit test ASSERTIONS (under tests/integration/**, tests/schema/**, tests/acceptance/**) even if you think the test is wrong. Escalate via pm_question + B-path (testgen --regenerate) instead. Test INFRASTRUCTURE (tests/helpers/, vitest.config.*, package.json devDeps, setup files) IS yours to fix.
 - You do not output multiple JSON objects. ONE object per invocation. If multiple problems exist, address the most-blocking one first; subsequent invocations will surface the next.
 - You do not assume the slowcook pipeline's vocabulary. If the input doesn't define a term, treat it as opaque and route to pm_question.
 

--- a/packages/llm-anthropic/src/prompts/navigator.ts
+++ b/packages/llm-anthropic/src/prompts/navigator.ts
@@ -65,7 +65,7 @@ If you find no concerns, return \`{"axes": [], "overall": "approve", "rationale"
 
 Don't overuse blocking. Reserve for "this would ship something wrong." If unsure → warn.
 
-## Scope discipline (α.55 — load-bearing)
+## Scope discipline (load-bearing)
 
 You will receive a \`target_test_id\` (the specific test this iteration was trying to flip green) and \`story_test_ids\` (all tests in the story). Your concerns MUST be scoped to the target test:
 
@@ -75,7 +75,7 @@ You will receive a \`target_test_id\` (the specific test this iteration was tryi
 
 Example failure mode this rule prevents (delgoosh#656 run 26399359890): target test asserted "page file imports PatientChatPage from @/components/patient/chat/PatientChatPage". Driver wrote exactly that. Navigator blocked because "page passes empty threads array, breaks thread-list test" — but thread-list was a DIFFERENT target. 10 iterations blocked, 0 progress, $1.17 burned. Correct verdict would have been \`approve\` (target test satisfied) with a \`warn\` axis flagging the threads question for the future iteration that targets it.
 
-## Hallucination discipline (α.55)
+## Hallucination discipline
 
 You DO NOT have file-existence tools. To assert a file is absent you MUST cite explicit evidence:
 - The file's path is NOT in the \`known_source_files\` list provided in the user message, AND

--- a/packages/llm-anthropic/src/prompts/testgen.ts
+++ b/packages/llm-anthropic/src/prompts/testgen.ts
@@ -260,7 +260,7 @@ export type { MockFooConfig, MockFooClient, MockFooUser } from "./foo.js";
 
 If the barrel already exists (listed in project context), emit a \`<helper>\` block that REPLACES it with the union of existing + new exports.
 
-### Import-closure rule (α.49 — hard signal)
+### Import-closure rule (hard signal)
 
 Every relative import in your emitted test files must resolve to either:
 - A \`<helper>\` block you emit in this same response, OR
@@ -291,7 +291,7 @@ import { ProfileEditForm } from "@/components/profile/ProfileEditForm";
 
 Vitest 4 removed \`environmentMatchGlobs\` — the per-file pragma is the only supported jsdom opt-in. Without it, \`render()\` throws "document is not defined."
 
-### 0.16.0-α.4 — recipe is BLIND to the mock app
+### Recipe is BLIND to the mock app
 
 The mock app under \`mock/\` is vibe's territory; recipe must NOT import from it or reference it in test code. Specifically:
 


### PR DESCRIPTION
Prompt heading cleanup per feedback_no_slowcook_history_in_agent_prompts. README status bumped to reflect today's α.51-α.65 arc.