### PR TITLE
feat(init): scaffold agent-bootstrap preflight + PM-onboarding doc

### DIFF
--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -132,8 +132,10 @@ function applyAction(cwd: string, a: FileAction): void {
       : "";
   writeFileSync(full, contents, "utf8");
   // Git hooks (under .githooks/) must be executable or git silently
-  // ignores them. Any file under .githooks/ gets +x on write.
-  if (a.path.startsWith(".githooks/")) {
+  // ignores them. Same goes for shell scripts under scripts/ that
+  // agents are expected to invoke directly (e.g., agent-preflight.sh
+  // from the 0.19.x agent-bootstrap layer).
+  if (a.path.startsWith(".githooks/") || a.path.endsWith(".sh")) {
     chmodSync(full, 0o755);
   }
 }
@@ -313,4 +315,19 @@ export async function init(argv: string[], cliVersion: string): Promise<void> {
   console.log(`    with a \`@slowcook-one-time-scaffold\` marker; safe to customise, but note that`);
   console.log(`    \`slowcook init --force\` will overwrite them. Delete the marker to flag the file`);
   console.log(`    as consumer-owned if/when a future-proof guard lands.`);
+
+  console.log();
+  console.log("Agent onboarding (0.19.x+):");
+  console.log(`  • \`scripts/agent-preflight.sh\` is the script your agents should run at`);
+  console.log(`    session start. It checks they have ssh/git/gh/jq installed + are`);
+  console.log(`    authenticated. Exit 1 = fail; agent should ask you to fix rather than`);
+  console.log(`    self-heal.`);
+  console.log(`  • \`ops/agent-bootstrap.md\` is YOUR runbook for onboarding a new agent`);
+  console.log(`    (per-agent SSH keys, gh PAT, known_hosts). Agents do NOT consult this`);
+  console.log(`    file — they're not provisioning anything. AGENTS.md is the agent's`);
+  console.log(`    operating manual.`);
+  console.log(`  • Per-project preflight checks (SSH key on disk for a remote dev box,`);
+  console.log(`    env vars, etc.) go in \`scripts/agent-preflight.local.sh\` —`);
+  console.log(`    gitignored sibling sourced by the generic script. Add the path to`);
+  console.log(`    \`.gitignore\` so per-machine state stays out of the repo.`);
 }

--- a/packages/cli/src/commands/init/plan.ts
+++ b/packages/cli/src/commands/init/plan.ts
@@ -9,6 +9,8 @@ import {
   patternsReadme,
   slowcookCliVersionFile,
   preCommitHook,
+  agentPreflightScript,
+  agentBootstrapDoc,
   codeownersFullFile,
   codeownersSection,
   gitkeep,
@@ -92,6 +94,8 @@ const TARGETS = {
   manifestsGitkeep: ".brewing/manifests/.gitkeep",
   patternsReadme: ".brewing/patterns/README.md",
   preCommitHook: ".githooks/pre-commit",
+  agentPreflightScript: "scripts/agent-preflight.sh",
+  agentBootstrapDoc: "ops/agent-bootstrap.md",
   codeowners: "CODEOWNERS",
   gitignore: ".gitignore",
   packageJson: "package.json",
@@ -266,6 +270,29 @@ export function buildPlan(reader: FileReader, options: PlanOptions): Plan {
     options.force,
     TARGETS.preCommitHook,
     preCommitHook()
+  );
+
+  // 5f. scripts/agent-preflight.sh + ops/agent-bootstrap.md (0.19.x+).
+  // Two artifacts that close the agent-first-action environment gap:
+  // the preflight script the agent runs at session start to confirm
+  // its tools + auth + (optional) per-project SSH keys are in place;
+  // and the bootstrap doc the PM consults when onboarding a new agent.
+  // See ops/agent-bootstrap.md for the full provisioning recipe.
+  // Script is marked executable by index.ts via the same scripts/-prefix
+  // chmod handler that covers githooks.
+  addSimpleFile(
+    actions,
+    reader,
+    options.force,
+    TARGETS.agentPreflightScript,
+    agentPreflightScript()
+  );
+  addSimpleFile(
+    actions,
+    reader,
+    options.force,
+    TARGETS.agentBootstrapDoc,
+    agentBootstrapDoc()
   );
 
   // 6. CODEOWNERS — special case (append if exists without our markers)

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -341,6 +341,214 @@ No registry, no metadata, no slowcook-side change required.
 `;
 }
 
+/**
+ * 0.19.x+ — generic agent-bootstrap preflight script.
+ *
+ * Run this from any new agent session's first action. Prints PASS/FAIL
+ * for each prerequisite the agent needs to do real work in this
+ * consumer's environment:
+ *
+ *   - SSH client (often needed for remote dev servers, gh-via-ssh, etc.)
+ *   - git (writing branches)
+ *   - gh CLI (opening PRs — the slowcook branch-discipline rule depends
+ *     on `gh pr create`)
+ *   - jq (parsing JSON from gh/api calls)
+ *   - gh auth status (logged in)
+ *
+ * Consumer-specific checks (SSH key on disk for a remote dev box, etc.)
+ * go in a separate `scripts/agent-preflight.local.sh` that this script
+ * sources when present. Keeps the slowcook-shipped template generic.
+ *
+ * Why this exists: GitHub Actions mounts secrets for workflows; agents
+ * running OUTSIDE workflows (long-lived Claude Code sessions, Managed
+ * Agents, etc.) have no programmatic path to GH secrets and need
+ * out-of-band provisioning by the PM. Without a preflight, the agent
+ * flails on its first action and burns a turn debugging its own
+ * environment.
+ *
+ * Surfaced from a delgoosh bijan-agent triage 2026-05-30: the agent
+ * lacked `gh`, had no path to obtain its SSH key, and the PM-facing
+ * server-setup doc was being handed to the agent as if it were
+ * agent-facing.
+ */
+export function agentPreflightScript(): string {
+  return `#!/usr/bin/env bash
+# Slowcook agent preflight — run this from your first action of any
+# new session. Checks that the tools + auth + secrets you need are in
+# place. Edit this file to add consumer-specific checks (e.g. SSH key
+# at \`~/.ssh/<your-name>-key\`, env vars, etc.) — keep the generic
+# slowcook checks intact.
+#
+# Exit 0 = all green, agent may proceed.
+# Exit 1 = at least one FAIL. Ask the PM to fix; do NOT self-heal.
+#
+# Convention: each check prints \`PASS <name>\` or \`FAIL <name> — <hint>\`
+# in two columns so the agent can grep \`^FAIL\` for the bad list.
+
+set -u
+
+exit_code=0
+ok()   { printf 'PASS  %s\\n' "$1"; }
+fail() { printf 'FAIL  %s — %s\\n' "$1" "$2"; exit_code=1; }
+
+# --- Tools ----------------------------------------------------------
+command -v ssh >/dev/null  && ok "ssh installed"  || fail "ssh installed"  "apt install -y openssh-client / brew install openssh"
+command -v git >/dev/null  && ok "git installed"  || fail "git installed"  "apt install -y git / brew install git"
+command -v gh  >/dev/null  && ok "gh installed"   || fail "gh installed"   "https://cli.github.com — slowcook's branch-discipline rule depends on \\\`gh pr create\\\`"
+command -v jq  >/dev/null  && ok "jq installed"   || fail "jq installed"   "apt install -y jq / brew install jq"
+command -v node >/dev/null && ok "node installed" || fail "node installed" "install Node 20 via nvm or system"
+
+# --- Auth -----------------------------------------------------------
+if command -v gh >/dev/null; then
+  gh auth status >/dev/null 2>&1 \\
+    && ok "gh authenticated" \\
+    || fail "gh authenticated" "run \\\`gh auth login\\\` with a PAT scoped to repo,read:org,workflow (ask PM if you don't have one)"
+fi
+
+# --- Repo write access ---------------------------------------------
+if command -v gh >/dev/null && gh auth status >/dev/null 2>&1; then
+  REMOTE_URL=\$(git config --get remote.origin.url 2>/dev/null || echo "")
+  if [ -n "\$REMOTE_URL" ]; then
+    REPO_NWO=\$(printf '%s' "\$REMOTE_URL" | sed -E 's#(git@github.com:|https://github.com/)([^/]+/[^/.]+)(\\.git)?#\\2#')
+    if [ -n "\$REPO_NWO" ]; then
+      PERM=\$(gh api "repos/\$REPO_NWO" --jq '.permissions.push // false' 2>/dev/null || echo "false")
+      if [ "\$PERM" = "true" ]; then
+        ok "push access to \$REPO_NWO"
+      else
+        fail "push access to \$REPO_NWO" "your gh user has no push permission — ask PM to invite you"
+      fi
+    fi
+  fi
+fi
+
+# --- Consumer-specific hook ----------------------------------------
+# Put your project's per-agent checks (SSH key on disk for a remote
+# dev box, env vars, deploy-key bootstrap, etc.) into the .local.sh
+# sibling. Gitignore'd by convention so it doesn't leak per-machine
+# state into the repo.
+LOCAL_HOOK="\$(dirname "\$0")/agent-preflight.local.sh"
+if [ -f "\$LOCAL_HOOK" ]; then
+  # shellcheck disable=SC1090
+  source "\$LOCAL_HOOK"
+fi
+
+exit "\$exit_code"
+`;
+}
+
+/**
+ * 0.19.x+ — agent-bootstrap doc. Describes what the PM provisions
+ * out-of-band for each agent (per-agent SSH keys, gh auth, env vars,
+ * etc.) so the agent's preflight passes.
+ *
+ * Lives at \`ops/agent-bootstrap.md\` — under \`ops/\` so it's clearly
+ * PM-facing (agents should consult AGENTS.md for their operating
+ * manual; \`ops/\` files are server-side / per-agent setup runbooks
+ * for the PM).
+ */
+export function agentBootstrapDoc(): string {
+  return `# Agent bootstrap — per-agent provisioning (PM-facing)
+
+> **Audience: PM.** This doc is for whoever runs the project; agents
+> should not consult it. Agents read \`AGENTS.md\` and run
+> \`scripts/agent-preflight.sh\` instead. (See the slowcook managed
+> block in AGENTS.md for the audience convention.)
+
+When you onboard a new agent (Claude Code session, Codex, Cursor,
+etc.) into this repo, you need to provision a few things out-of-band
+so its first \`scripts/agent-preflight.sh\` passes:
+
+## 1. \`gh\` CLI authentication
+
+Agents need \`gh\` to open PRs (slowcook's branch-discipline rule
+depends on it). Pre-install the binary in the agent's container/image
+and authenticate one of these ways:
+
+- **PAT** (simplest): \`gh auth login --with-token < ~/.pat\`. Scopes:
+  \`repo, read:org, workflow\`. Per-agent token so revocation is
+  surgical.
+- **GitHub App installation token**: cleaner for org-policy reasons;
+  more setup.
+- **OAuth web flow**: only if the agent's environment can pop a
+  browser, which most managed contexts can't.
+
+## 2. SSH keys for remote services (if you have a dev box)
+
+If your project has a remote dev/staging box that agents need to SSH
+into (e.g., delgoosh-box for the rotating-URL dev-server pattern):
+
+- Generate a per-agent SSH keypair locally (not on the box).
+- **Public half** → install in the box's \`/home/<agent-user>/.ssh/authorized_keys\`.
+  See server-side setup runbook (e.g., \`ops/box/<agent>-agent-setup.md\`).
+- **Private half** → install in the agent's environment at
+  \`~/.ssh/<agent-name>-key\` with \`chmod 600\`. ALSO upload to GitHub
+  Secrets as \`<PROJECT>_<AGENT>_SSH_KEY\` for any workflow agents.
+
+**Why two places**: GitHub secrets are workflow-mounted only — they
+cannot be read by agents running outside Actions (long-lived Claude
+Code, Managed Agents, etc.). For those, the private key must already
+be on disk before the agent's first action.
+
+## 3. SSH config + known_hosts
+
+For convenience, add a stanza in the agent's \`~/.ssh/config\`:
+
+\`\`\`
+Host <project>-box
+  HostName <ip-or-hostname>
+  Port 22
+  User <agent-user>
+  IdentityFile ~/.ssh/<agent-name>-key
+  IdentitiesOnly yes
+  ServerAliveInterval 30
+\`\`\`
+
+Pre-populate \`~/.ssh/known_hosts\` so the first SSH doesn't prompt:
+
+\`\`\`bash
+ssh-keyscan -t ed25519 <ip-or-hostname> >> ~/.ssh/known_hosts
+ssh-keyscan -t ed25519 github.com      >> ~/.ssh/known_hosts
+\`\`\`
+
+## 4. Project-specific preflight (\`agent-preflight.local.sh\`)
+
+The generic \`scripts/agent-preflight.sh\` shipped by slowcook init
+sources \`scripts/agent-preflight.local.sh\` if present. Put your
+project's per-agent checks there. Example:
+
+\`\`\`bash
+# scripts/agent-preflight.local.sh — gitignored
+[ -f ~/.ssh/<agent-name>-key ] \\
+  && ok "ssh key present" \\
+  || fail "ssh key present" "PM must install per ops/agent-bootstrap.md §2"
+
+[ "\$(stat -c %a ~/.ssh/<agent-name>-key 2>/dev/null)" = 600 ] \\
+  && ok "ssh key chmod 600" \\
+  || fail "ssh key chmod 600" "chmod 600 ~/.ssh/<agent-name>-key"
+
+ssh -o BatchMode=yes -o ConnectTimeout=5 <project>-box 'whoami' 2>/dev/null | grep -qx "<agent-user>" \\
+  && ok "ssh to <project>-box as <agent-user>" \\
+  || fail "ssh to <project>-box as <agent-user>" "key or known_hosts misconfigured"
+\`\`\`
+
+The \`.local.sh\` form is gitignored — add it to \`.gitignore\` so
+per-agent quirks don't leak into the repo.
+
+## Tear-down
+
+When you retire an agent:
+
+1. Revoke the GH PAT (or GitHub App installation token).
+2. Revoke the SSH key on the dev box (remove from
+   \`~/<agent-user>/.ssh/authorized_keys\`).
+3. Delete the GitHub secret (\`gh secret delete <PROJECT>_<AGENT>_SSH_KEY\`).
+4. Optionally delete the OS user on the dev box (\`userdel -r <agent-user>\`).
+
+Per-agent scoping is the point — each step is independent of every
+other agent.
+`;
+}
+
 export function gitignoreSection(): string {
   return `${SLOWCOOK_GITIGNORE_MARKER_BEGIN}
 # Slowcook-derived data — regenerated from src/ on every brew iter


### PR DESCRIPTION
## Why

Surfaced by a delgoosh \`bijan-agent\` triage 2026-05-30. Every consumer using slowcook + agents hits the same gap:

- GitHub secrets are **workflow-mounted only** — long-lived agents (Claude Code sessions, Managed Agents, Cursor in a remote shell) have no programmatic path to pull SSH keys / PATs from secrets at runtime.
- Without a preflight, the agent's first action burns turns debugging its own environment instead of doing the work.
- "Did the PM pre-install the SSH key?" / "is \`gh\` actually here?" is not a yes/no the agent can self-discover — it needs an assertion + report.

The delgoosh case: PM pointed Bijan's agent at \`AGENTS.md\` + \`ops/box/bijan-agent-setup.md\` and said "everything you need is in those two files." The second file is a PM-facing server-setup runbook (90 lines of \`useradd\` / \`chmod\` / \`/etc/sudoers.d/\`); none of it actionable from the agent's seat. And \`AGENTS.md\` never told the agent how to obtain the SSH key when running outside Actions.

## What

Two new artifacts shipped by \`slowcook init\`:

### 1. \`scripts/agent-preflight.sh\` (chmod 0755)

Generic check that the visiting agent has the tools + auth + push access it needs:

\`\`\`
PASS  ssh installed
PASS  git installed
FAIL  gh installed — https://cli.github.com — slowcook's branch-discipline rule depends on \`gh pr create\`
PASS  jq installed
PASS  node installed
FAIL  gh authenticated — run \`gh auth login\` with a PAT scoped to repo,read:org,workflow
…
\`\`\`

Sources a gitignored \`scripts/agent-preflight.local.sh\` sibling for per-project checks (SSH key on disk for a remote dev box, env vars, etc.). Exit 0 = green, exit 1 = at least one FAIL — convention is **the agent asks the PM to fix rather than self-heal.**

### 2. \`ops/agent-bootstrap.md\` (PM-facing runbook)

What the PM provisions out-of-band per new agent:

- \`gh\` CLI authentication (PAT, GitHub App installation token, or OAuth)
- SSH keypair (public on box, private on agent's environment — **NOT** pulled from GH secrets because those are workflow-mounted only)
- SSH config + known_hosts (pre-populated so first SSH doesn't prompt)
- Consumer-specific \`agent-preflight.local.sh\` content
- Tear-down (revoke PAT, remove SSH key, delete GH secret, optionally delete OS user)

Doc body opens with **"Audience: PM. This doc is for whoever runs the project; agents should not consult it."** Companion finding to be filed separately: an audience-marker convention in the upsert-agent-docs managed block (so the slowcook side enforces what every consumer needs anyway).

## Wired into \`init\`

- New \`TARGETS\` entries (\`agentPreflightScript\`, \`agentBootstrapDoc\`); emitted alongside the other scaffolds.
- The \`applyAction\` chmod handler now marks \`*.sh\` files executable (was: only \`.githooks/*\`). Generic enough to cover any shell scripts the init scaffold may emit later.
- Post-run instructions now include an "Agent onboarding (0.19.x+)" section pointing the PM at both new files.

## Tests

Full cli suite still green: 69 files / 1063 tests. No new unit tests — preflight script is testable but integration-shaped (real shell, real env); open to adding a vitest harness if reviewers want one.

## Context

Local-claude-pipeline session findings, second batch. See [#126](https://github.com/aminazar/slowcook/issues/126) (issue from first batch) for context on the methodology — first batch shipped as 0.19.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)