### PR TITLE
feat(cli): `slowcook cost log` subcommand for non-Actions agents

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { fixtures } from "./commands/fixtures/index.js";
 import { refreshKnowledge } from "./commands/refresh-knowledge.js";
 import { upsertAgentDocs } from "./commands/upsert-agent-docs.js";
 import { knowledgeAdd } from "./commands/knowledge-add.js";
+import { costLog } from "./commands/cost-log.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
 import { budget } from "./commands/budget/index.js";
@@ -149,6 +150,17 @@ async function main(): Promise<void> {
       const sub = args[1];
       if (sub === "add") { await knowledgeAdd(args.slice(2)); return; }
       console.error(`unknown knowledge subcommand: ${sub ?? "(none)"}. try \`slowcook knowledge add --help\``);
+      process.exit(64);
+    }
+    case "cost": {
+      // `slowcook cost log --story <id> --usd <n> --agent <name> [...]`
+      // 0.19.x+ — explicit logging primitive for non-Actions agents
+      // (Claude Code sessions, Managed Agents, etc.) so their LLM spend
+      // lands in the canonical cost sidecar alongside in-process agent
+      // entries. See packages/cli/src/commands/cost-log.ts.
+      const sub = args[1];
+      if (sub === "log") { await costLog(args.slice(2)); return; }
+      console.error(`unknown cost subcommand: ${sub ?? "(none)"}. try \`slowcook cost log --help\``);
       process.exit(64);
     }
     case "on-spec-merged":

--- a/packages/cli/src/commands/cost-log.test.ts
+++ b/packages/cli/src/commands/cost-log.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { costLogCore, parseCostLogArgs } from "./cost-log.js";
+
+describe("parseCostLogArgs", () => {
+  it("extracts all supported flags", () => {
+    const args = parseCostLogArgs([
+      "--story", "009",
+      "--usd", "0.4234",
+      "--agent", "local-claude-pipeline",
+      "--model", "claude-opus-4-7",
+      "--source-url", "https://github.com/x/y/pull/1",
+      "--round", "brew-iter-3",
+      "--tokens-in", "12000",
+      "--tokens-out", "1500",
+      "--cache-read", "85000",
+      "--cache-create", "12000",
+      "--apply-to-spec",
+    ]);
+    expect(args).toMatchObject({
+      storyId: "009",
+      usd: 0.4234,
+      agent: "local-claude-pipeline",
+      model: "claude-opus-4-7",
+      sourceUrl: "https://github.com/x/y/pull/1",
+      round: "brew-iter-3",
+      tokensIn: 12000,
+      tokensOut: 1500,
+      cacheRead: 85000,
+      cacheCreate: 12000,
+      applyToSpec: true,
+      help: false,
+    });
+  });
+
+  it("defaults applyToSpec=false and help=false", () => {
+    const args = parseCostLogArgs(["--story", "009", "--usd", "0.5", "--agent", "x"]);
+    expect(args.applyToSpec).toBe(false);
+    expect(args.help).toBe(false);
+  });
+
+  it("recognises --help and -h", () => {
+    expect(parseCostLogArgs(["--help"]).help).toBe(true);
+    expect(parseCostLogArgs(["-h"]).help).toBe(true);
+  });
+
+  it("ignores unknown flags rather than throwing", () => {
+    const args = parseCostLogArgs(["--story", "009", "--usd", "0.5", "--agent", "x", "--unknown", "value"]);
+    expect(args.storyId).toBe("009");
+    expect(args.usd).toBe(0.5);
+  });
+});
+
+describe("costLogCore — sidecar append", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "slowcook-cost-log-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("appends a JSONL entry to specs/story-<id>.cost.jsonl", () => {
+    const result = costLogCore({
+      repoRoot: tmpDir,
+      storyId: "009",
+      entry: {
+        agent: "local-claude-pipeline",
+        usd: 0.42,
+        model: "claude-opus-4-7",
+        at: "2026-05-31T10:00:00.000Z",
+      },
+      applyToSpec: false,
+    });
+
+    expect(existsSync(result.sidecarPath)).toBe(true);
+    const body = readFileSync(result.sidecarPath, "utf8");
+    expect(body.trim().split("\n")).toHaveLength(1);
+    const parsed = JSON.parse(body.trim());
+    expect(parsed.agent).toBe("local-claude-pipeline");
+    expect(parsed.usd).toBe(0.42);
+    expect(parsed.model).toBe("claude-opus-4-7");
+  });
+
+  it("appends multiple entries without overwriting", () => {
+    costLogCore({
+      repoRoot: tmpDir,
+      storyId: "009",
+      entry: { agent: "a1", usd: 0.1, at: "2026-05-31T10:00:00Z" },
+      applyToSpec: false,
+    });
+    costLogCore({
+      repoRoot: tmpDir,
+      storyId: "009",
+      entry: { agent: "a2", usd: 0.2, at: "2026-05-31T11:00:00Z" },
+      applyToSpec: false,
+    });
+
+    const sidecar = readFileSync(
+      join(tmpDir, "specs/story-009.cost.jsonl"),
+      "utf8"
+    );
+    const lines = sidecar.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).agent).toBe("a1");
+    expect(JSON.parse(lines[1]!).agent).toBe("a2");
+  });
+
+  it("optionally applies cost to spec when --apply-to-spec is set", () => {
+    // Pre-create a minimal spec yaml so applyCostToSpec has something to update.
+    mkdirSync(join(tmpDir, "specs"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "specs/story-009.yaml"),
+      `story_id: "009"
+title: test
+status: active
+created_at: 2026-05-31T00:00:00Z
+supersedes: []
+superseded_by: null
+actors: []
+preconditions: []
+invariants: []
+acceptance_scenarios: []
+non_goals: []
+cost:
+  total_usd: 0
+  last_updated: 2026-05-31T00:00:00Z
+`,
+      "utf8"
+    );
+
+    const result = costLogCore({
+      repoRoot: tmpDir,
+      storyId: "009",
+      entry: { agent: "local", usd: 0.42, at: "2026-05-31T12:00:00Z" },
+      applyToSpec: true,
+    });
+
+    expect(result.appliedToSpec).toBe(true);
+    const specBody = readFileSync(join(tmpDir, "specs/story-009.yaml"), "utf8");
+    expect(specBody).toContain("total_usd: 0.42");
+  });
+});

