### PR TITLE
release: 0.19.2 + llm-anthropic 0.16.1 — local-pipeline session-batch (9 findings)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",


### PR DESCRIPTION
Patch release: cli 0.19.1 → 0.19.2 + llm-anthropic 0.16.0 → 0.16.1. All 9 findings from the local-pipeline dogfood session-batch landed. 1063/1063 tests passing. Keystone: #132 refine entity-field lint + #133 meta-loop proactive-feedback fix. Full per-finding breakdown in the commit message.