### PR TITLE
fix(init): mention esbuild.jsx automatic in post-run vitest guidance

### DIFF
--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -291,7 +291,10 @@ export async function init(argv: string[], cliVersion: string): Promise<void> {
   console.log("UI testing (tier-1, 0.7.5+):");
   console.log(`  • devDependencies (add to package.json, then \`npm install\`):`);
   console.log(`      npm install -D ${depList}`);
-  console.log(`  • vitest.config.ts — add .tsx to the test include pattern:`);
+  console.log(`  • vitest.config.ts — add .tsx to the test include pattern AND`);
+  console.log(`    enable the automatic JSX runtime (testgen-emitted .tsx test`);
+  console.log(`    files never \`import React\`; without automatic runtime they`);
+  console.log(`    all error with \`ReferenceError: React is not defined\`):`);
   console.log(`      test: {`);
   console.log(`        include: [`);
   console.log(`          "src/**/*.test.ts",`);
@@ -300,7 +303,8 @@ export async function init(argv: string[], cliVersion: string): Promise<void> {
   console.log(`          "tests/**/*.test.ts",`);
   console.log(`        ],`);
   console.log(`        // … your existing setupFiles stay unchanged`);
-  console.log(`      }`);
+  console.log(`      },`);
+  console.log(`      esbuild: { jsx: "automatic" },   // ← add this`);
   console.log(`  • Each .tsx UI test file must start with a jsdom pragma on line 1:`);
   console.log(`      // @vitest-environment jsdom`);
   console.log(`    Vitest 4 removed \`environmentMatchGlobs\`; the per-file pragma is the`);


### PR DESCRIPTION
## Why

The post-run "UI testing (tier-1)" block in \`slowcook init\` already tells the consumer to add the \`.tsx\` glob to \`test.include\` and the \`// @vitest-environment jsdom\` pragma per file. It doesn't mention that **vitest also needs \`esbuild: { jsx: \"automatic\" }\`**.

Without that line, every testgen-emitted \`.tsx\` file errors with \`ReferenceError: React is not defined\` at runtime, because testgen emits no \`import React\` statement.

Silently broken in delgoosh/monorepo since story-003 testgen landed — masked because the story-003 component was still a throwing \`@slowcook-stub\`, so tests failed on import before JSX rendered. The story-009 brew unmasked it; chef-style freehand added the line and captured the fix-class.

## What

Extends the printed guidance block (lines 294–307 of \`packages/cli/src/commands/init/index.ts\`) so first-time consumers wire the runtime correctly without having to hit the failure mode first.

This PR **doesn't patch any consumer file** — init prints guidance, doesn't modify \`vitest.config.ts\` itself. The patch is purely to the post-run console output.

## Diff

\`\`\`diff
-  console.log(\`  • vitest.config.ts — add .tsx to the test include pattern:\`);
+  console.log(\`  • vitest.config.ts — add .tsx to the test include pattern AND\`);
+  console.log(\`    enable the automatic JSX runtime (testgen-emitted .tsx test\`);
+  console.log(\`    files never \\\`import React\\\`; without automatic runtime they\`);
+  console.log(\`    all error with \\\`ReferenceError: React is not defined\\\`):\`);
   …
   console.log(\`        // … your existing setupFiles stay unchanged\`);
-  console.log(\`      }\`);
+  console.log(\`      },\`);
+  console.log(\`      esbuild: { jsx: "automatic" },   // ← add this\`);
\`\`\`

## Tests

Full cli suite still green: 69 files / 1049 tests.

## Context

Part of the local-claude-pipeline session findings — see [#126](https://github.com/aminazar/slowcook/issues/126) finding #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)