### PR TITLE
docs(agent-docs): combined testgen+brew PR for small stories (sc#151 #6)

### DIFF
--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -99,6 +99,18 @@ The slowcook pipeline opens one branch per stage (\`slowcook/<kind>/story-N\`). 
 - Slowcook agents stay on \`slowcook/<kind>/story-N\` branches; non-slowcook agents should use \`<your-name>/<short-description>\`.
 - Don't \`--force-push\` to shared branches. The human PM holds admin bypass for emergencies; agents don't.
 
+### Combined testgen+brew for small stories
+
+The default pipeline cadence (testgen PR → merge → brew PR → merge) is sized for medium/large stories where the test contract benefits from independent human review before brew touches it. For stories where \`spec.estimate === 'small'\` AND brew is expected to touch < ~10 files, a **combined testgen+brew PR** is acceptable:
+
+- Branch: \`slowcook/brew/story-N-<ts>\` (single branch — skip the separate \`slowcook/tests/story-N\` step)
+- Commit: ONE commit containing both the failing test scaffold AND the impl. Title clearly states "combined testgen+brew" so reviewers know what they're looking at.
+- PR body: explain why combined was chosen (small estimate, narrow surface). Reviewers can still red-line the test contract before approving — the diff just isn't split across two PRs.
+
+When NOT to combine: any story with \`estimate: medium\` or \`large\`, any story that introduces a new dependency that brew will install, any story where the test contract reasonably might change during impl. When in doubt, split.
+
+Recorded sc#151 finding 6 — the combined-PR variant was used for delgoosh story-017 (mirror of story-006) and shipped cleanly in one PR.
+
 ### Working alongside other agents (multi-agent choreography)
 
 When your work depends on another agent's still-open PR — common when one agent owns the app shell + another owns a feature inside it — follow this:


### PR DESCRIPTION
## Summary

Adds a "Combined testgen+brew for small stories" section to the managed-block scaffolded by \`slowcook upsert-agent-docs\`. The default two-PR cadence is sized for medium/large stories; for small ones the two-PR overhead is process theater.

Closes issue #151 finding 6.

## Why

The default \`testgen → merge → brew → merge\` cadence forces 4 round-trips even for stories where the test contract is just one handler test. Recurrence: delgoosh story-017 was a strict role-mirror of story-006 (estimate: small, < 10 files), delivered as ONE combined PR — cleanly. Single review surface, no coordination overhead between branches.

## What the guidance says

- Allowed when \`spec.estimate === 'small'\` AND brew touches < ~10 files
- Branch: single \`slowcook/brew/story-N-<ts>\` (skip the separate tests branch)
- Commit: ONE commit, title makes "combined testgen+brew" explicit
- PR body explains why combined was chosen
- Reviewers still red-line the test contract before approving — diff just isn't split
- When NOT to combine: medium/large stories, new-dep stories, stories where test contract might change during impl

## What didn't change

- Default pipeline cadence stays two-PR for medium/large
- The dispatch workflows (\`slowcook-brew-auto.yml\` etc.) untouched — this is a methodology guidance change, not a routing change
- No CLI behavior change

## Test plan

- [x] \`packages/cli\` 1078/1078 tests pass (no behavioral coupling — text-only addendum)
- [x] tsc build clean

Refs: aminazar/slowcook#151 finding 6.

🤖 Generated by local Claude Code session