### PR TITLE
docs(agent-docs): make feedback-PR instruction imperative, not advisory

### DIFF
--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -124,6 +124,25 @@ Or (if you're not running slowcook) edit \`.brewing/repo-knowledge/curated/<topi
 \`\`\`
 
 Knowledge entries are soft signal — agents reading them weight by recency and evidence, not by exact matching. \`slowcook knowledge verify\` flags [PRECARIOUS] entries whose evidence file has moved (but never auto-deletes).
+
+### Feedback to slowcook itself — open PRs proactively, don't wait
+
+If you hit a slowcook bug, a missing auto-digest, a stale prompt, or an ambiguous methodology rule while working in this repo: **open a PR to [aminazar/slowcook](https://github.com/aminazar/slowcook), don't just log it locally**. Treat this as a standing duty, not a polite suggestion.
+
+Thresholds:
+
+- **≥3 unrelated findings** accumulated across a session → open a single tracking issue with the batch, **and** open a bug-fix PR for the most actionable one immediately. Don't sit on a batch waiting for the human to ask.
+- **Any single blocking bug** (silently broken digest, prompt regression, missing chef-known-fix the consumer keeps re-hitting) → open the fix PR the moment you have a reliable repro, even mid-session. The human reviews on merge.
+- **Slowcook convention you wished was clearer** → doc PR with one paragraph + the concrete example that confused you. These compound across consumers.
+
+Conventions (matches slowcook's CONTRIBUTING.md):
+
+- One concern per PR. Bug fixes need a regression test; doc / prompt PRs don't.
+- Title: \`<scope>: <short summary>\` — e.g. \`fix(refresh-knowledge): strip JSDoc/line comments before parsing enum values\`.
+- Body: WHY it was broken + user-visible symptom + the repro / consumer-side evidence. The diff explains WHAT.
+- Cross-link the consumer side (this repo) so the maintainer can trace your local-pipeline session back to its source artifact.
+
+The agent that finds a slowcook bug is the cheapest place in the world to fix it — every other consumer is one merge away from the same paper cut. Don't defer.
 `;
 }
 


### PR DESCRIPTION
## Why

Today the managed block (installed by \`slowcook upsert-agent-docs\` into each consumer's AGENTS.md / CLAUDE.md / etc.) ends at "Contributing back" — and that section is purely about \`slowcook knowledge add\` for the consumer's CURATED memory. There's **nothing telling the visiting agent to OPEN PRs UPSTREAM TO SLOWCOOK** when it hits a slowcook bug.

## Consequence

A local-Claude-pipeline session driving delgoosh story-009/005/007 accumulated **9 distinct findings**:

1. missing AppointmentsStatusEnum digest (→ PR #125)
2. missing aliases digest (→ PR #128)
3. vitest jsx-runtime gap (→ PR #130)
4. fake-timer vs axe incompatibility (→ pending)
5. optimistic-UI brew pattern gap (→ PR #131)
6. hallucinated entity-field references (→ PR #132)
7. mock-reuse heuristic miss (→ pending)
8. this very issue — agent doesn't proactively open feedback PRs

The agent saw the *"When you have 3+ findings, batch them into a single PR"* line in delgoosh's local pipeline doc and treated it as **advisory**. It kept working, mentioned the threshold once in the end-of-turn summary, then waited for the human to ask. The human eventually pushed: *"it seems you can submit more bugs to slowcook. do them as prs"*. **That's a paper cut paid in every consumer.**

## What

Appends a "**Feedback to slowcook itself**" sub-section to the managed block with **imperative language**:

- "Open a PR to aminazar/slowcook, don't just log it locally."
- "Treat this as a standing duty, not a polite suggestion."
- Concrete thresholds (≥3 unrelated findings, ANY blocking bug, doc ambiguity → open a PR).
- Convention bridge to slowcook's CONTRIBUTING.md (one concern per PR, regression test for fixes, etc.).
- A *"The agent that finds a slowcook bug is the cheapest place in the world to fix it — every other consumer is one merge away from the same paper cut. Don't defer."* line so the cost framing is explicit.

## Refresh path

The block is delimited by the existing \`<!-- BEGIN: managed by … -->\` markers. Re-running \`slowcook upsert-agent-docs\` on any consumer that already has the block refreshes it in place. Idempotent; content outside the markers untouched.

## Tests

Full cli suite still green: 69 files / 1049 tests.

## Context

Part of the local-claude-pipeline session findings — see [#126](https://github.com/aminazar/slowcook/issues/126) finding #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)