### PR TITLE
docs(chef prompt): DTO-rename surface grep before applying edits (sc#151 #8)

### DIFF
--- a/packages/llm-anthropic/src/prompts/chef.ts
+++ b/packages/llm-anthropic/src/prompts/chef.ts
@@ -192,6 +192,13 @@ For other gaps (missing testid, className typo, missing api_contract entry):
 1. The fix is local + mechanical → autonomous.
 2. Use the \`navigator_history\`'s \`recommendation\` field as direct guidance when available.
 
+For DTO field renames in shared interfaces (e.g. \`packages/dtos/\`, \`src/types/\`, \`src/lib/entities/\`):
+1. Treat the rename as multi-file from the start. The TypeScript compiler catches typed consumers, but loose-property access (\`JSON.parse(...).oldField\`, \`row['oldField']\`, dynamic indexing) silently breaks.
+2. **Grep for the OLD field name across the entire repo before crafting edits.** Search at least \`src/\`, \`apps/\`, \`mock/\`, \`tests/\`, \`packages/\`, and \`.brewing/repo-knowledge/curated/\`. Use \`grep -rn 'oldFieldName' <dirs>\` semantics — every hit is a coordinated edit.
+3. If the search returns > 10 hits across > 3 files, the rename is structural, not surgical — return \`kind: "pm_question"\` with the hit list and ask whether the PM wants to proceed.
+4. Update curated knowledge files alongside the rename: \`co-changes.md\`, \`test-patterns.md\`, anything that referenced the old name in evidence trails.
+5. Add an entry to \`.brewing/repo-knowledge/curated/chef-known-fixes.md\` documenting the rename + the surface affected, so future agents have a reference (recorded sc#151 finding 8).
+
 ### Step 3: design the edits
 
 For each affected file:


### PR DESCRIPTION
## Summary

Extends chef's classification decision tree (Step 2) with a "For DTO field renames in shared interfaces" subsection. Tells chef to grep for the OLD field name across all consumer dirs (src/, apps/, mock/, tests/, packages/, .brewing/repo-knowledge/curated/) before crafting edits.

Closes issue #151 finding 8.

## Why

TypeScript catches consumers that import the DTO type directly. But loose-property access — \`JSON.parse(...).oldField\`, \`row['oldField']\`, dynamic indexing in test helpers, references in curated knowledge files — silently breaks on rename.

Recurrence: delgoosh story-017 renamed \`PeerChatThreadListItemDto.unreadCountForPatient\` → \`unreadCountForViewer\`. Got lucky: all 4 sites were type-safe and the compiler caught them. For a wider rename in a less type-safe layer (e.g. a test helper using bracket access), the same pattern would silently regress.

## The new guidance

1. Treat shared-DTO renames as multi-file from the start
2. \`grep -rn 'oldFieldName'\` across all repo dirs before edits
3. If > 10 hits / > 3 files → escalate to \`pm_question\` (structural rename)
4. Update curated knowledge files alongside the rename
5. Add a \`chef-known-fixes.md\` entry for future agents

## Test plan

- [x] \`packages/llm-anthropic\` build + 42 tests pass (prompt-text only, no behavior coupling)

Refs: aminazar/slowcook#151 finding 8.

🤖 Generated by local Claude Code session