### PR TITLE
release: 0.19.1 — fix enum-parser JSDoc handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",


### PR DESCRIPTION
Patch release carrying #125. cli 0.19.0 → 0.19.1. Empirical impact: 41 of 45 enums missing from the digest pre-fix; restored to 45/45. First validation of the cross-tool dogfood-feedback loop. 1042/1042 tests passing. After merge: `pnpm publish --filter @slowcook-ai/cli --tag latest --no-git-checks`.