### PR TITLE
feat(refine): post-emit lint checks components_to_reuse mock-vs-spec shape

### DIFF
--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -30,7 +30,11 @@ export function stripModelEmittedDuplicates(body: string): string {
 }
 import { synthesizeProposalsFromSpec } from "./proposals-synth.js";
 import { writeMockFixtures } from "./mock-fixtures.js";
-import { validateAndRepairSpec, validateEntityFieldReferences } from "./spec-validate.js";
+import {
+  validateAndRepairSpec,
+  validateEntityFieldReferences,
+  validateComponentReuseShape,
+} from "./spec-validate.js";
 import { SpecProposalsSchema } from "./spec-yaml.js";
 import type {
   ForgeAdapter,
@@ -471,6 +475,24 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
       const md = readFileSync(entityCatalogPath, "utf8");
       validationFindings.push(...validateEntityFieldReferences(spec, md));
     }
+  } catch {
+    // Never fail spec emit on a lint hiccup.
+  }
+
+  // 0.19.x+ — check each `components_to_reuse` entry actually renders
+  // the spec's data fields. Refine sometimes lists semantically wrong
+  // mocks (delgoosh story-005 listed a preferences mock for a profile
+  // spec). Reads each candidate path from disk; flags low-overlap ones.
+  try {
+    validationFindings.push(
+      ...validateComponentReuseShape(spec, (relPath) => {
+        try {
+          return readFileSync(join(ctx.repoRoot, relPath), "utf8");
+        } catch {
+          return null;
+        }
+      })
+    );
   } catch {
     // Never fail spec emit on a lint hiccup.
   }

--- a/packages/cli/src/commands/refine/spec-validate.test.ts
+++ b/packages/cli/src/commands/refine/spec-validate.test.ts
@@ -3,6 +3,7 @@ import {
   validateAndRepairSpec,
   validateEntityFieldReferences,
   parseEntityCatalog,
+  validateComponentReuseShape,
 } from "./spec-validate.js";
 import type { Spec } from "@slowcook-ai/core";
 
@@ -238,5 +239,112 @@ describe("validateEntityFieldReferences", () => {
       invariants: ["Reads `user.timezone.label`"],
     });
     expect(validateEntityFieldReferences(spec, "")).toEqual([]);