--- a/packages/cli/src/commands/cost-log.ts
+++ b/packages/cli/src/commands/cost-log.ts
@@ -1,0 +1,204 @@
+/**
+ * `slowcook cost log` — 0.19.x+
+ *
+ * Append a cost entry for a non-Actions agent run into the canonical
+ * cost sidecar (`specs/story-<id>.cost.jsonl`).
+ *
+ * Why this exists: slowcook agents that run in-process emit cost
+ * markers + `appendCostEntry` calls automatically. But long-lived
+ * agents OUTSIDE slowcook's process (Claude Code session in a
+ * consumer repo, Managed Agents, Cursor mimicking the pipeline)
+ * generate no cost entries — their LLM spend is invisible to the
+ * cost-store + the workflow rollup. That makes "what does the
+ * methodology cost end-to-end" unanswerable, which matters for
+ * 0.20's AI-native-org thesis.
+ *
+ * This subcommand is the explicit logging primitive for those agents.
+ * Usage:
+ *
+ *   slowcook cost log \\
+ *     --story 009 \\
+ *     --usd 0.42 \\
+ *     --agent local-claude-pipeline \\
+ *     [--model claude-opus-4-7] \\
+ *     [--source-url https://github.com/.../pull/698] \\
+ *     [--round brew-iteration-3] \\
+ *     [--tokens-in 12000] [--tokens-out 1500] \\
+ *     [--cache-read 85000] [--cache-create 12000] \\
+ *     [--apply-to-spec]
+ *
+ * `--apply-to-spec` recomputes spec.cost.total_usd from the full
+ * sidecar after appending (same call slowcook agents make in-process).
+ *
+ * The convention: each session's log a single entry summarising the
+ * whole session (`--usd $TOTAL`), or one entry per logical round
+ * (refine-mimic, testgen-mimic, brew-mimic, …). Either works; the
+ * aggregator just sums.
+ */
+
+import {
+  appendCostEntry,
+  applyCostToSpec,
+  costSidecarPath,
+  type CostEntry,
+} from "../cost-store.js";
+
+export interface CostLogArgs {
+  repoRoot: string;
+  storyId: string;
+  entry: CostEntry;
+  applyToSpec: boolean;
+}
+
+export interface CostLogResult {
+  sidecarPath: string;
+  appendedEntry: CostEntry;
+  appliedToSpec: boolean;
+}
+
+export function costLogCore(args: CostLogArgs): CostLogResult {
+  appendCostEntry(args.repoRoot, args.storyId, args.entry);
+  let appliedToSpec = false;
+  if (args.applyToSpec) {
+    applyCostToSpec(args.repoRoot, args.storyId);
+    appliedToSpec = true;
+  }
+  return {
+    sidecarPath: costSidecarPath(args.repoRoot, args.storyId),
+    appendedEntry: args.entry,
+    appliedToSpec,
+  };
+}
+
+interface ParsedArgs {
+  storyId?: string;
+  usd?: number;
+  agent?: string;
+  model?: string;
+  sourceUrl?: string;
+  round?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  cacheRead?: number;
+  cacheCreate?: number;
+  applyToSpec: boolean;
+  help: boolean;
+}
+
+/** Pure arg parser — exported for testing. */
+export function parseCostLogArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = { applyToSpec: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case "--story":
+        if (next !== undefined) { out.storyId = next; i++; }
+        break;
+      case "--usd":
+        if (next !== undefined) { out.usd = parseFloat(next); i++; }
+        break;
+      case "--agent":
+        if (next !== undefined) { out.agent = next; i++; }
+        break;
+      case "--model":
+        if (next !== undefined) { out.model = next; i++; }
+        break;
+      case "--source-url":
+        if (next !== undefined) { out.sourceUrl = next; i++; }
+        break;
+      case "--round":
+        if (next !== undefined) { out.round = next; i++; }
+        break;
+      case "--tokens-in":
+        if (next !== undefined) { out.tokensIn = parseInt(next, 10); i++; }
+        break;
+      case "--tokens-out":
+        if (next !== undefined) { out.tokensOut = parseInt(next, 10); i++; }
+        break;
+      case "--cache-read":
+        if (next !== undefined) { out.cacheRead = parseInt(next, 10); i++; }
+        break;
+      case "--cache-create":
+        if (next !== undefined) { out.cacheCreate = parseInt(next, 10); i++; }
+        break;
+      case "--apply-to-spec":
+        out.applyToSpec = true;
+        break;
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+    }
+  }
+  return out;
+}
+
+function printHelp(): void {
+  console.log(`slowcook cost log — append a non-Actions agent's cost into the story sidecar
+
+Required:
+  --story <id>        story id (e.g. "009")
+  --usd <amount>      cost of this run in USD (e.g. 0.42)
+  --agent <name>      identifier for the emitting agent
+                      (e.g. local-claude-pipeline, cursor, codex-mimic)
+
+Optional:
+  --model <id>        model used (e.g. claude-opus-4-7)
+  --source-url <url>  PR / comment / run URL where the work happened
+  --round <label>     round label (e.g. refine-mimic, brew-iter-3)
+  --tokens-in <n>     input tokens consumed
+  --tokens-out <n>    output tokens produced
+  --cache-read <n>    cache-hit tokens read
+  --cache-create <n>  cache-write tokens
+  --apply-to-spec     after appending, recompute spec.cost.total_usd
+                      from the sidecar (same call in-process agents make)
+  --help, -h          show this help
+
+Example:
+  slowcook cost log --story 009 --usd 0.42 \\
+    --agent local-claude-pipeline --model claude-opus-4-7 \\
+    --source-url https://github.com/delgoosh/monorepo/pull/698 \\
+    --apply-to-spec
+`);
+}
+
+export async function costLog(argv: string[]): Promise<void> {
+  const parsed = parseCostLogArgs(argv);
+  if (parsed.help) { printHelp(); return; }
+
+  const missing: string[] = [];
+  if (!parsed.storyId) missing.push("--story");
+  if (parsed.usd === undefined || Number.isNaN(parsed.usd)) missing.push("--usd");
+  if (!parsed.agent) missing.push("--agent");
+  if (missing.length > 0) {
+    console.error(`slowcook cost log: missing required args: ${missing.join(", ")}`);
+    console.error(`run \`slowcook cost log --help\` for usage`);
+    process.exit(64);
+  }
+
+  const entry: CostEntry = {
+    agent: parsed.agent!,
+    usd: parsed.usd!,
+    at: new Date().toISOString(),
+  };
+  if (parsed.model !== undefined) entry.model = parsed.model;
+  if (parsed.sourceUrl !== undefined) entry.source_url = parsed.sourceUrl;
+  if (parsed.round !== undefined) entry.round = parsed.round;
+  if (parsed.tokensIn !== undefined) entry.tokens_in = parsed.tokensIn;
+  if (parsed.tokensOut !== undefined) entry.tokens_out = parsed.tokensOut;
+  if (parsed.cacheRead !== undefined) entry.cache_read = parsed.cacheRead;
+  if (parsed.cacheCreate !== undefined) entry.cache_create = parsed.cacheCreate;
+
+  const result = costLogCore({
+    repoRoot: process.cwd(),
+    storyId: parsed.storyId!,
+    entry,
+    applyToSpec: parsed.applyToSpec,
+  });
+
+  console.log(`slowcook cost log: appended $${entry.usd.toFixed(4)} (agent=${entry.agent}) to ${result.sidecarPath}`);
+  if (result.appliedToSpec) {
+    console.log(`slowcook cost log: applied to spec specs/story-${parsed.storyId}.yaml`);
+  }
+}


