### PR TITLE
release: cli 0.19.3 — local-pipeline session-batch #2 (team-ergonomics)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",


### PR DESCRIPTION
Patch release: cli 0.19.2 → 0.19.3. Six PRs from second local-pipeline session: methodology for multi-agent operation (#138-140), public cost surface (#141-142), maintainer release tooling (#143). 1070/1070 tests passing. llm-anthropic stays at 0.16.1 (no prompt changes).