### PR TITLE
release: 0.19.4 + 0.16.2 + 0.12.3 — fourth-batch fixes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/forge-github/package.json
+++ b/packages/forge-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/forge-github",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "GitHub ForgeAdapter implementation for slowcook",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",


### PR DESCRIPTION
Triple-package patch: cli 0.19.3 → 0.19.4 + llm-anthropic 0.16.1 → 0.16.2 + forge-github 0.12.2 → 0.12.3. Carries #147 + #148 + #149 from issue #146 batch. 1075/1075 tests passing.