### PR TITLE
plan: 0.20 and beyond — slowcook as foundation of AI-native software org

### DIFF
--- a/docs/plans/0.20-and-beyond.md
+++ b/docs/plans/0.20-and-beyond.md
@@ -1,0 +1,338 @@
+# 0.20 and beyond — slowcook as the foundation of an AI-native software org
+
+> **Status: strategy doc, not committed scope.** Captures the next-major-arc thinking after the 0.19.0 stable cut. Written 2026-05-27 by the maintainer + Claude in dialogue; subject to revision as priorities settle.
+
+## Repositioning question
+
+Slowcook today is positioned as a **TDD-first agent harness** — a developer tool. The 0.19.0 cut closed the core pipeline (refine→testgen→vibe→plate→brew→chef + knowledge layer + recovery loop).
+
+The user's roadmap question — PM-tool integration + multi-role human collaboration + ops elasticity + monetization ledger — repositions slowcook as a **team orchestration platform**. That's a meaningfully bigger product.
+
+**Strategic split worth considering:**
+
+- **`@slowcook-ai/*` (open-source, MIT)** — agent harness, pipeline, knowledge layer, chef. Stays free; the foundation.
+- **`@slowcook-ai/team-platform` (commercial, SaaS-style)** — the team-orchestration layer that adds PM-tool adapters, budget, ops, ledger. Could be the monetization channel for the project itself.
+
+This keeps the core honest (real OSS, useful standalone) while a commercial layer funds development. Common pattern: GitLab Core/Premium, Sentry self-host/cloud, Posthog OSS/cloud.
+
+Until that split is decided, the doc below treats everything as "slowcook orbit" — some inside the OSS core, some likely outside.
+
+---
+
+## Themes, ideated
+
+### 1. PM tool integration (the unblock for everything else)
+
+**Current state:** slowcook is GitHub-Issues-first. Issue body = story input, comments = PM-refine dialogue, PRs = stages. The forge abstraction (`@slowcook-ai/forge-github`) means swapping forges is structurally possible; GitLab is a fast-follow.
+
+**The interesting integrations are PM tools, not just forges:**
+
+| Tool | Adoption pattern | Adapter shape |
+|---|---|---|
+| **Linear** | Strong dev-team adoption, clean API | Bi-directional sync: Linear issue ↔ slowcook story; refine PR comments mirror back to Linear |
+| **Jira** | Enterprise-heavy; schema-rich (epics, sprints, workflows, custom fields) | More work — needs schema-mapping layer. Probably a hosted webhook bridge rather than direct API in cli |
+| **Notion** | Doc-first PM teams; weakest issue model | Could read Notion-database rows as story input |
+| **Asana / ClickUp / Monday** | Defer until Linear adapter validates the pattern | — |
+
+**Ideated design (Linear-first):**
+
+1. PM creates Linear ticket with a `slowcook:refine` label
+2. Linear webhook → `slowcook-ai/linear-adapter` (a hosted bridge or self-hosted GH Action) → creates a mirror GitHub issue with the Linear ID in the body + labels `needs-refinement`
+3. slowcook refine runs as usual; spec PR opens
+4. PR comments + status changes mirror back to the Linear ticket
+5. When brew PR merges, Linear ticket auto-moves to Done
+
+Similar products that integrate at this layer:
+- **Replit Agent** — Jira integration; "PM logs ticket, agent works"
+- **Devin (Cognition)** — Linear + Slack
+- **Sweep.dev** — GitHub-native + Linear support
+- **Cursor** — IDE-only, no PM layer
+
+Where slowcook differs from above: those are mostly **single-agent-end-to-end**. Slowcook's pipeline is **multi-stage with human gates** (refine spec merge, mockup merge, tests merge, brew merge). So slowcook's PM integration should expose **each gate as a Linear status transition**, not just "ticket → done".
+
+**Tier 1 priority. Without this, slowcook stays an indie dev tool.**
+
+### 2. Multi-role human interactions (the org around code)
+
+User flagged three roles + asked for more. Real product teams have these natural touchpoints:
+
+| Role | Existing slowcook interaction | Stage | Missing |
+|---|---|---|---|
+| **PM** | Issue → refine → spec PR comments | refine | Sprint planning view; cross-story dependencies |
+| **UI/UX designer** | Element-anchored review overlay on mockup PR → plate | plate | Figma plugin that round-trips comments to plate |
+| **Manual QA** | Bug issue → investigate/sift; brew PR → manual QA recipe (today's `EVALUATING-A-BREW.md`) | investigate, plate, brew | Repro fixture builder; "QA approved" gate |
+| **Engineering lead** | Refined spec PR review | refine merge | Architectural-decision view (cross-spec); migration-impact summarizer |
+| **Security/compliance** | CODEOWNERS on frozen paths | continuous | Auth/PII detection at refine time (auto-flag); SOC2 audit-trail extraction |
+| **DevOps** | None today | deploy | Brew PR → preview-deploy URL → real-world QA |
+| **Data analyst** | None today | refine | Acceptance criterion auto-emission ("emit `track('X')` for this CTA") |
+| **Customer support** | None today | bug-flow entry | Bug-report front-end widget that creates issues + labels |
+| **Sales/marketing** | None today | "marketing-page brew" flow? | Landing-page-from-spec template (heavy hand-tuning needed) |
+| **Finance** | None today | budget read | Story cost roll-up; budget burn-down |
+
+The unifying pattern: **each role has a natural artifact** (Linear ticket, Figma comment, Sentry error, axe scan, latency p99, Stripe charge, customer support ticket) that should route into the slowcook pipeline at the right stage.
+
+**Tier 2 priority overall.** Build the framework via roles 1-3 (PM, designer, QA — already mostly there); leave the rest as plugin slots for community contribution.
+
+Similar products with multi-role thinking:
+- **MetaGPT** — multi-agent role-play (CTO, engineer, QA personas). Interesting prior art; their gap is that the "humans" are simulated, slowcook keeps real humans in the loop.
+- **AutoGen / Crew.AI** — multi-agent orchestration frameworks. Tooling-level; not opinionated about roles.
+- **Linear's "AI assignee" beta** — assigns Linear tickets to an AI agent; minimal pipeline.
+
+### 3. Budgeting (tokens + manhours)
+
+Today slowcook tracks tokens via `specs/story-N.cost.jsonl`. Manhours are NOT tracked.
+
+For an AI-native team, the unified budget is the right abstraction. Both costs are real; both should be visible:
+
+**Story-level (`specs/story-N.budget.yaml`):**
+```yaml
+estimated:
+  tokens_usd: 3.00
+  manhours:
+    pm: 1.0
+    dev_review: 2.0
+    qa: 1.5
+    designer: 0.5
+    eng_lead: 0.5
+actual:
+  tokens_usd: 3.85
+  manhours:
+    pm: 0.5          # answered refine questions efficiently
+    dev_review: 0.8  # slowcook autonomous; review only
+    qa: 1.2
+    designer: 0.0    # mock already had the design
+    eng_lead: 0.3
+```
+
+**Sprint-level (`specs/_budget.yaml`):**
+```yaml
+cap:
+  tokens_usd: 200
+  manhours:
+    pm: 40
+    dev_review: 80
+    qa: 30
+total_committed_stories: [007, 008, 009, ...]
+```
+
+**CLI:**
+- `slowcook budget --story N` — estimated vs actual breakdown
+- `slowcook budget --sprint` — sprint roll-up; burn-down chart
+- `slowcook budget --forecast` — predict next-sprint cost from prior actuals (linear regression on historical story types)
+
+**Manhour tracking input:** doesn't have to be heavy. A `slowcook log-time <story> <role> <hours> [--note "..."]` CLI that appends to the `actual:` block. Or a tiny web form. Or integration with **Toggl / Harvest** for teams already using those.
+
+Calibrating estimates against actuals is the killer feature — agents get cheaper over time; humans get more efficient as the bedrock matures. The dashboard shows BOTH curves; team sees the leverage.
+
+**Tier 1 priority.** Quantifies the value slowcook delivers ("we saved 4 dev-hours this story; spent $3.85 of LLM").
+
+Similar tools:
+- **Linear** — story points, time tracking via integration
+- **Jira** — same
+- **Harvest** — time tracking; GH integration
+- **Forecast** — Linear-affiliated resource planning
+
+What slowcook adds: AGENT-COST AUTOMATIC TRACKING. No other tool combines that with manhour estimates.
+
+### 4. Parallelization
+
+Existing slowcook has **stage-parallel** paths: testgen ‖ vibe fire on spec merge; converge at plate.
+
+What teams actually need is **story-parallel**: 10 stories in a sprint, parallelized across team members + agent lanes.
+
+**Bottlenecks today (in observed order):**
+1. PM bandwidth for refine clarification rounds
+2. Human review of spec PRs (gates everything downstream)
+3. Reviewer bandwidth for brew PRs
+4. Anthropic credit + rate limits (rarely; usually fast at Opus pricing)
+
+**Levers:**
+- **Better digests** (bedrock helps refine make decisions; less back-and-forth with PM) — shipped in 0.19
+- **PR summarization** (auto-emitted EVALUATING-STORY-N.md from spec, populated by `proposals` + `acceptance_scenarios`) — pending follow-up
+- **Story-PR rolling-window** (don't open all 10 brew PRs at once; reviewer fatigue. Open in waves of 3.) — workflow-level orchestration
+- **Risk-weighted review** (a spec touching auth + payments needs eng lead + security; a spec touching only mock UI doesn't) — CODEOWNERS + slowcook-aware
+
+**Tier 2 priority.** Levers exist; framework to use them well doesn't.
+
+### 5. Support team integration (bug-flow front-end)
+
+User's request: bug report → QA repro → bug-fix.
+
+Slowcook already has the bug-flow pipeline: `investigate → recipe --regression → sift → chef-orchestrate`. The missing piece is the FRONT-END — how does a customer bug report actually enter the system.
+
+**Ideated stack:**
+
+1. **In-app feedback widget** (`@slowcook-ai/feedback-widget`):
+   - Drop-in `<FeedbackButton />` React component
+   - Captures: screenshot (html2canvas), console errors, current URL, user role/ID, free-form description
+   - POSTs to a configurable endpoint (could be the consumer's backend or a hosted bridge)
+   - Creates a GitHub issue with body filled from the capture + label `bug:from-customer`
+
+2. **Triage CLI** (`slowcook triage <issue>`):
+   - Reads the issue body
+   - If it has a stack trace → routes to `slowcook investigate`
+   - If it has reproducible steps → routes to `slowcook recipe --regression`
+   - If neither → posts a comment with a triage question
+
+3. **QA repro panel:**
+   - QA opens the bug issue; clicks "start repro session" (slowcook command)
+   - Opens the prod URL via `dev-prod-on-box.sh <branch>` automatically
+   - QA reproduces; clicks "save repro"
+   - Slowcook commits the steps + a video to the issue
+
+4. **Auto-fix attempt:**
+   - Once `recipe --regression` test exists, `slowcook brew` runs against the failing test
+   - If it converges, PR opens
+   - If it halts, chef-on-brew-halt fires (existing as of α.60)
+
+**Similar products:**
+- **Sentry** — error reporting; has issue creation but no auto-fix
+- **Userpilot / Pendo** — user-feedback widgets; route to product team
+- **Linear's bug-from-issue + AI assignee** — closest existing model
+
+**Tier 2 priority.** High value if you have customer-facing software; lower if you're building infra.
+
+### 6. DevOps + elasticity
+
+User's request: stress tests + load sensors → auto-scale + CLI connection.
+
+This is observability + autoscaling. Slowcook is far from this domain today; it's a different product.
+
+**Possible integrations (not slowcook core):**
+
+- **Stress test as brew mode:** spec promises "endpoint handles 100 req/s"; brew implements + a tier-3 test runs `k6 run` against it
+- **Load-sensor → issue auto-emission:** Datadog/Grafana alert webhook → slowcook GitHub issue `bug:performance-regression` → goes through investigate-flow
+- **Autoscale CLI hooks (`@slowcook-ai/ops`):**
+  - `slowcook ops scale up --service api --reason "p99 > 500ms 5min"` — logs the decision in a story + executes via Kubernetes API
+  - `slowcook ops watch --service api --threshold 'p99<300ms'` — sensor that creates issues
+  - Defaults to safe (alert-only) unless explicit `--execute` flag
+
+**Similar products:**
+- **PagerDuty** — incident alerting
+- **Honeycomb's AI assist** — trace analysis
+- **Datadog APM** — observability
+- **Kubernetes HPA** — pod autoscaling
+
+**Tier 3 priority.** Slowcook's edge here is weak; the integrations are useful but the differentiation isn't strong. Probably defer to community plugins (consumer wires their own observability into slowcook's issue webhook).
+
+### 7. Monetization + accounting (the AI-native financial layer)
+
+User's request: income channels (ads, e-commerce, SaaS, donations) + expenditures (ads, dev) → P&L + cashflow + impressions/conversions/CAC.
+
+This is essentially building a STARTUP DASHBOARD inside slowcook for each consumer. Heavy scope.
+
+**Decomposition:**
+
+| Layer | Existing solution | Slowcook integration |
+|---|---|---|
+| Revenue tracking | Stripe, Lemon Squeezy | Read Stripe API → cost ledger |
+| Product analytics | Mixpanel, Amplitude, PostHog | Pull conversion events into ledger |
+| Ad spend | Google Ads, Meta Ads | API pull for spend; manual CAC calc |
+| Accounting | Mercury, Pilot, QuickBooks | Out of scope; slowcook stays read-only |
+| P&L / cashflow | Spreadsheet + above | Auto-aggregate into `slowcook ledger` |
+
+**Ideated CLI:**
+```bash
+slowcook ledger pull              # fetch latest from Stripe + Mixpanel + Ad APIs
+slowcook ledger show              # console table: revenue, expense, P&L, cashflow
+slowcook ledger metrics           # impressions, conversions, CAC, LTV, churn
+slowcook ledger story <N>         # this story's revenue contribution (if attributable)
+```
+
+**Hardest part:** ATTRIBUTION. Which dollars came from which feature? Requires event tagging at refine time + Stripe-event correlation. Most teams don't get this right manually; slowcook could provide a framework.
+
+**Similar products:**
+- **Baremetrics, ChartMogul** — SaaS metrics
+- **Profitwell** — subscription metrics
+- **Stripe Sigma** — SQL on Stripe data
+- **PostHog** — open-source product analytics + paywalled "metrics"
+
+**Tier 3 priority.** Genuinely useful for AI-native orgs but it's a real product on its own. Better as a separate `@slowcook-ai/ledger` package — or a commercial layer entirely (`team-platform`).
+
+---
+
+## Prioritization grid
+
+| Tier | Item | Why this priority |
+|---|---|---|
+| **1 (do next, in order)** | Linear adapter (PM-tool integration) | Without this, slowcook stays a dev tool; PM bandwidth is the #1 bottleneck |
+| 1 | Per-story budget (tokens + manhours) | Quantifies the slowcook value-add; calibrates over time |
+| 1 | Auto-emitted per-story `EVALUATING-STORY-N.md` from spec yaml | Cuts reviewer bottleneck (#3 bottleneck above) |
+| **2 (after Tier 1 lands)** | Multi-role gate framework (Figma plugin, repro panel, CODEOWNERS hooks) | Each role gets its natural artifact; broadens slowcook from dev tool to team platform |
+| 2 | Customer-feedback widget + triage CLI | Closes the bug-flow front-end (the user's "support team" ask) |
+| 2 | Cost forecasting + sprint planning view | Once budget exists, forecasting is cheap; teams will want it immediately |
+| **3 (probably separate products)** | `@slowcook-ai/ops` (autoscale + load sensors) | Different domain; defer to community plugins or a separate package |
+| 3 | `@slowcook-ai/ledger` (monetization + accounting) | Different product entirely; potential commercial offering |
+| 3 | Notion / Jira / Asana adapters | Validate the Linear-adapter pattern first; these come after |
+
+---
+
+## Proposed version cuts
+
+| Version | Theme | Scope |
+|---|---|---|
+| **0.20** | Tier-1 (a): Linear adapter | `@slowcook-ai/linear-adapter` package; Linear webhook → GH issue mirror; status sync back |
+| 0.21 | Tier-1 (b): Per-story budget | `specs/story-N.budget.yaml` schema; `slowcook budget` cli; `log-time` cli |
+| 0.22 | Tier-1 (c): Reviewer summarization | brew auto-emits `EVALUATING-STORY-N.md` populated from spec yaml at PR-open |
+| 0.23 | Tier-2 (a): Designer Figma plugin | Figma comments round-trip to plate |
+| 0.24 | Tier-2 (b): Customer feedback widget | `@slowcook-ai/feedback-widget` React component + triage CLI |
+| 0.25+ | Multi-role CODEOWNERS hooks, cost forecasting, etc. | Tier-2 (c)+ |
+| **1.0** | **See criteria below** | Empirical adoption + stability commitments |
+
+---
+
+## When 1.0?
+
+The original `docs/DESIGN.md` framed 1.0 as "HITL dashboard + end-to-end pipeline validated on a real consumer." That target was effectively achieved by 0.19.0 (knowledge layer + chef-on-brew-halt + end-to-end dogfood validation).
+
+For a HONEST 1.0, propose these criteria (concrete + auditable):
+
+### Adoption
+- [ ] **3+ different consumers** (not just the maintainer's dogfood) using slowcook in production
+- [ ] At least one consumer that ISN'T the maintainer's org has shipped a PR through brew with the bedrock-grounded pipeline
+
+### Stability
+- [ ] **Eval-fixture coverage** for every agent stage (refine + testgen + vibe + plate + brew + chef + recon + navigator) — at least 3 fixtures per agent that catch real regressions
+- [ ] **No CRITICAL bugs open** for 30 consecutive days
+- [ ] **Stable API surface** — cli commands, spec.schema.json, workflow yamls don't break consumers; semver-protected
+- [ ] Each public package has a `BREAKING.md` documenting any forward-incompat from 0.x to 1.0
+
+### Documentation
+- [ ] **Fresh-eyes test passes**: a developer who hasn't seen slowcook can adopt it from README + AGENTS.md + spec schema alone, without DM'ing the maintainer (concrete bar: 1 external dev gets to a green brew without unblocking)
+- [ ] CLAUDE-CODE-PIPELINE-style guide for non-slowcook agents (Cursor / Codex / Aider) — companion to LOCAL-CLAUDE-PIPELINE.md but maintainer-side
+
+### Ecosystem
+- [ ] At least one **Tier-1 PM-tool integration** (Linear or Jira) shipped + battle-tested
+- [ ] Per-story budget infrastructure (Tier-1 b) shipped
+- [ ] Auto-emitted EVALUATING-STORY-N.md from spec yaml (Tier-1 c) shipped
+
+### Commercial separation (if pursued)
+- [ ] OSS / commercial split decided (if `team-platform` is the path): `@slowcook-ai/*` remains MIT; commercial layer in a separate repo + license
+
+**Realistic timing:** if Tier 1 ships across 0.20-0.22 (3 release cycles, ~4-6 weeks each based on the 0.18→0.19 cadence) + 1 external adoption in parallel + eval-fixture buildout, **1.0 is 4-6 months out** (Q3 2026 plausible).
+
+The slower variable is external adoption. Could happen faster if the maintainer markets actively; could take longer if it stays a one-team tool.
+
+---
+
+## Open questions for the maintainer
+
+1. **OSS-only or OSS-core + commercial-layer?** Determines positioning + how big to scope team-platform features.
+2. **Linear or Jira first?** Both are real; Linear is faster (cleaner API, dev-team-aligned); Jira is enterprise-revenue.
+3. **Should the OSS core gain "team" features at all, or stay agent-harness-only?** If commercial-layer is the plan, keep core lean.
+4. **What's the maintainer's appetite for outside contributors?** Determines how many of these features can land in parallel (community PRs) vs how many are single-maintainer work.
+5. **Is `team-platform` a slowcook concern or a different project entirely?**
+
+---
+
+## What this doc is + isn't
+
+- ✓ Ideation + research + prioritization
+- ✓ Concrete enough to commit Tier 1 if maintainer signs off
+- ✓ Honest about which tiers are slowcook-core vs separate products
+
+- ✗ NOT a committed scope yet — maintainer signs off per tier
+- ✗ NOT a marketing plan — that's a separate exercise once positioning settles
+- ✗ NOT a complete pricing/business-model design for `team-platform` — that's a separate dialogue if commercial-layer is pursued
+
+Next decision point: maintainer picks **Linear-adapter (0.20)** OR **per-story budget (0.21)** as the first item, then writes a tighter scoped plan doc (e.g., `0.20-linear-adapter.md`) for the actual implementation.


### PR DESCRIPTION
Strategy doc post-0.19.0. Ideates PM-tool integration, multi-role gates, token+manhour budget, parallelization, support-team front-end, ops elasticity, monetization ledger. Prioritized into Tier 1/2/3. Proposes 0.20/0.21/0.22 scope + 1.0 criteria. Five open questions at the end for maintainer sign-off.