### PR TITLE
docs(agent-docs): add doc-audience convention to managed block

### DIFF
--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -125,6 +125,16 @@ Or (if you're not running slowcook) edit \`.brewing/repo-knowledge/curated/<topi
 
 Knowledge entries are soft signal — agents reading them weight by recency and evidence, not by exact matching. \`slowcook knowledge verify\` flags [PRECARIOUS] entries whose evidence file has moved (but never auto-deletes).
 
+### Doc audience — read this, skip that
+
+This repo's docs split by audience. Don't burn turns reading the wrong layer.
+
+- **Agent-facing** (you should read): \`AGENTS.md\` and every file it links from inside this managed block. These are your operating manual — what YOU do per session.
+- **PM-facing** (you should NOT read): anything under \`ops/\` is a server-side / per-agent provisioning runbook for the human PM. Examples: \`ops/agent-bootstrap.md\` (how the PM provisions a new agent), \`ops/box/*-agent-setup.md\` (server-side useradd / sudoers / SSH key install). These require root on the dev box and are not actionable from your seat. If the PM points you at one of these by mistake, surface it: "this looks PM-facing — what specifically should I take from it?"
+- **Shared** (read on demand): \`README.md\`, \`docs/*\` typically — informational for humans + agents both.
+
+Convention: if a file's first heading says **"Audience: PM."** or lives under \`ops/\`, skip unless the PM has explicitly told you to look at one specific section. Onboarding-day cost-saver: run \`scripts/agent-preflight.sh\` (if present) at session start — it'll tell you upfront whether your environment is configured correctly without you having to read the bootstrap runbook to find out.
+
 ### Feedback to slowcook itself — open PRs proactively, don't wait
 
 If you hit a slowcook bug, a missing auto-digest, a stale prompt, or an ambiguous methodology rule while working in this repo: **open a PR to [aminazar/slowcook](https://github.com/aminazar/slowcook), don't just log it locally**. Treat this as a standing duty, not a polite suggestion.


### PR DESCRIPTION
## Why

The managed block today doesn't tell agents which files in the consumer's repo are MEANT for them vs. which are PM-only.

Real incident from a delgoosh \`bijan-agent\` triage 2026-05-30: the PM told the agent "everything you need is in \`AGENTS.md\` and \`ops/box/bijan-agent-setup.md\`." The second file is a **PM-facing server-side runbook** — \`useradd\`, sudoers, \`/etc/sudoers.d/\`, ssh \`authorized_keys\` install. None of it actionable from the agent's seat. The agent reading it would burn turns reverse-engineering which 5 lines are even relevant.

## What

Adds a "**Doc audience — read this, skip that**" section to the managed block before the existing "Feedback to slowcook itself" section, establishing:

| Audience | Files | What to do |
|---|---|---|
| **Agent-facing** | \`AGENTS.md\` + everything linked from the managed block | read these |
| **PM-facing** | anything under \`ops/\` (server setup, per-agent provisioning, root required) | skip — not actionable from your seat |
| **Shared** | \`README.md\`, \`docs/*\` | read on demand |

Plus recognition rules for the agent:

- File's first heading says **"Audience: PM."** → skip
- Lives under \`ops/\` → skip unless explicitly told otherwise
- PM points you at a PM-facing file by mistake → push back: "what specifically should I take from it?"

## Companion

Cross-references the \`scripts/agent-preflight.sh\` shipped by companion PR #138 (agent-bootstrap preflight). The audience convention is what makes #138's PM-facing bootstrap doc safe to ship: agents won't mistakenly try to follow it.

## Tests

Full cli suite still green: 69 files / 1063 tests.

## Context

Local-claude-pipeline session findings, second batch. See [#126](https://github.com/aminazar/slowcook/issues/126) for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)