### PR TITLE
docs(agent-docs): add multi-agent choreography section to managed block

### DIFF
--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -99,6 +99,18 @@ The slowcook pipeline opens one branch per stage (\`slowcook/<kind>/story-N\`). 
 - Slowcook agents stay on \`slowcook/<kind>/story-N\` branches; non-slowcook agents should use \`<your-name>/<short-description>\`.
 - Don't \`--force-push\` to shared branches. The human PM holds admin bypass for emergencies; agents don't.
 
+### Working alongside other agents (multi-agent choreography)
+
+When your work depends on another agent's still-open PR — common when one agent owns the app shell + another owns a feature inside it — follow this:
+
+- **Cut your branch off the OTHER agent's branch**, not \`main\`. Lets you import / reference their changes locally while you build. Example: \`git checkout -b slowcook/brew/story-009-on-bijan origin/feat/patient-therapist-portal-pages\`.
+- **Open your PR with \`--base\` pointing at THEIR branch**, not \`main\`. GitHub stacks the PRs; when their PR merges, GitHub auto-changes your PR's base to \`main\` and the diff narrows to just YOUR commits.
+- **Don't modify their files in your PR.** If you need a tweak in their work, drop a PR-comment review on THEIR PR ("can you change X?"). Editing their files in your PR creates a merge conflict at the moment THEIR PR merges, which is exactly the wrong moment to be solving conflicts.
+- **After their PR merges**: \`git fetch origin main && git rebase origin/main\` on your branch. Push with \`--force-with-lease\`. Your diff should now show only your net additions. If it shows their changes too, you missed a rebase step.
+- **If you and another agent are about to touch the same file** (same component, same migration, etc.): leave a one-line PR-comment on their open PR flagging the overlap before you cut your branch. Coordination cost ≪ conflict-resolution cost.
+
+If the PR you depend on stalls (no merge in sight), surface that to the human PM rather than waiting silently — they can either push the merge or unblock you to base on \`main\` and accept a temporary divergence.
+
 ### Refreshing the goldmine
 
 Run when you've made structural changes that other agents will need to know about:


### PR DESCRIPTION
## Why

The managed block today covers single-agent branch discipline but has nothing for the increasingly common case: **two agents with overlapping or stacked work** (one owns the app shell, another owns a feature inside it; one ships infra, another consumes it).

Real incident from a delgoosh local-pipeline session 2026-05-27:

- Bijan's agent had open PR delgoosh#700 building the \`apps/patient\` shell.
- My PR delgoosh#698 needed his \`@/lib/api\` to land cleanly but was based on \`main\`.
- Result: my PR's docker build broke on \`@/lib/data/appointment-by-patient\` (apps/patient's \`@/\` alias resolves into apps/patient/src, not root).
- The fix was rebasing onto Bijan's branch (became PR delgoosh#701) — but nowhere in the managed block did it say how to handle this case.

## What

Adds a "**Working alongside other agents (multi-agent choreography)**" sub-section between Branch discipline and Refreshing the goldmine. Covers:

- **Cut your branch off the OTHER agent's branch**, not \`main\`.
- **Open the PR with \`--base\` pointing at their branch**; GitHub auto-changes base to \`main\` when their PR merges.
- **Don't modify their files in your PR** — drop a PR-comment review on theirs instead. Editing their files at the moment their PR merges = guaranteed merge conflict at the worst possible moment.
- **After their PR merges**: \`git fetch origin main && git rebase origin/main\` + force-with-lease. Diff should narrow to your net additions.
- **Pre-emptively coordinate**: if you're about to touch the same file, leave a one-line PR-comment on their open PR FIRST.
- **Stalled-PR fallback**: surface to PM, don't wait silently.

These are conventions I derived empirically across the local-pipeline session; making them explicit so every consumer benefits.

## Tests

Full cli suite still green: 69 files / 1063 tests.

## Context

Local-claude-pipeline session findings, second batch. Companion to #138 (agent-bootstrap) and #139 (audience convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)