### PR DESCRIPTION
## Why

Slowcook in-process agents (\`refine\`, \`brew\`, \`vibe\`, \`chef\` in the workflow path) already call \`appendCostEntry\` so their LLM spend lands in \`specs/story-<id>.cost.jsonl\` for canonical accounting.

**Long-lived agents OUTSIDE slowcook's process generate no entries**:

- Claude Code sessions mimicking the pipeline in a consumer repo
- Managed Agents driving slowcook stages from another runtime
- Cursor / Codex / Windsurf agents doing slowcook-shaped work

Their LLM spend is invisible to the cost-store + the workflow rollup. Makes *"what does the methodology cost end-to-end"* unanswerable, which matters for 0.20's AI-native-org thesis.

## What

Explicit logging primitive — \`slowcook cost log\` — wired through the existing cost-store layer so external-agent entries are first-class citizens alongside in-process ones.

\`\`\`bash
slowcook cost log \\
  --story 009 \\
  --usd 0.42 \\
  --agent local-claude-pipeline \\
  [--model claude-opus-4-7] \\
  [--source-url <pr-url>] \\
  [--round brew-mimic] \\
  [--tokens-in N] [--tokens-out N] \\
  [--cache-read N] [--cache-create N] \\
  [--apply-to-spec]
\`\`\`

\`--apply-to-spec\` recomputes \`spec.cost.total_usd\` from the full sidecar after appending — same call slowcook agents make in-process.

## Implementation

- Pure helper \`costLogCore(args)\` for testing — wraps existing \`appendCostEntry\` + optional \`applyCostToSpec\`.
- Argv parser \`parseCostLogArgs\` exported for testing.
- CLI dispatcher in \`cli.ts\` mirrors the existing \`knowledge add\` subcommand pattern (\`slowcook cost log ...\`).

## Tests

7 new regression tests:
1. Argv parser extracts all 11 supported flags.
2. Defaults: \`applyToSpec=false\`, \`help=false\`.
3. Recognises \`--help\` and \`-h\`.
4. Ignores unknown flags (defensive).
5. \`appendCostEntry\` creates sidecar with one JSONL line.
6. Multiple calls append without overwriting.
7. \`--apply-to-spec\` round-trips: \`cost.total_usd\` updates in the spec yaml.

Full cli suite: 70 files / 1070 tests (1063 base + 7 new).

## Migration

Drop-in. Existing in-process \`appendCostEntry\` callers unchanged; the new subcommand is purely additive. Consumers wanting to log local-pipeline spend can start using it immediately.

## Context

Local-claude-pipeline session findings, second batch. Companion artefact: my actual local-pipeline session spent ~\$N over 8 slowcook PRs + 4 delgoosh PRs and none of that landed in any cost sidecar — exact incident this command would fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)