### PR TITLE
feat(refine): `validateRouteCollisions` — flag route.file already taken (sc#151 #3)

### DIFF
--- a/packages/cli/src/commands/check/spec-validate.ts
+++ b/packages/cli/src/commands/check/spec-validate.ts
@@ -30,6 +30,7 @@ import {
   validateAndRepairSpec,
   validateEntityFieldReferences,
   validateComponentReuseShape,
+  validateRouteCollisions,
   type SpecValidationFinding,
 } from "../refine/spec-validate.js";
 import type { Spec } from "@slowcook-ai/core";
@@ -127,6 +128,12 @@ export function runSpecValidateCheck(
       findings.push(...validateEntityFieldReferences(spec, entityCatalogMd));
     }
     findings.push(...validateComponentReuseShape(spec, mockReader));
+    // 0.19.4-α+ (sc#151 finding 3) — route-file collision check
+    findings.push(
+      ...validateRouteCollisions(spec, (relPath) =>
+        existsSync(resolve(repoRoot, relPath))
+      )
+    );
 
     totalFindings += findings.length;
     perFile.push({ file: rel, storyId, findings });

--- a/packages/cli/src/commands/refine/agent.ts
+++ b/packages/cli/src/commands/refine/agent.ts
@@ -34,6 +34,7 @@ import {
   validateAndRepairSpec,
   validateEntityFieldReferences,
   validateComponentReuseShape,
+  validateRouteCollisions,
 } from "./spec-validate.js";
 import { SpecProposalsSchema } from "./spec-yaml.js";
 import type {
@@ -492,6 +493,21 @@ export async function runRefinement(ctx: RefineContext): Promise<RefineOutcome> 
           return null;
         }
       })
