### PR TITLE
fix(refresh-knowledge): strip JSDoc/line comments before parsing enum values

### DIFF
--- a/packages/cli/src/commands/refresh-knowledge.test.ts
+++ b/packages/cli/src/commands/refresh-knowledge.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseEnumValues } from "./refresh-knowledge";
+
+/**
+ * Regression: `buildBackendEnumsDigest` used to inline the value-
+ * extraction logic and the regex didn't strip JSDoc / line comments
+ * before splitting on commas. Enums whose every value had a preceding
+ * JSDoc block (a common consumer convention — observed in
+ * delgoosh/monorepo's `packages/enums/src/appointments-status.enum.ts`)
+ * yielded ZERO parsed values. The whole enum then dropped from
+ * `backend-enums.md`, leaving testgen + refine without an
+ * authoritative source for the value list.
+ *
+ * Symptom on the consumer side:
+ *   $ grep -i AppointmentsStatus .brewing/repo-knowledge/auto/backend-enums.md
+ *   (no output — but the enum exists at packages/enums/src/)
+ *
+ * Surfaced by a local-claude-pipeline session 2026-05-27 while
+ * mimicking testgen for delgoosh story-009 (patient appointment list).
+ */
+describe("parseEnumValues — JSDoc + line-comment handling (regression)", () => {
+  it("parses a JSDoc-decorated enum body without dropping any values", () => {
+    const body = `
+  /**
+   * Appointment slot is available and free to be reserved
+   */
+  FREE = 'FREE',
+
+  /**
+   * Appointment is temporarily reserved before checkout is completed
+   */
+  RESERVED_BEFORE_CHECKOUT = 'RESERVED_BEFORE_CHECKOUT',
+
+  /**
+   * Appointment is confirmed and reserved
+   */
+  RESERVED = 'RESERVED',
+`;
+    expect(parseEnumValues(body)).toEqual([
+      "FREE",
+      "RESERVED_BEFORE_CHECKOUT",
+      "RESERVED",
+    ]);
+  });
+
+  it("parses a plain enum body (no comments) — existing behavior", () => {
+    const body = `
+  ACTIVE = 'ACTIVE',
+  PAUSED = 'PAUSED',
+  ARCHIVED = 'ARCHIVED',
+`;
+    expect(parseEnumValues(body)).toEqual(["ACTIVE", "PAUSED", "ARCHIVED"]);
+  });
+
+  it("strips line comments too (// …) — defensive", () => {
+    const body = `
+  // legacy — kept for backwards-compat
+  LEGACY = 'LEGACY',
+  ACTIVE = 'ACTIVE',
+`;
+    expect(parseEnumValues(body)).toEqual(["LEGACY", "ACTIVE"]);
+  });
+
+  it("ignores values that aren't all-uppercase identifiers (e.g., string-init enums or numeric)", () => {
+    const body = `
+  Active = 'active',
+  Paused = 'paused',
+`;
+    // Existing uppercase-only filter is preserved; this stays as
+    // documentation of intent (slowcook digests target the
+    // SCREAMING_SNAKE convention used in the consumer's enum files).
+    expect(parseEnumValues(body)).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/refresh-knowledge.ts
+++ b/packages/cli/src/commands/refresh-knowledge.ts
@@ -283,6 +283,29 @@ export function buildBackendRoutesDigest(repoRoot: string) {
   });
 }
 
+/**
+ * Parse the values out of an `export enum { … }` body.
+ *
+ * Strips JSDoc block comments + line comments first, then splits on
+ * commas. Without the strip, enums whose every value is preceded by
+ * a JSDoc block (a common convention in the consumer's
+ * `packages/enums/src/*.enum.ts`) would yield zero parsed values —
+ * the JSDoc text leaks into the identifier slot, fails the
+ * uppercase-only filter, and the whole enum drops from the digest.
+ *
+ * Exported for testing.
+ */
+export function parseEnumValues(enumBody: string): string[] {
+  return enumBody
+    // Strip JSDoc / block comments — `/* … */` (incl. multi-line).
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    // Strip line comments — `// …` to end of line.
+    .replace(/\/\/.*$/gm, "")
+    .split(",")
+    .map((v) => v.trim().split("=")[0]!.trim().replace(/['"\s]/g, ""))
+    .filter((v) => v && /^[A-Z_]+$/.test(v));
+}
+
 export function buildBackendEnumsDigest(repoRoot: string) {
   const enumsDir = join(repoRoot, "packages/enums/src");
   const files = existsSync(enumsDir)
@@ -300,10 +323,7 @@ export function buildBackendEnumsDigest(repoRoot: string) {
         const enumMatch = body.match(/export enum (\w+) \{([\s\S]*?)\}/);
         if (!enumMatch) continue;
         const enumName = enumMatch[1]!;
-        const values = (enumMatch[2] ?? "")
-          .split(",")
-          .map((v) => v.trim().split("=")[0]!.trim().replace(/['"\s/*]/g, ""))
-          .filter((v) => v && /^[A-Z_]+$/.test(v));
+        const values = parseEnumValues(enumMatch[2] ?? "");
         if (values.length === 0) continue;
         lines.push(`## ${enumName}`);
         lines.push(values.map((v) => `- ${v}`).join("\n"));


### PR DESCRIPTION
## Bug

`buildBackendEnumsDigest` inlines a value parser that splits the enum body on commas and runs identifiers through an uppercase-only filter. The filter rejects any segment containing lowercase letters — so the moment a JSDoc block precedes an enum value, the JSDoc text leaks into the identifier slot and the value is dropped. If **every** value has a JSDoc block (a common consumer convention), every value gets dropped, the enum's value-list is zero-length, and the entire enum falls out of `backend-enums.md`.

### Symptom (consumer side)

In `delgoosh/monorepo`:

```bash
$ grep -i AppointmentsStatus .brewing/repo-knowledge/auto/backend-enums.md
# (no output)
```

…even though the enum exists at `packages/enums/src/appointments-status.enum.ts` and is exported from the barrel. Every value has a JSDoc block (per the consumer's TS-doc convention):

```ts
export enum AppointmentsStatusEnum {
  /**
   * Appointment slot is available and free to be reserved
   */
  FREE = 'FREE',
  /**
   * Appointment is temporarily reserved before checkout is completed
   */
  RESERVED_BEFORE_CHECKOUT = 'RESERVED_BEFORE_CHECKOUT',
  // …
}
```

Result: `refine` + `testgen` + `brew` had no authoritative source for the enum values. Surfaced by a local-claude-pipeline session 2026-05-27 while mimicking testgen for delgoosh story-009 (patient appointment list — spec references `AppointmentsStatusEnum.RESERVED_BEFORE_CHECKOUT` etc. verbatim).

## Fix

- Extract the value-parsing logic into a pure `parseEnumValues` helper (exported for testing).
- Strip JSDoc / block comments (`/* … */`, multi-line) before splitting.
- Strip line comments (`// …`) too — defensive.
- The uppercase-only filter is preserved (slowcook digests target the consumer's SCREAMING_SNAKE convention).

## Regression test

`packages/cli/src/commands/refresh-knowledge.test.ts` — 4 tests:

1. JSDoc-decorated body parses all values (the original bug shape).
2. Plain enum body still parses (no behavior change for the happy path).
3. Line comments stripped.
4. Lowercase / non-SCREAMING_SNAKE values still filtered.

## Test run

```
Test Files  69 passed (69)
Tests       1042 passed (1042)
```

(Includes the 4 new tests; rest unchanged. Pre-existing `tsc -b` failure on main re: missing `@slowcook-ai/review-overlay` is unrelated — verified by `git stash` + rebuild.)

## Part of a session-batch

This bug was finding #1 of 9 from a single local-claude-pipeline session. The other 8 will land as a feedback issue (one PR per concern per CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)