### PR TITLE
feat(refine): post-emit lint flags hallucinated entity.field references

### DIFF
--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -30,7 +30,7 @@ export function stripModelEmittedDuplicates(body: string): string {
 }
 import { synthesizeProposalsFromSpec } from "./proposals-synth.js";
 import { writeMockFixtures } from "./mock-fixtures.js";
-import { validateAndRepairSpec } from "./spec-validate.js";
+import { validateAndRepairSpec, validateEntityFieldReferences } from "./spec-validate.js";
 import { SpecProposalsSchema } from "./spec-yaml.js";
 import type {
   ForgeAdapter,
@@ -57,7 +57,7 @@ import {
   SPECS_DIR,
 } from "./spec-yaml.js";
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { buildProjectContext } from "./context.js";
 import {
@@ -458,9 +458,26 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
   // 0.14.0-α.6+ — content-level repair before persisting. Catches LLM
   // truncation that Zod missed (e.g. unterminated `var(--tint-in`).
   const validationFindings = validateAndRepairSpec(spec);
+
+  // 0.19.x+ — catch hallucinated entity.field references against the
+  // auto/backend-entities.md catalog. Best-effort: if the digest is
+  // missing (consumer hasn't run refresh-knowledge yet), skip silently.
+  try {
+    const entityCatalogPath = join(
+      ctx.repoRoot,
+      ".brewing/repo-knowledge/auto/backend-entities.md"
+    );
+    if (existsSync(entityCatalogPath)) {
+      const md = readFileSync(entityCatalogPath, "utf8");
+      validationFindings.push(...validateEntityFieldReferences(spec, md));
+    }
+  } catch {
+    // Never fail spec emit on a lint hiccup.
+  }
+
   if (validationFindings.length > 0) {
     console.warn(
-      `[refine] spec post-emit validation: ${validationFindings.length} finding(s) — corrupt token entries pruned:`
+      `[refine] spec post-emit validation: ${validationFindings.length} finding(s):`
     );
     for (const f of validationFindings) {
       console.warn(`  - ${f.path}: ${f.message} (${f.action})`);

--- a/packages/cli/src/commands/refine/spec-validate.test.ts
+++ b/packages/cli/src/commands/refine/spec-validate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateAndRepairSpec } from "./spec-validate.js";
+import {
+  validateAndRepairSpec,
+  validateEntityFieldReferences,
+  parseEntityCatalog,
+} from "./spec-validate.js";
 import type { Spec } from "@slowcook-ai/core";
 
 function baseSpec(extra: Partial<Spec> = {}): Spec {
@@ -113,5 +117,126 @@ describe("validateAndRepairSpec — token list pruning", () => {
     const spec = baseSpec();
     const findings = validateAndRepairSpec(spec);
     expect(findings).toEqual([]);
+  });
+});
+
+/**
+ * Regression: refine sometimes invents entity fields that don't exist.
+ * Story-005 in delgoosh referenced `user.timezone.label` but the
+ * Timezone entity has only `name`/`offset`/`offsetStr` — no `label`
+ * field. The lint catches this before brew silently grounds against
+ * a non-existent field.
+ */
+const SAMPLE_CATALOG = `
+## User \`packages/postgres/src/entities/user.entity.ts\`
+- firstName: string
+- lastName: string
+- email: string | null
+- timezone?: Timezone
+
+## Timezone \`packages/postgres/src/entities/timezone.entity.ts\`
+- name: string
+- offset: number
+- offsetStr: string
+
+## Appointment \`packages/postgres/src/entities/appointment.entity.ts\`
+- status: AppointmentsStatusEnum
+- startDate: Date
+- therapist: Therapist
+`;
+
+describe("parseEntityCatalog", () => {
+  it("indexes entities by lowercased name with their field set", () => {
+    const map = parseEntityCatalog(SAMPLE_CATALOG);
+    expect(map.get("user")).toEqual(
+      new Set(["firstName", "lastName", "email", "timezone"])
+    );
+    expect(map.get("timezone")).toEqual(
+      new Set(["name", "offset", "offsetStr"])
+    );
+    expect(map.get("appointment")).toEqual(
+      new Set(["status", "startDate", "therapist"])
+    );
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(parseEntityCatalog("")).toEqual(new Map());
+  });
+});
+
+describe("validateEntityFieldReferences", () => {
+  it("flags `user.timezone.label` when Timezone has no `label` field (story-005 regression)", () => {
+    const spec = baseSpec({
+      invariants: [
+        "Timezone display reads `user.timezone.label` (string from Timezone relation), never the raw timezone UUID",
+      ],
+    });
+    const findings = validateEntityFieldReferences(spec, SAMPLE_CATALOG);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("`timezone.label`");
+    expect(findings[0]!.message).toContain("timezone entity has no `label`");
+    expect(findings[0]!.action).toBe("flagged");
+  });
+
+  it("does NOT flag valid chained relation traversals (user.timezone, timezone.name)", () => {
+    const spec = baseSpec({
+      invariants: [
+        "The greeting uses `user.timezone.name` to render the patient's local zone",
+      ],
+    });
+    expect(validateEntityFieldReferences(spec, SAMPLE_CATALOG)).toEqual([]);
+  });
+
+  it("flags only the FIRST occurrence of a given pair (avoids noise across many invariants)", () => {
+    const spec = baseSpec({
+      invariants: [
+        "Show `user.timezone.label` in the header",
+        "Tooltip shows `user.timezone.label` too",
+        "Sort by `user.timezone.label`",
+      ],
+    });
+    const findings = validateEntityFieldReferences(spec, SAMPLE_CATALOG);
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores pairs whose LHS isn't a known entity (avoids false positives on `data.value` etc.)", () => {
+    const spec = baseSpec({
+      invariants: [
+        "The page calls `api.fetch()` and reads `result.items[0].name`",
+      ],
+    });
+    expect(validateEntityFieldReferences(spec, SAMPLE_CATALOG)).toEqual([]);
+  });
+
+  it("walks api_contract response strings + acceptance_scenarios (not just invariants)", () => {
+    const spec = baseSpec({
+      api_contract: [
+        {
+          method: "GET",
+          path: "/user/:id",
+          request_schema: "",
+          responses: {
+            "200":
+              "Response includes user.firstName and user.bogusField for display",
+          },
+        },
+      ],
+      acceptance_scenarios: [
+        "Given a user, when the page renders, then `user.fakeField` is shown",
+      ],
+    });
+    const findings = validateEntityFieldReferences(spec, SAMPLE_CATALOG);
+    const messages = findings.map((f) => f.message).join("\n");
+    // Both bogus refs flagged — across both api_contract AND
+    // acceptance_scenarios sections (not just invariants).
+    expect(messages).toContain("user.fakeField");
+    expect(messages).toContain("user.bogusField");
+  });
+
+  it("returns [] when no catalog is provided (defensive — never errors)", () => {
+    const spec = baseSpec({
+      invariants: ["Reads `user.timezone.label`"],
+    });
+    expect(validateEntityFieldReferences(spec, "")).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/refine/spec-validate.ts
+++ b/packages/cli/src/commands/refine/spec-validate.ts
@@ -109,6 +109,134 @@ function pruneTokenList(
   return out;
 }
 
+/**
+ * 0.19.x+ — catch hallucinated entity.field references in the spec.
+ *
+ * Refine sometimes invents fields that don't exist on the consumer's
+ * actual entities (e.g. story-005 in delgoosh referenced
+ * `user.timezone.label` but Timezone has only `name`/`offset`/`offsetStr`).
+ * Brew + testgen downstream silently grounded against the wrong field,
+ * leading to a runtime error that took a human to spot.
+ *
+ * This lint parses `.brewing/repo-knowledge/auto/backend-entities.md`,
+ * walks every string-typed field of the spec, and for each
+ * `lowercaseName.fieldName` pair where `lowercaseName` matches a known
+ * entity, checks whether `fieldName` is in that entity's field set.
+ * Misses are flagged as `"flagged"` (kept as-is — the spec text isn't
+ * auto-repairable since we don't know what the author meant).
+ *
+ * Chained references like `user.timezone.label` are decomposed into
+ * pairs (`user.timezone`, `timezone.label`); each pair is checked
+ * independently. Relation traversal works because relation field
+ * values are themselves listed in the entity catalog with the
+ * other-entity name as their type.
+ *
+ * Exported for testing.
+ */
+export function parseEntityCatalog(md: string): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  let current: string | null = null;
+  let currentFields: Set<string> | null = null;
+  for (const line of md.split(/\r?\n/)) {
+    const headerMatch = line.match(/^##\s+([A-Z]\w+)\b/);
+    if (headerMatch) {
+      if (current && currentFields) out.set(current, currentFields);
+      // Map by LOWERCASED entity name so spec text like `user.firstName`
+      // resolves to the User entity.
+      current = headerMatch[1]!.toLowerCase();
+      currentFields = new Set<string>();
+      continue;
+    }
+    if (!currentFields) continue;
+    const fieldMatch = line.match(/^-\s+(\w+)\??:/);
+    if (fieldMatch) currentFields.add(fieldMatch[1]!);
+  }
+  if (current && currentFields) out.set(current, currentFields);
+  return out;
+}
+
+/**
+ * Walk every string in a value (recursing into arrays/objects).
+ * Yields each string with a dotted path for diagnostic context.
+ */
+function* walkStrings(
+  value: unknown,
+  path = ""
+): Generator<{ path: string; text: string }> {
+  if (typeof value === "string") {
+    yield { path, text: value };
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      yield* walkStrings(value[i], `${path}[${i}]`);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) {
+      yield* walkStrings(v, path ? `${path}.${k}` : k);
+    }
+  }
+}
+
+export function validateEntityFieldReferences(
+  spec: Spec,
+  entityCatalogMd: string
+): SpecValidationFinding[] {
+  const findings: SpecValidationFinding[] = [];
+  const catalog = parseEntityCatalog(entityCatalogMd);
+  if (catalog.size === 0) return findings; // No catalog → can't lint.
+
+  // Sections worth walking. We deliberately skip free-form metadata
+  // (title, notes, rationale text under proposals) to keep false-
+  // positives low — only fields where field references are LOAD-BEARING.
+  const sections: Array<{ key: keyof Spec; value: unknown }> = [
+    { key: "invariants", value: spec.invariants },
+    { key: "preconditions", value: spec.preconditions },
+    { key: "acceptance_scenarios", value: spec.acceptance_scenarios },
+    { key: "api_contract", value: spec.api_contract },
+    { key: "ui_behavior", value: spec.ui_behavior },
+  ];
+
+  // Per pair, only flag the FIRST occurrence so a single typo
+  // doesn't generate noise across 20 invariants.
+  const seen = new Set<string>();
+
+  for (const section of sections) {
+    if (section.value == null) continue;
+    for (const { path, text } of walkStrings(section.value, String(section.key))) {
+      // Match every dotted chain (>=2 segments) and split into adjacent
+      // pairs. `regex.exec` with /g advances past each full match, so we
+      // can't catch overlapping pairs (`user.timezone` and
+      // `timezone.label` inside `user.timezone.label`) with a single
+      // pair-regex — extract the whole chain and decompose.
+      const chainRe = /\b([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)+)\b/g;
+      let m: RegExpExecArray | null;
+      while ((m = chainRe.exec(text)) !== null) {
+        const segments = m[1]!.split(".");
+        for (let i = 0; i < segments.length - 1; i++) {
+          const lhs = segments[i]!.toLowerCase();
+          const rhs = segments[i + 1]!;
+          const fields = catalog.get(lhs);
+          if (!fields) continue; // LHS isn't a known entity — skip.
+          if (fields.has(rhs)) continue; // Field exists.
+          const key = `${lhs}.${rhs}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          findings.push({
+            path,
+            message: `Spec references \`${segments[i]}.${rhs}\` but the ${lhs} entity has no \`${rhs}\` field. Known fields: ${[...fields].sort().join(", ") || "(none)"}.`,
+            action: "flagged",
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
 function pruneStringList(
   items: string[],
   pathPrefix: string,


### PR DESCRIPTION
## Why

Refine sometimes invents fields that don't exist on the consumer's real entities. Example from delgoosh story-005:

\`\`\`yaml
invariants:
  - \"Timezone display reads \`user.timezone.label\` (string from Timezone relation), never the raw timezone UUID\"
\`\`\`

The Timezone entity (\`packages/postgres/src/entities/timezone.entity.ts\`) has only \`name\` / \`offset\` / \`offsetStr\` — there is no \`label\` field. Brew + testgen downstream silently grounded against the non-existent field; only a human spotted the mismatch.

## What

Post-emit validator that:

1. Parses \`.brewing/repo-knowledge/auto/backend-entities.md\` into a \`Map<lowercasedEntityName, Set<fieldName>>\`.
2. Walks every string in the spec's load-bearing sections (\`invariants\`, \`preconditions\`, \`acceptance_scenarios\`, \`api_contract\`, \`ui_behavior\`) for dotted reference chains like \`user.timezone.label\`.
3. Decomposes each chain into adjacent pairs and checks each one:
   - \`user.timezone\` — \`timezone\` is a relation field on User ✓
   - \`timezone.label\` — \`label\` is NOT a field on Timezone ✗ → flagged

Flagged entries are reported via the existing \`SpecValidationFinding\` shape (action=\"flagged\" — the spec text isn't auto-repairable since the author's intent is ambiguous). Refine surfaces them in run logs alongside the existing token-list validators.

## Restraints to keep false-positives low

- Only walks **load-bearing** sections, not free-form \`title\`/\`notes\`/\`rationale\` prose.
- Only flags chains whose LHS matches a known entity (avoids \`data.value\`, \`result.items\`, etc.).
- Each pair flagged **at most once per spec** (no noise across 20 invariants that all reference the same typo).
- **Defensive**: missing entity catalog (consumer hasn't run \`refresh-knowledge\` yet) → silently skip. Never fails the spec emit.

## Exports

Three pure helpers (all exported for testing):
- \`parseEntityCatalog(md)\` — md → entity field map
- \`validateEntityFieldReferences(spec, md)\` — the lint itself
- \`walkStrings(value, path)\` — recurse into arrays/objects yielding every string with a dotted path (internal helper)

## Tests

8 new regression tests in \`spec-validate.test.ts\`:
1. Catalog parsing — entities indexed by lowercased name with field sets.
2. Empty input → empty map.
3. The story-005 regression — \`user.timezone.label\` flagged.
4. Valid chained traversal — \`user.timezone.name\` NOT flagged.
5. Dedup — same pair across 3 invariants → 1 finding.
6. False-positive avoidance — \`api.fetch\`, \`result.items\` ignored (LHS not an entity).
7. Multi-section walking — \`api_contract\` + \`acceptance_scenarios\`, not just \`invariants\`.
8. Defensive — empty catalog → empty findings.

Full cli suite still green: 69 files / 1057 tests (1049 base + 8 new).

## Wired up

Called from \`refine/agent.ts\` immediately after the existing \`validateAndRepairSpec\` call, concatenating into the same findings list. Console output via the existing warn-loop. Wrapped in try/catch so a digest-read failure can never fail the spec emit.

## Context

Part of the local-claude-pipeline session findings — see [#126](https://github.com/aminazar/slowcook/issues/126) finding #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)