+    );
+  } catch {
+    // Never fail spec emit on a lint hiccup.
+  }
+
+  // 0.19.4-α+ (sc#151 finding 3) — flag route-file collisions with
+  // existing repo files. Delgoosh story-006 proposed `/patient/chat`
+  // for peer-chat while AI chat already lived at that path; brew had
+  // to pick a different path ad-hoc. Catch the collision at refine
+  // time so the spec author resolves it before merge.
+  try {
+    validationFindings.push(
+      ...validateRouteCollisions(spec, (relPath) =>
+        existsSync(join(ctx.repoRoot, relPath))
+      )
     );
   } catch {
     // Never fail spec emit on a lint hiccup.

--- a/packages/cli/src/commands/refine/spec-validate.test.ts
+++ b/packages/cli/src/commands/refine/spec-validate.test.ts
@@ -4,6 +4,7 @@ import {
   validateEntityFieldReferences,
   parseEntityCatalog,
   validateComponentReuseShape,
+  validateRouteCollisions,
 } from "./spec-validate.js";
 import type { Spec } from "@slowcook-ai/core";
 
@@ -346,5 +347,50 @@ describe("validateComponentReuseShape", () => {
     });
     const reader = () => "x".repeat(1000);
     expect(validateComponentReuseShape(spec, reader)).toEqual([]);
+  });
+});
+
+describe("validateRouteCollisions — route file collides with existing file (sc#151 #3)", () => {
+  it("flags a route whose file already exists in the repo", () => {
+    const spec = baseSpec({
+      proposals: {
+        routes: {
+          status: "pending",
+          proposed_by: "test",
+          paths: [
+            { path: "/patient/chat", file: "apps/patient/src/app/patient/chat/page.tsx" },
+            { path: "/patient/peer-chat", file: "apps/patient/src/app/patient/peer-chat/page.tsx" },
+          ],
+        },
+      },
+    });
+    // Only /patient/chat collides; /patient/peer-chat does not.
+    const fileExists = (p: string) =>
+      p === "apps/patient/src/app/patient/chat/page.tsx";
+    const findings = validateRouteCollisions(spec, fileExists);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.path).toBe("proposals.routes.paths[0].file");
+    expect(findings[0]!.action).toBe("flagged");
+    expect(findings[0]!.message).toMatch(/already exists/);
+  });
+
+  it("returns empty when no routes proposal exists", () => {
+    const spec = baseSpec();
+    const findings = validateRouteCollisions(spec, () => true);
+    expect(findings).toEqual([]);
+  });
+
+  it("returns empty when no paths collide", () => {
+    const spec = baseSpec({
+      proposals: {
+        routes: {
+          status: "pending",
+          proposed_by: "test",
+          paths: [{ path: "/new", file: "src/app/new/page.tsx" }],
+        },
+      },
+    });
+    const findings = validateRouteCollisions(spec, () => false);
+    expect(findings).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/refine/spec-validate.ts
+++ b/packages/cli/src/commands/refine/spec-validate.ts
@@ -364,3 +364,47 @@ function pruneStringList(
   }
   return out;
 }
+
+/**
+ * 0.19.4-α+ (sc#151 finding 3) — flag every `routes.paths[].file` whose
+ * destination path is ALREADY OCCUPIED by an existing file in the consumer
+ * repo. Refine sometimes proposes a route at e.g. `/patient/chat` because
+ * the spec uses it as the natural noun, but the consumer repo already
+ * hosts a different feature at that path (AI chat vs peer chat in the
+ * delgoosh dogfood). Brew would have to either silently overwrite the
+ * live page or pick a different path on its own — neither is a clean
+ * handoff.
+ *
+ * Action is "flagged" (not "repaired") — the resolution is upstream:
+ * the spec author renames the route OR the existing file relocates
+ * before the spec merges.
+ *
+ * `fileExists` is a reader so the function stays pure + testable.
+ * Callers pass `(p) => existsSync(join(repoRoot, p))`.
+ */
+export function validateRouteCollisions(
+  spec: Spec,
+  fileExists: (path: string) => boolean
+): SpecValidationFinding[] {
+  const findings: SpecValidationFinding[] = [];
+  const paths = spec.proposals?.routes?.paths;
+  if (!paths || paths.length === 0) return findings;
+  for (let i = 0; i < paths.length; i++) {
+    const entry = paths[i];
+    if (!entry) continue;
+    const file = entry.file;
+    if (typeof file !== "string" || file.length === 0) continue;
+    if (fileExists(file)) {
+      findings.push({
+        path: `proposals.routes.paths[${i}].file`,
+        message:
+          `Spec proposes route \`${entry.path}\` mapped to file \`${file}\` — ` +
+          `that file already exists in the repo (likely an unrelated feature). ` +
+          `Rename the spec's route OR relocate the existing file before brewing; ` +
+          `brew would otherwise silently overwrite live code or pick a different path ad-hoc.`,
+        action: "flagged",
+      });
+    }
+  }
+  return findings;
+}


### PR DESCRIPTION
## Summary

New `validateRouteCollisions(spec, fileExists)` validator. Catches the case where `routes.paths[].file` would land on a path that already exists in the consumer repo. Wires into both refine's post-emit lint chain AND the spec-validate workflow shipped in #147.

Closes issue #151 finding 3 (promoted from the 5th feedback batch).

## Why

Refine sometimes proposes a route at `/patient/chat` because the spec uses the natural noun, but the consumer repo already hosts a different feature at that path. Brew is then stuck:
- Silently overwrite the live page (bad — surprise feature loss)
- Pick a different path ad-hoc (bad — spec text drifts from what shipped)
- Halt and ask the human (best, but the existing pipeline has no signal for this)

Concrete recurrence: delgoosh story-006 spec proposed `/patient/chat` → `apps/patient/src/app/patient/chat/page.tsx` while the AI chat feature already lived there. The brew worked around by landing peer-chat at `/patient/peer-chat`, but the spec text still says `/patient/chat` — invisible drift.

## What changed

`packages/cli/src/commands/refine/spec-validate.ts`:
- New `validateRouteCollisions(spec, fileExists): SpecValidationFinding[]`. Iterates `spec.proposals.routes.paths`, calls `fileExists(entry.file)`, emits a `flagged` finding per collision. `fileExists` is a reader so the function stays pure + testable.

`packages/cli/src/commands/refine/agent.ts`:
- Wires the validator into the post-emit lint chain alongside the existing three (`validateAndRepairSpec`, `validateEntityFieldReferences`, `validateComponentReuseShape`). Same try/catch envelope — never fails spec emit.

`packages/cli/src/commands/check/spec-validate.ts`:
- Wires the validator into the workflow CLI shipped in #147. Per-file findings include collision now.

`packages/cli/src/commands/refine/spec-validate.test.ts`:
- 3 new tests (collision detected; no routes proposal; no collision).

## Test plan

- [x] `packages/cli` 1078/1078 tests pass (was 1075; +3 new)
- [x] tsc build clean
- [ ] Exercise once merged: re-run `slowcook check spec specs/story-006.yaml` against delgoosh/monorepo (still has the `/patient/chat` proposal) and verify the new finding surfaces

Refs: aminazar/slowcook#151 finding 3.

🤖 Generated by local Claude Code session driving the slowcook-mimic pipeline