+  });
+});
+
+/**
+ * Mock-reuse shape check — when refine lists `mock/.../page.tsx` in
+ * `components_to_reuse`, verify the mock actually mentions the
+ * spec's data fields. story-005 in delgoosh listed a mock that
+ * rendered a completely different surface (therapy preferences vs.
+ * the spec's profile fields).
+ */
+describe("validateComponentReuseShape", () => {
+  function specWithReuse(reuse: string[], over: Partial<Spec> = {}): Spec {
+    return baseSpec({
+      invariants: [
+        "Page renders user.firstName, user.lastName, user.email",
+        "Personal info card shows user.phoneNumber and user.bio",
+        "Location card shows userLocation.city, userLocation.country",
+        "Birthdate input enforces user.birthOfDate ranges",
+      ],
+      proposals: {
+        ui_layout: {
+          status: "pending",
+          proposed_by: "refine-agent",
+          components_to_reuse: reuse,
+        },
+      },
+      ...over,
+    });
+  }
+
+  it("flags a mock that renders a different surface (story-005 regression)", () => {
+    // Mock body renders therapy preferences — none of the spec's
+    // profile fields appear.
+    const reader = (p: string) =>
+      p === "mock/src/app/patient/profile/page.tsx"
+        ? `'use client';
+          import { useLang } from '@/design-system/i18n/LanguageContext';
+          // Mock for therapy preferences: topics / approach / gender / belief.
+          const TOPICS = ['anxiety', 'depression', 'relationships'] as const;
+          const APPROACH_OPTS = ['modern', 'classical', 'integrative'] as const;
+          export default function PatientProfilePage() {
+            return <div>{TOPICS.map((t) => <span key={t}>{t}</span>)}</div>;
+          }
+        // pad so length > 500 to skip the empty-mock bail
+        // ${"x ".repeat(300)}
+        `
+        : null;
+    const spec = specWithReuse(["mock/src/app/patient/profile/page.tsx"]);
+    const findings = validateComponentReuseShape(spec, reader);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("mock likely renders a different surface");
+    expect(findings[0]!.action).toBe("flagged");
+  });
+
+  it("does NOT flag a mock that renders most of the spec's fields", () => {
+    const reader = (_p: string) =>
+      `'use client';
+       export default function PatientProfilePage({ user, userLocation }) {
+         return (
+           <main>
+             <div>{user.firstName} {user.lastName}</div>
+             <div>{user.email}</div>
+             <div>{user.phoneNumber}</div>
+             <div>{user.bio}</div>
+             <div>{user.birthOfDate}</div>
+             <div>{userLocation.city}, {userLocation.country}</div>
+           </main>
+         );
+       }
+       // ${"x ".repeat(300)}
+      `;
+    const spec = specWithReuse(["mock/src/app/patient/profile/page.tsx"]);
+    expect(validateComponentReuseShape(spec, reader)).toEqual([]);
+  });
+
+  it("flags a missing-on-disk reuse target with a distinct message", () => {
+    const reader = () => null;
+    const spec = specWithReuse(["mock/src/app/patient/profile/page.tsx"]);
+    const findings = validateComponentReuseShape(spec, reader);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("does not exist on disk");
+  });
+
+  it("skips small/empty mocks (under 500 chars) to avoid scaffolding false-positives", () => {
+    const reader = () => "// TODO\n";
+    const spec = specWithReuse(["mock/src/app/patient/profile/page.tsx"]);
+    expect(validateComponentReuseShape(spec, reader)).toEqual([]);
+  });
+
+  it("skips backtick-name entries (`ComponentName (path TBD …)`) — no path to check", () => {
+    const reader = () => "";
+    const spec = specWithReuse(["`PatientProfilePage` (path TBD — derived from spec prose)"]);
+    expect(validateComponentReuseShape(spec, reader)).toEqual([]);
+  });
+
+  it("returns [] when the spec has no field references", () => {
+    const spec = baseSpec({
+      proposals: {
+        ui_layout: {
+          status: "pending",
+          proposed_by: "refine-agent",
+          components_to_reuse: ["mock/src/app/foo.tsx"],
+        },
+      },
+    });
+    const reader = () => "x".repeat(1000);
+    expect(validateComponentReuseShape(spec, reader)).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/refine/spec-validate.ts
+++ b/packages/cli/src/commands/refine/spec-validate.ts
@@ -237,6 +237,103 @@ export function validateEntityFieldReferences(
   return findings;
 }
 
+/**
+ * 0.19.x+ — check whether the mock files refine listed in
+ * `components_to_reuse` actually render the spec's data fields.
+ *
+ * Refine derives `components_to_reuse` from spec prose mentions of
+ * `src/components/...` paths (proposals-synth.ts:198). It doesn't
+ * verify the mock at that path actually mentions the fields the
+ * spec cares about. A reuse listing of the WRONG mock misleads
+ * brew into lifting unrelated UI.
+ *
+ * Concrete repro (delgoosh story-005):
+ *   spec.invariants reference user.firstName / user.lastName /
+ *   user.email / userLocation.city / userLocation.country / etc.
+ *   refine's components_to_reuse listed mock/src/app/patient/profile/page.tsx
+ *   which actually renders therapy PREFERENCES (topics/approach/gender/belief)
+ *   — none of the spec's fields appear in that mock at all.
+ *
+ * Heuristic: extract the set of unique field names mentioned in the
+ * spec's load-bearing sections (RHS of every dotted reference like
+ * `user.firstName`). For each `components_to_reuse` entry that names
+ * a real path, count how many of those field names appear in the
+ * file body. If overlap is < 25% of the spec's field set AND the
+ * file body is non-trivial (>500 chars — empty mocks aren't false
+ * positives), flag the entry.
+ *
+ * Action is "flagged" — the spec text isn't auto-repairable; the
+ * author needs to either drop the reuse listing or rebuild the
+ * mock at that path. Surfaced in run logs alongside other findings.
+ *
+ * Exported for testing.
+ */
+export function validateComponentReuseShape(
+  spec: Spec,
+  mockReader: (path: string) => string | null
+): SpecValidationFinding[] {
+  const findings: SpecValidationFinding[] = [];
+  const reuse = spec.proposals?.ui_layout?.components_to_reuse;
+  if (!reuse || reuse.length === 0) return findings;
+
+  // Extract every field-name (RHS-and-after of dotted refs) from
+  // load-bearing sections — same chain shape as
+  // validateEntityFieldReferences.
+  const sections: unknown[] = [
+    spec.invariants,
+    spec.preconditions,
+    spec.acceptance_scenarios,
+    spec.api_contract,
+    spec.ui_behavior,
+  ];
+  const specFields = new Set<string>();
+  const chainRe = /\b[a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)+\b/g;
+  for (const section of sections) {
+    if (section == null) continue;
+    for (const { text } of walkStrings(section)) {
+      let m: RegExpExecArray | null;
+      while ((m = chainRe.exec(text)) !== null) {
+        const segments = m[0].split(".");
+        for (let i = 1; i < segments.length; i++) {
+          specFields.add(segments[i]!);
+        }
+      }
+    }
+  }
+  if (specFields.size === 0) return findings;
+
+  for (let i = 0; i < reuse.length; i++) {
+    const entry = reuse[i]!;
+    // Skip backtick-name entries (`Component-name (path TBD)`) — no path to read.
+    const pathMatch = entry.match(/^(src\/[^\s(]+|mock\/[^\s(]+|apps\/[^\s(]+)/);
+    if (!pathMatch) continue;
+    const body = mockReader(pathMatch[1]!);
+    if (body == null) {
+      findings.push({
+        path: `proposals.ui_layout.components_to_reuse[${i}]`,
+        message: `Reuse target ${JSON.stringify(pathMatch[1])} does not exist on disk — path is wrong, or the mock hasn't been authored yet.`,
+        action: "flagged",
+      });
+      continue;
+    }
+    if (body.length < 500) continue; // Empty / placeholder mock — not a false positive.
+    let hits = 0;
+    for (const f of specFields) {
+      const re = new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+      if (re.test(body)) hits++;
+    }
+    const ratio = hits / specFields.size;
+    if (ratio < 0.25) {
+      findings.push({
+        path: `proposals.ui_layout.components_to_reuse[${i}]`,
+        message: `Reuse target ${JSON.stringify(pathMatch[1])} mentions only ${hits}/${specFields.size} of the spec's data fields (${Math.round(ratio * 100)}%). The mock likely renders a different surface — verify the listing or update the mock before brew lifts it.`,
+        action: "flagged",
+      });
+    }
+  }
+  return findings;
+}
+
 function pruneStringList(
   items: string[],
   pathPrefix: string,


### PR DESCRIPTION
## Why

Refine derives \`components_to_reuse\` from spec prose mentions of \`src/components/...\` paths (\`proposals-synth.ts:198\`). It doesn't verify the mock at that path actually mentions the fields the spec cares about. **A reuse listing of the WRONG mock misleads brew into lifting unrelated UI.**

## Concrete repro

Delgoosh story-005 spec invariants reference \`user.firstName\` / \`user.lastName\` / \`user.email\` / \`userLocation.city\` / \`userLocation.country\` / \`user.phoneNumber\` / \`user.bio\` / \`user.birthOfDate\`. Refine listed \`mock/src/app/patient/profile/page.tsx\` in \`components_to_reuse\`. But that mock page renders therapy **preferences** (\`topics\` / \`approach\` / \`gender\` / \`belief\`) — **zero overlap** with the spec's profile fields. Spec even flagged this in \`non_goals\` ("preferences are NOT backed by the patient profile DTO — separate story"), yet refine still listed the mock as reusable.

## What

Post-emit validator that:

1. Extracts the set of unique field names from RHS-and-after of every dotted reference in the spec's load-bearing sections (\`invariants\`, \`preconditions\`, \`acceptance_scenarios\`, \`api_contract\`, \`ui_behavior\`).
2. For each \`components_to_reuse\` entry naming a real path, counts how many of those field names appear in the file body.
3. If overlap is **< 25%** AND the file body is **non-trivial** (>500 chars — empty mocks aren't false positives), flags the entry.

Action is \`"flagged"\` — the spec text isn't auto-repairable; the author needs to either drop the reuse listing or rebuild the mock at that path. Surfaced in run logs alongside the existing token-list + entity-field validators.

## Restraints to keep false-positives low

- Skip backtick-name entries (\`\\\`ComponentName\\\` (path TBD)\`) — no path to read.
- Skip small mocks (<500 chars) — scaffolding shouldn't trigger.
- 25% overlap threshold catches "completely wrong surface" while tolerating partial-overlap cases (sub-spec mock, related domain).

## Dependency injection

The validator takes a \`(path) => string | null\` reader, so it's **pure-testable**. Agent wires the production reader (\`readFileSync\` against \`repoRoot\`) in \`agent.ts\`.

## Tests

6 new regression tests in \`spec-validate.test.ts\`:

1. The story-005 regression — preferences mock flagged for profile spec.
2. Profile mock with matching fields → NOT flagged.
3. Missing path on disk → distinct flagged message.
4. Empty mock (<500 chars) → skipped.
5. Backtick-name entry → skipped.
6. Spec with no field references → empty findings.

Full cli suite still green: 69 files / 1063 tests (1057 base + 6 new).

## Dependency chain

Builds on PR #132 (entity-field lint) — same DI pattern + \`walkStrings\` helper. Should merge after #132. Rebased onto that branch; will rebase onto main once #132 lands.

## Context

Part of the local-claude-pipeline session findings — see [#126](https://github.com/aminazar/slowcook/issues/126) finding #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)