### PR TITLE
feat(check): `slowcook check spec` — re-run spec validators on PR amendments (sc#146 #2)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -75,6 +75,7 @@ Usage:
   slowcook port --story <id> [--cwd <path>] [--dry-run] [--force]
   slowcook preview (deploy|teardown) --pr <number> [--ssh-key <path>] [--cwd <path>]
   slowcook check mock-isolation [--cwd <path>]
+  slowcook check spec [file...] [--cwd <path>]
   slowcook run-mock <story-id> [--no-poll] [--poll-seconds <n>] [--branch <ref>]
   slowcook dispatch <step> [inputs...]
   slowcook fixtures check [--max-age-days <n>] [--story <id>]
@@ -109,7 +110,7 @@ Commands available in ${VERSION}:
   plate              (0.15-α.3) Mockup amendment agent. Triggered by /plate PR comments on slowcook-mockup PRs; force-pushes amendments.
   port               (0.16-α.8) Deterministic mock/ → src/ copy. Walks mock/src/, applies useScenarioFixture → useDataDomain rewrite, prepends provenance header. Pre-brew CI step.
   preview            (0.16-α.5) SSH preview deploy. \`deploy --pr N\`: build + run the mock app on the consumer's box; post URL to PR. \`teardown --pr N\`: stop + remove.
-  check              (0.16-α.13) Static structural checks. \`check mock-isolation\` verifies every import in mock/ stays inside mock/ (catches vibe-prompt slippage that breaks the mock-vs-prod separation rule).
+  check              (0.16-α.13) Static structural checks. \`check mock-isolation\` verifies every import in mock/ stays inside mock/ (catches vibe-prompt slippage that breaks the mock-vs-prod separation rule). \`check spec\` (0.19.4-α) re-runs spec content validators on a PR's spec files — closes the amendment-bypass gap where refine's in-process lint never re-fires.
   recon              (0.17.6+) Pre-brew structural divergence check. Compares story tests against mock + src/, surfaces missing components / testid gaps / brownfield rename hazards. Runs in slowcook-brew-auto.yml before brew dispatch.
   run-mock           (0.16-α.17) One-command mock launch + auto-pull. \`run-mock <story>\`: checkout mockup branch, npm install in mock/, run next dev with overlay env vars, poll origin every 15s + git pull --ff-only on plate amendments.
   dispatch           Trigger a slowcook GitHub Actions workflow remotely (brew / testgen / refine).

--- a/packages/cli/src/commands/check/index.ts
+++ b/packages/cli/src/commands/check/index.ts
@@ -5,6 +5,8 @@
  *
  * Subcommands:
  *   - `mock-isolation`  — every mock/ import resolves inside mock/
+ *   - `spec`            — re-run spec content validators on PRs touching
+ *                          specs/story-*.yaml (0.19.4-α / sc#146 #2)
  *
  * More to come (e.g. `mock-runtime-exports` to whitelist hooks vibe
  * may import; `port-provenance` to verify src/ files copied via port
@@ -12,12 +14,15 @@
  */
 
 import { runMockIsolationCheck } from "./mock-isolation.js";
+import { runSpecValidateCli } from "./spec-validate.js";
 
 export async function check(argv: string[], _cliVersion: string): Promise<void> {
   const sub = argv[0];
   switch (sub) {
     case "mock-isolation":
       return runMockIsolationCli(argv.slice(1));
+    case "spec":
+      return runSpecValidateCli(argv.slice(1));
     case undefined:
     case "help":
     case "--help":
@@ -37,11 +42,15 @@ slowcook check — static structural checks (0.16-α.13)
 
 Usage:
   slowcook check mock-isolation [--cwd <path>]
+  slowcook check spec [file...] [--cwd <path>]
 
 Subcommands:
   mock-isolation   Verify every import in mock/ stays inside mock/.
                    Catches vibe-prompt slippage where a mock component
                    tries to import from the consumer's production src/.
+  spec             Re-run spec content validators on one or more spec
+                   files. Catches drift on amendment commits that
+                   bypass refine's in-process lint.
 
 Exit codes:
   0  no violations

--- a/packages/cli/src/commands/check/spec-validate.test.ts
+++ b/packages/cli/src/commands/check/spec-validate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runSpecValidateCheck } from "./spec-validate.js";
+
+function makeRepo(): string {
+  return mkdtempSync(join(tmpdir(), "sc-spec-validate-"));
+}
+
+function writeSpec(repoRoot: string, storyId: string, body: string): string {
+  const dir = join(repoRoot, "specs");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `story-${storyId}.yaml`);
+  writeFileSync(path, body, "utf8");
+  return path;
+}
+
+const MINIMAL_VALID = `\
+story_id: "001"
+title: "minimal spec"
+status: active
+created_at: "2026-06-01T00:00:00Z"
+supersedes: []
+superseded_by: null
+actors:
+  - name: patient
+preconditions: []
+invariants: []
+acceptance_scenarios: []
+non_goals: []
+`;
+
+describe("runSpecValidateCheck", () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = makeRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("returns 0 findings + 0 files when no specs match", () => {
+    const result = runSpecValidateCheck(repoRoot);
+    expect(result.filesChecked).toBe(0);
+    expect(result.totalFindings).toBe(0);
+  });
+
+  it("PASSes a minimal valid spec", () => {
+    writeSpec(repoRoot, "001", MINIMAL_VALID);
+    const result = runSpecValidateCheck(repoRoot);
+    expect(result.filesChecked).toBe(1);
+    expect(result.totalFindings).toBe(0);
+    expect(result.hasParseErrors).toBe(false);
+  });
+
+  it("reports a parseError on malformed YAML", () => {
+    writeSpec(repoRoot, "002", "this is: not[ valid {yaml");
+    const result = runSpecValidateCheck(repoRoot);
+    expect(result.filesChecked).toBe(1);
+    expect(result.hasParseErrors).toBe(true);
+    expect(result.perFile[0]!.parseError).toBeTruthy();
+  });
+
+  it("flags entity.field references that don't appear in the entity catalog", () => {
+    const entityCatalogDir = join(
+      repoRoot,
+      ".brewing",
+      "repo-knowledge",
+      "auto"
+    );
+    mkdirSync(entityCatalogDir, { recursive: true });
+    // Minimal catalog: User entity with fields firstName, lastName, email
+    writeFileSync(
+      join(entityCatalogDir, "backend-entities.md"),
+      `## User\n\n- firstName: string\n- lastName: string\n- email: string\n`,
+      "utf8"
+    );
+
+    writeSpec(
+      repoRoot,
+      "003",
+      `\
+story_id: "003"
+title: "spec with hallucinated field"
+status: active
+created_at: "2026-06-01T00:00:00Z"
+supersedes: []
+superseded_by: null
+actors:
+  - name: patient
+preconditions: []
+invariants:
+  - "Renders user.bogusField when present"
+acceptance_scenarios: []
+non_goals: []
+`
+    );
+    const result = runSpecValidateCheck(repoRoot);
+    expect(result.filesChecked).toBe(1);
+    // The first occurrence of user.bogusField should produce one finding.
+    expect(result.totalFindings).toBeGreaterThan(0);
+    expect(result.perFile[0]!.findings.some((f) => /bogus/i.test(f.message))).toBe(true);
+  });
+
+  it("scopes to the given paths when explicit files are passed", () => {
+    writeSpec(repoRoot, "010", MINIMAL_VALID);
+    writeSpec(repoRoot, "011", "this is: not[ valid {yaml");
+    // Only check 010 — 011's parse error should not surface.
+    const result = runSpecValidateCheck(repoRoot, ["specs/story-010.yaml"]);
+    expect(result.filesChecked).toBe(1);
+    expect(result.hasParseErrors).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/check/spec-validate.ts
+++ b/packages/cli/src/commands/check/spec-validate.ts
@@ -1,0 +1,245 @@
+/**
+ * `slowcook check spec [file...]` — 0.19.4-α (sc#146 finding 2).
+ *
+ * Re-runs the spec content validators (the same ones refine/agent.ts
+ * calls in-process at emit time) against one or more on-disk spec
+ * files. Designed for CI to catch drift on PRs that AMEND a spec
+ * post-merge — the in-process lint never fires on amendments because
+ * those go straight to git, bypassing refine.
+ *
+ * Three validators wrap one CLI:
+ *   - validateAndRepairSpec        — token truncation / shape repair
+ *   - validateEntityFieldReferences — `entity.field` ↔ auto/backend-entities.md
+ *   - validateComponentReuseShape   — components_to_reuse mock mentions spec fields
+ *
+ * If `auto/backend-entities.md` is absent the entity-field check is
+ * skipped quietly (its `parseEntityCatalog` returns empty). Same for
+ * the mock reader when the mock/ tree is missing.
+ *
+ * Exit codes:
+ *   0  — no findings across all files
+ *   1  — at least one finding (printed)
+ *   2  — invocation error (unreadable file, parse failure, etc.)
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, relative, basename } from "node:path";
+import YAML from "yaml";
+import { schemas } from "../refine/spec-yaml.js";
+import {
+  validateAndRepairSpec,
+  validateEntityFieldReferences,
+  validateComponentReuseShape,
+  type SpecValidationFinding,
+} from "../refine/spec-validate.js";
+import type { Spec } from "@slowcook-ai/core";
+
+export interface SpecCheckPerFileResult {
+  file: string;
+  storyId: string | null;
+  findings: SpecValidationFinding[];
+  /** Set when the file couldn't be parsed at all (Zod / YAML failure). */
+  parseError?: string;
+}
+
+export interface SpecCheckResult {
+  perFile: SpecCheckPerFileResult[];
+  filesChecked: number;
+  totalFindings: number;
+  hasParseErrors: boolean;
+}
+
+/**
+ * Run the check. If `specPaths` is given, validates exactly those
+ * files (used by CI which passes the PR's changed-files list). If
+ * empty/undefined, scans `specs/story-*.yaml`.
+ */
+export function runSpecValidateCheck(
+  repoRoot: string,
+  specPaths?: string[]
+): SpecCheckResult {
+  const targets =
+    specPaths && specPaths.length > 0
+      ? specPaths.map((p) => (resolve(repoRoot, p)))
+      : discoverSpecs(repoRoot);
+
+  const entityCatalogPath = join(
+    repoRoot,
+    ".brewing",
+    "repo-knowledge",
+    "auto",
+    "backend-entities.md"
+  );
+  const entityCatalogMd = existsSync(entityCatalogPath)
+    ? readFileSync(entityCatalogPath, "utf8")
+    : "";
+
+  const mockReader = makeMockReader(repoRoot);
+
+  const perFile: SpecCheckPerFileResult[] = [];
+  let totalFindings = 0;
+  let hasParseErrors = false;
+
+  for (const abs of targets) {
+    const rel = relative(repoRoot, abs);
+    const storyId = extractStoryId(rel);
+    if (!existsSync(abs)) {
+      perFile.push({
+        file: rel,
+        storyId,
+        findings: [],
+        parseError: "file not found",
+      });
+      hasParseErrors = true;
+      continue;
+    }
+    let spec: Spec;
+    try {
+      const raw = YAML.parse(readFileSync(abs, "utf8"));
+      const parsed = schemas.Spec.safeParse(raw);
+      if (!parsed.success) {
+        perFile.push({
+          file: rel,
+          storyId,
+          findings: [],
+          parseError: parsed.error.issues
+            .map((i) => `${String(i.path.join("."))}: ${i.message}`)
+            .join("; "),
+        });
+        hasParseErrors = true;
+        continue;
+      }
+      spec = parsed.data as Spec;
+    } catch (err) {
+      perFile.push({
+        file: rel,
+        storyId,
+        findings: [],
+        parseError: err instanceof Error ? err.message : String(err),
+      });
+      hasParseErrors = true;
+      continue;
+    }
+
+    const findings: SpecValidationFinding[] = [];
+    findings.push(...validateAndRepairSpec(spec));
+    if (entityCatalogMd) {
+      findings.push(...validateEntityFieldReferences(spec, entityCatalogMd));
+    }
+    findings.push(...validateComponentReuseShape(spec, mockReader));
+
+    totalFindings += findings.length;
+    perFile.push({ file: rel, storyId, findings });
+  }
+
+  return {
+    perFile,
+    filesChecked: targets.length,
+    totalFindings,
+    hasParseErrors,
+  };
+}
+
+function discoverSpecs(repoRoot: string): string[] {
+  const specsDir = join(repoRoot, "specs");
+  if (!existsSync(specsDir)) return [];
+  return readdirSync(specsDir)
+    .filter((f) => f.startsWith("story-") && f.endsWith(".yaml"))
+    .map((f) => join(specsDir, f));
+}
+
+function extractStoryId(relPath: string): string | null {
+  const m = basename(relPath).match(/^story-(.+)\.yaml$/);
+  return m ? m[1]! : null;
+}
+
+function makeMockReader(repoRoot: string): (path: string) => string | null {
+  return (path: string) => {
+    const abs = resolve(repoRoot, path);
+    if (!existsSync(abs)) return null;
+    try {
+      if (statSync(abs).isFile()) return readFileSync(abs, "utf8");
+    } catch {
+      return null;
+    }
+    return null;
+  };
+}
+
+/** CLI wrapper. Wraps `runSpecValidateCheck`, prints, exits. */
+export function runSpecValidateCli(argv: string[]): void {
+  let cwd = process.cwd();
+  const files: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--cwd" && argv[i + 1]) {
+      cwd = argv[i + 1]!;
+      i++;
+      continue;
+    }
+    if (a === "--help" || a === "-h") {
+      printHelp();
+      return;
+    }
+    files.push(a);
+  }
+  const result = runSpecValidateCheck(cwd, files);
+  if (result.filesChecked === 0) {
+    console.log(
+      `slowcook check spec: no spec files matched (expected specs/story-*.yaml or explicit paths).`
+    );
+    return;
+  }
+
+  let exitCode = 0;
+  for (const f of result.perFile) {
+    if (f.parseError) {
+      console.error(`FAIL ${f.file} — parse error: ${f.parseError}`);
+      exitCode = 2;
+      continue;
+    }
+    if (f.findings.length === 0) {
+      console.log(`PASS ${f.file}`);
+      continue;
+    }
+    console.error(`FAIL ${f.file} — ${f.findings.length} finding(s):`);
+    for (const finding of f.findings) {
+      console.error(
+        `  [${finding.action}] ${finding.path} — ${finding.message}`
+      );
+    }
+    if (exitCode === 0) exitCode = 1;
+  }
+  console.error("");
+  console.error(
+    `slowcook check spec: ${result.totalFindings} finding(s) across ${result.filesChecked} file(s).`
+  );
+  if (exitCode !== 0) process.exit(exitCode);
+}
+
+function printHelp(): void {
+  console.log(`
+slowcook check spec — re-run spec content validators on PRs that touch specs/story-*.yaml
+
+Usage:
+  slowcook check spec [file...] [--cwd <path>]
+
+Files default to specs/story-*.yaml when none are passed. CI workflows
+should pass the PR's changed-files list so the check stays narrow.
+
+Validators run:
+  - validateAndRepairSpec        — token truncation / shape repair
+  - validateEntityFieldReferences — entity.field references vs
+                                    .brewing/repo-knowledge/auto/backend-entities.md
+  - validateComponentReuseShape   — proposals.ui_layout.components_to_reuse
+                                    mock-vs-spec field overlap
+
+Auto-skips checks whose context is missing (no entity catalog → skip
+entity-field check; no mock/ tree → skip reuse-shape check).
+
+Exit codes:
+  0  no findings
+  1  at least one finding
+  2  invocation error (parse failure, missing file)
+`);
+}

