### PR TITLE
docs(brew prompt): clarify slowcook-canonical vs production app-shell paths

### DIFF
--- a/packages/llm-anthropic/src/prompts/brew.ts
+++ b/packages/llm-anthropic/src/prompts/brew.ts
@@ -164,6 +164,7 @@ When the target test is a page-link assertion, it reads a Next.js page file and 
 - **Render the component** in the page's JSX (\`<ComponentName .../>\` or \`<ComponentName>...children...</ComponentName>\`).
 - **If the page is a server component fetching data**, pass the fetched data to the component as a prop. Don't convert the page to a client component to avoid the fetch — that breaks the rest of the page.
 - **Existing layout stays** — don't refactor unrelated sections. Wedge the component in alongside what's already there (a new \`<section>\` block is typical).
+- **Slowcook-canonical vs. production app shell.** The page-link test pins the SLOWCOOK-CANONICAL path (typically \`src/app/(main)/<path>/page.tsx\` at the root of the consumer repo). That path is sized for slowcook tests, not for the consumer's real Next.js app. In monorepo consumers, the production app shell often lives at \`apps/<role>/src/app/<path>/page.tsx\` (different route group, sometimes different URL prefix). When refine's route proposal points there: satisfy the page-link test FIRST by editing the slowcook-canonical path (that's what flips the test green), THEN lift the same component to the spec's proposed apps/<role>/ path so the consumer's deployed app actually renders it. Both paths import from the SAME \`src/components/<path>/Component.tsx\` (the component is presentational; data-as-props). Don't duplicate the component itself — duplicate only the thin server-rendered page wrappers.
 
 ## UI component tests (tier-1 UI, target file ends in \`.test.tsx\`)
 


### PR DESCRIPTION
## Why

The page-link test (target file ends in \`-page.test.ts\`) pins the SLOWCOOK-CANONICAL path — typically \`src/app/(main)/<path>/page.tsx\` at the root of the consumer repo. But in monorepo consumers (\`apps/<role>/\` subdirs), the **production app shell** often lives at a DIFFERENT path: \`apps/<role>/src/app/<path>/page.tsx\`, sometimes with a different route group or URL prefix.

Without explicit guidance, brew has to pick:

- **(a)** follow the testgen template — flips the test green but the consumer's deployed app doesn't render the component
- **(b)** follow refine's \`apps/<role>/\` proposal — consumer's app shell picks up the component, but the page-link test never flips green
- **(c)** write to both

The right answer is **(c)**, and the right component-vs-page split is:

- **ONE presentational component** at \`src/components/<path>/Component.tsx\` (data-as-props)
- **TWO thin page wrappers**:
  - one at the slowcook-canonical path (satisfies the page-link test)
  - one at \`apps/<role>/...\` (so the deployed app actually renders it)

## Concrete repro

Delgoosh story-009 brew first emitted only the \`apps/patient/src/app/(authenticated)/appointments/page.tsx\` file (per refine's proposal), but the page-link test pinned \`src/app/(main)/patient/appointments/page.tsx\` and stayed red. A human had to spot the divergence and reconcile. With this prompt addition, brew should ship both wrappers immediately.

(Bonus surface: the \`apps/<role>/src/app/(authenticated)/...\` route group didn't even exist in the consumer's shell — the actual sidebar nav used \`apps/patient/src/app/patient/appointments/page.tsx\`. So brew also has to read the consumer's existing route conventions; mentioned in passing.)

## What

Adds one bullet to the **Page-link assertion** section of the brew system prompt explicitly naming the dual-path pattern. Component duplication is forbidden; page-wrapper duplication is encouraged.

## Tests

llm-anthropic suite still green (5 files / 42 tests).

## Context

Part of the local-claude-pipeline session findings — see [#126](https://github.com/aminazar/slowcook/issues/126) finding #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)