--- a/packages/forge-github/src/templates.ts
+++ b/packages/forge-github/src/templates.ts
@@ -905,7 +905,79 @@ export function getGitHubCiArtifacts(params: {
     // 0.16.0-α.5 — SSH preview deploy + teardown for the mock app.
     { path: ".github/workflows/slowcook-preview-deploy.yml", contents: slowcookPreviewDeployWorkflow() },
     { path: ".github/workflows/slowcook-preview-teardown.yml", contents: slowcookPreviewTeardownWorkflow() },
+    // 0.19.4-α (sc#146 finding 2) — re-runs spec validators on amendment
+    // PRs. refine's in-process lint never re-fires on commits that bypass
+    // refine, so a workflow check catches drift after merge.
+    { path: ".github/workflows/slowcook-spec-validate.yml", contents: slowcookSpecValidateWorkflow() },
   ];
+}
+
+/**
+ * 0.19.4-α (sc#146 finding 2) — spec content validators as a PR check.
+ *
+ * Fires on pull_request when files matching `specs/story-*.yaml` change.
+ * Runs `slowcook check spec` against the changed-files list (so noise
+ * stays narrow). Catches:
+ *
+ *   - YAML/Zod parse failures introduced by hand-amendments
+ *   - entity.field hallucinations (validated against
+ *     `.brewing/repo-knowledge/auto/backend-entities.md`)
+ *   - components_to_reuse paths whose mock file doesn't mention the
+ *     spec's data fields (shape mismatch — caught by sc#136 lint at
+ *     refine emit time, now also at PR-amendment time)
+ *
+ * Why a workflow and not just refine's in-process lint: the in-process
+ * check fires when refine emits the spec. Hand-amendment commits push
+ * straight to git and bypass refine entirely. Without this workflow,
+ * the lint never sees them.
+ */
+export function slowcookSpecValidateWorkflow(): string {
+  return `name: slowcook spec validate
+
+# 0.19.4-α (sc#146 finding 2)
+# Re-runs spec validators on PRs that touch specs/story-*.yaml. Refine
+# runs the same lints in-process when it emits a spec; amendment
+# commits bypass refine, so they bypass the lint too. This workflow
+# closes that gap.
+
+on:
+  pull_request:
+    paths:
+      - "specs/story-*.yaml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+${RESOLVE_PIN_STEP}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Collect changed spec files
+        id: changed
+        run: |
+          BASE_SHA="\${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="\${{ github.event.pull_request.head.sha }}"
+          mapfile -t FILES < <(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" | grep -E '^specs/story-.*\\.yaml$' || true)
+          if [ "\${#FILES[@]}" -eq 0 ]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+          else
+            printf 'files=%s\\n' "\${FILES[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: slowcook check spec
+        if: steps.changed.outputs.files != ''
+        run: npx --yes "$SLOWCOOK_CLI" check spec \${{ steps.changed.outputs.files }}
+`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `slowcook check spec` subcommand + a `slowcook-spec-validate.yml` workflow template that re-runs the three spec content validators (`validateAndRepairSpec`, `validateEntityFieldReferences`, `validateComponentReuseShape`) on pull requests touching `specs/story-*.yaml`.

Closes the amendment-bypass gap noted in issue #146 finding 2 (promoted from #145 finding 1 because two amendments this session bypassed the lint).

## Why

Refine runs all three validators in-process when it emits a spec. But commits that amend an already-merged spec push directly to git and bypass refine entirely — the lint never sees them. Two amendments in the local-claude-pipeline session this PR responds to bypassed the lint:

- `user.timezone.label` (story-005 amendment) — caught only on manual post-PR re-review
- `PostAppointmentNote.{by,body,fileId}` (story-016 amendment) — caught on self-review post-emit

This workflow gives the same lint a second chance to run on a per-PR basis.

## What's new

| File | Change |
|---|---|
| `packages/cli/src/commands/check/spec-validate.ts` | New: `runSpecValidateCheck(repoRoot, paths?)` + `runSpecValidateCli(argv)`. Loads `auto/backend-entities.md` if present; constructs a `mockReader` rooted at the repo. Skips checks whose context is missing. |
| `packages/cli/src/commands/check/spec-validate.test.ts` | New: 5 tests (no-specs, valid-spec, parse-error, hallucinated-field-flagged, explicit-paths-scope). |
| `packages/cli/src/commands/check/index.ts` | Dispatch new `spec` subcommand under `check`. |
| `packages/cli/src/cli.ts` | USAGE line + check description updated. |
| `packages/forge-github/src/templates.ts` | New `slowcookSpecValidateWorkflow()` + entry in `getGitHubCiArtifacts`. |

## Test plan

- [x] `packages/cli`: 1075/1075 tests pass (5 new ones for the new subcommand)
- [x] Smoke test against delgoosh/monorepo's `specs/`: surfaces the `timezone.label` finding the previous session caught manually + one new finding (`chatThread.therapist` on story-003) we hadn't noticed
- [x] CLI help (`slowcook check spec --help`) renders
- [x] Workflow YAML lints (no syntax issues — uses the same `RESOLVE_PIN_STEP` pattern as the other 14 workflow templates)
- [ ] Workflow exercise once merged into a consumer with `init` re-run + a deliberate hallucinated amendment

🤖 Generated by local Claude Code session driving delgoosh/monorepo.