### PR TITLE
feat(plate): validatePlateDtoColumns — flag DTO fields missing migration backing (sc#151 #4)

### DIFF
--- a/packages/cli/src/commands/plate/dto-columns.test.ts
+++ b/packages/cli/src/commands/plate/dto-columns.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { validatePlateDtoColumns } from "./dto-columns.js";
+
+describe("validatePlateDtoColumns — sc#151 #4", () => {
+  it("returns no findings when every DTO field matches a migration column", () => {
+    const dtos = [
+      {
+        path: "packages/dtos/src/back/peer-chat/list-threads.response.dto.ts",
+        contents: `
+export class ThreadDto {
+  threadId: string;
+  patientId: string;
+  therapistId: string;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "packages/postgres/src/migrations/1772100000000-create-peer-chat-tables.ts",
+        contents: `
+await DatabaseCreateTable(queryRunner, 'threads', [
+  { name: 'thread_id', type: 'uuid' },
+  { name: 'patient_id', type: 'uuid' },
+  { name: 'therapist_id', type: 'uuid' },
+]);
+`,
+      },
+    ];
+    expect(validatePlateDtoColumns(dtos, migrations)).toEqual([]);
+  });
+
+  it("flags a DTO field that has no backing column", () => {
+    const dtos = [
+      {
+        path: "packages/dtos/src/back/peer-chat/list-threads.response.dto.ts",
+        contents: `
+export class ThreadDto {
+  threadId: string;
+  lastMessagePreview: string | null;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "packages/postgres/src/migrations/1772100000000-create-peer-chat-tables.ts",
+        contents: `
+await DatabaseCreateTable(queryRunner, 'threads', [
+  { name: 'thread_id', type: 'uuid' },
+]);
+`,
+      },
+    ];
+    const findings = validatePlateDtoColumns(dtos, migrations);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.fieldName).toBe("lastMessagePreview");
+    expect(findings[0]!.dtoLine).toBe(4);
+    expect(findings[0]!.action).toBe("flagged");
+    expect(findings[0]!.message).toMatch(/lastMessagePreview/);
+    expect(findings[0]!.message).toMatch(/computed/);
+  });
+
+  it("accepts a field tagged with a `// computed:` comment", () => {
+    const dtos = [
+      {
+        path: "packages/dtos/src/back/peer-chat/list-threads.response.dto.ts",
+        contents: `
+export class ThreadDto {
+  threadId: string;
+  // computed: SUBQUERY against messages.body ORDER BY sent_at DESC LIMIT 1
+  lastMessagePreview: string | null;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "packages/postgres/src/migrations/1772100000000-create-peer-chat-tables.ts",
+        contents: `
+await DatabaseCreateTable(queryRunner, 'threads', [
+  { name: 'thread_id', type: 'uuid' },
+]);
+`,
+      },
+    ];
+    expect(validatePlateDtoColumns(dtos, migrations)).toEqual([]);
+  });
+
+  it("also accepts a field tagged with `// @computed`", () => {
+    const dtos = [
+      {
+        path: "x.dto.ts",
+        contents: `
+export class X {
+  // @computed
+  derived: number;
+}
+`,
+      },
+    ];
+    expect(validatePlateDtoColumns(dtos, [])).toEqual([]);
+  });
+
+  it("skips standard primary-key / audit columns (id, createdAt, etc.)", () => {
+    const dtos = [
+      {
+        path: "x.dto.ts",
+        contents: `
+export class X {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  payload: string;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "m.ts",
+        contents: `await x.addColumn('x', { name: 'payload' });`,
+      },
+    ];
+    expect(validatePlateDtoColumns(dtos, migrations)).toEqual([]);
+  });
+
+  it("matches camelCase DTO fields against snake_case migration columns", () => {
+    const dtos = [
+      {
+        path: "x.dto.ts",
+        contents: `
+export class X {
+  unreadCountForPatient: number;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "m.ts",
+        contents: `addColumn('threads', { name: 'unread_count_for_patient' })`,
+      },
+    ];
+    expect(validatePlateDtoColumns(dtos, migrations)).toEqual([]);
+  });
+
+  it("flags multiple drift fields across multiple DTOs", () => {
+    const dtos = [
+      {
+        path: "a.dto.ts",
+        contents: `
+export class A {
+  foo: string;
+  bar: string;
+}
+`,
+      },
+      {
+        path: "b.dto.ts",
+        contents: `
+export class B {
+  baz: string;
+  qux: string;
+}
+`,
+      },
+    ];
+    const migrations = [
+      {
+        path: "m.ts",
+        contents: `name: 'foo', name: 'baz'`,
+      },
+    ];
+    const findings = validatePlateDtoColumns(dtos, migrations);
+    expect(findings.map((f) => f.fieldName).sort()).toEqual(["bar", "qux"]);
+  });
+
+  it("does NOT flag jsdoc-commented fields without computed marker", () => {
+    // A vanilla jsdoc shouldn't count as a `// computed:` opt-out.
+    const dtos = [
+      {
+        path: "x.dto.ts",
+        contents: `
+export class X {
+  /** Just some description */
+  driftedField: string;
+}
+`,
+      },
+    ];
+    const findings = validatePlateDtoColumns(dtos, []);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.fieldName).toBe("driftedField");
+  });
+
+  it("computed marker is consumed once (doesn't shadow the next field)", () => {
+    const dtos = [
+      {
+        path: "x.dto.ts",
+        contents: `
+export class X {
+  // computed: from JOIN
+  firstDrift: string;
+  secondDrift: string;
+}
+`,
+      },
+    ];
+    const findings = validatePlateDtoColumns(dtos, []);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.fieldName).toBe("secondDrift");
+  });
+});

--- a/packages/cli/src/commands/plate/dto-columns.ts
+++ b/packages/cli/src/commands/plate/dto-columns.ts
@@ -1,0 +1,173 @@
+/**
+ * `validatePlateDtoColumns` — 0.19.5-α (sc#151 #4).
+ *
+ * Pure helper that flags every DTO field which has NO backing column
+ * in the consumer's TypeORM migrations AND no explicit
+ * `// computed: <source>` comment justifying its existence.
+ *
+ * Concrete recurrence (delgoosh story-006): the spec declared
+ * `lastMessagePreview` on `PeerChatThreadListItemDto` but no
+ * `last_message_body` column was added to `peer_chat_threads`. Brew
+ * was forced into a join-the-latest-message-per-row query OR returning
+ * null. Plate is the right point to surface this — the data layer
+ * (DTOs + migrations) is what plate reconciles when amending the
+ * mockup, so column-vs-DTO drift is in plate's wheelhouse.
+ *
+ * Action is "flagged" — the resolution is upstream: drop the field
+ * from the DTO OR add the backing column to the migration OR add a
+ * `// computed: <source>` comment explaining the JOIN/aggregate.
+ *
+ * Designed pure (no fs / no LLM): caller passes file contents already
+ * read. Same shape as `validateRouteCollisions` (sc#152) and
+ * `validateEntityFieldReferences` (sc#132).
+ */
+
+import type { SpecValidationFinding } from "../refine/spec-validate.js";
+
+export interface PlateDtoFinding extends SpecValidationFinding {
+  /** The DTO field name (camelCase, as it appears in TypeScript). */
+  fieldName: string;
+  /** Repo-relative path to the DTO file that declares the field. */
+  dtoFile: string;
+  /** Line number of the field declaration in the DTO file (1-based). */
+  dtoLine: number;
+}
+
+export interface DtoFile {
+  /** Repo-relative path, e.g. `packages/dtos/src/back/peer-chat/list-threads.response.dto.ts`. */
+  path: string;
+  /** Full file contents (UTF-8). */
+  contents: string;
+}
+
+export interface MigrationFile {
+  /** Repo-relative path, e.g. `packages/postgres/src/migrations/1772100000000-create-peer-chat-tables.ts`. */
+  path: string;
+  /** Full file contents (UTF-8). */
+  contents: string;
+}
+
+/**
+ * Run the check.
+ *
+ * @param dtos - all DTO files (typically the union of
+ *               `packages/dtos/src/**\/*.ts` AND the consumer's
+ *               `apps/<app>/src/modules/<feature>/dtos/*.ts`).
+ * @param migrations - all migration files
+ *                     (`packages/postgres/src/migrations/*.ts` etc.).
+ */
+export function validatePlateDtoColumns(
+  dtos: DtoFile[],
+  migrations: MigrationFile[]
+): PlateDtoFinding[] {
+  const findings: PlateDtoFinding[] = [];
+
+  // Build the set of all known column names from migration files.
+  // Migration files use the TypeORM addColumn / DatabaseCreateTable
+  // patterns; both lay column names as `name: '<snake_case>'`. We
+  // collect those literals + also store the camelCase equivalent so
+  // DTOs can match by either form.
+  const knownColumns = new Set<string>();
+  // Match `name: 'snake_case'` and `name: "snake_case"` — be liberal
+  // with whitespace + single/double quotes.
+  const colRe = /\bname\s*:\s*['"]([a-z][a-z0-9_]*)['"]/g;
+  for (const m of migrations) {
+    let match: RegExpExecArray | null;
+    while ((match = colRe.exec(m.contents)) !== null) {
+      const snake = match[1]!;
+      knownColumns.add(snake);
+      knownColumns.add(snakeToCamel(snake));
+    }
+    colRe.lastIndex = 0;
+  }
+
+  // Always-allowed identifiers: primary-key + audit columns from
+  // BaseEntity-style scaffolds. These rarely appear in migrations
+  // because they're provided by the BaseEntity helper.
+  const allowed = new Set<string>([
+    "id",
+    "createdAt",
+    "updatedAt",
+    "deletedAt",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+  ]);
+
+  for (const dto of dtos) {
+    const lines = dto.contents.split(/\r?\n/);
+    // Track the last comment we saw so we can pair it with the field
+    // beneath it (TypeScript convention: `// computed: ...` above the
+    // field declaration).
+    let lastCommentMarker: { lineNo: number; text: string } | null = null;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      const trimmed = line.trim();
+      // Detect a `// computed: ...` marker (or `// @computed`).
+      // Marker stays valid for one declaration; reset after consuming.
+      if (
+        /^\/\/\s*(?:computed|@computed)\b/i.test(trimmed) ||
+        /^\/\*\s*(?:computed|@computed)\b/i.test(trimmed)
+      ) {
+        lastCommentMarker = { lineNo: i + 1, text: trimmed };
+        continue;
+      }
+      // Skip blank lines + non-field lines but keep the marker valid
+      // through one blank line so `// computed: …\n\nfield: ...` works.
+      if (trimmed === "") continue;
+      // Skip jsdoc / generic comments — they don't qualify as
+      // computed-source markers and shouldn't shadow a real one.
+      if (
+        trimmed.startsWith("//") ||
+        trimmed.startsWith("/*") ||
+        trimmed.startsWith("*") ||
+        trimmed.startsWith("*/")
+      ) {
+        continue;
+      }
+      // Match a TypeScript field declaration. Conservative regex —
+      // we want false negatives over false positives. Matches:
+      //   foo: string;
+      //   public foo: string;
+      //   readonly foo?: string;
+      //   foo: string = "default";
+      const fieldMatch = trimmed.match(
+        /^(?:public\s+|private\s+|protected\s+|readonly\s+)*([a-z][a-zA-Z0-9_]*)\??\s*:/
+      );
+      if (!fieldMatch) continue;
+      const fieldName = fieldMatch[1]!;
+      // Skip framework / scaffolding fields.
+      if (allowed.has(fieldName)) {
+        lastCommentMarker = null;
+        continue;
+      }
+      // If we saw a computed marker for this field, accept + reset.
+      if (lastCommentMarker) {
+        lastCommentMarker = null;
+        continue;
+      }
+      // If field name matches a known column, accept.
+      if (knownColumns.has(fieldName)) {
+        continue;
+      }
+      findings.push({
+        path: `${dto.path}:${i + 1}`,
+        message:
+          `DTO field \`${fieldName}\` has no matching column in any migration + no ` +
+          `\`// computed: <source>\` comment. Either add the column to a migration, ` +
+          `drop the field from the DTO, or annotate the field with ` +
+          `\`// computed: <source>\` explaining the JOIN/aggregate that backs it.`,
+        action: "flagged",
+        fieldName,
+        dtoFile: dto.path,
+        dtoLine: i + 1,
+      });
+    }
+  }
+
+  return findings;
+}
+
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+}


### PR DESCRIPTION
## Summary

Adds pure helper \`validatePlateDtoColumns(dtos, migrations)\` to the plate command. Flags every DTO field that lacks BOTH a matching column in any migration AND a \`// computed: <source>\` comment justifying its non-column origin.

Closes issue #151 finding 4.

## Why

Concrete recurrence from the delgoosh dogfood: story-006's spec declared \`lastMessagePreview\` on \`PeerChatThreadListItemDto\` but no \`last_message_body\` column was added to \`peer_chat_threads\`. Brew was forced into either (a) join-the-latest-message-per-row (n+1) or (b) returning \`null\`. We picked (b) and flagged it for follow-up — but with this validator, plate would catch the drift before brew started.

Action is \`flagged\` (same as \`validateEntityFieldReferences\` from #132 and \`validateRouteCollisions\` from #152) — resolution is upstream: drop the field, add the column, or annotate the field as computed.

## The contract

```ts
validatePlateDtoColumns(
  dtos: DtoFile[],         // { path, contents } for each DTO file
  migrations: MigrationFile[],  // { path, contents } for each migration
): PlateDtoFinding[]       // { fieldName, dtoFile, dtoLine, action, path, message }
```

Three opt-outs:

1. **Matching column name** (camelCase↔snake_case aware): \`unreadCountForPatient\` matches \`name: 'unread_count_for_patient'\` in any migration.
2. **\`// computed: <source>\` comment** on the line above the field — explicitly opts the field out of column-backing requirement (e.g. \`// computed: SUBQUERY against messages.body ORDER BY sent_at DESC LIMIT 1\`).
3. **Standard PK/audit columns** (\`id\`, \`createdAt\`, \`updatedAt\`, \`deletedAt\` + snake variants) — always allowed.

## Why I didn't pursue the spec.api_contract version

The original sc#151 #4 finding contemplated scanning \`spec.api_contract.responses\` strings. I drafted that earlier in this batch and reverted (see issue #151 comment) — the response body is a free-text DSL string in the spec, scraping identifiers from it generates too many false positives on JOINs and nested objects.

This version is structurally different: it works against **TypeScript class declarations** (structured) instead of free-text spec strings. False-positive surface is much smaller because the inputs are concrete.

## Wire-up

The helper is exported from \`packages/cli/src/commands/plate/dto-columns.ts\` and ready to be invoked from the plate dispatch flow as a precheck. This PR ships the helper + tests so it's available for unit-test consumers + future agent loops; integrating into the main plate runtime as an active gate is a follow-up so the PR stays narrowly scoped to the validator itself (one concern per PR per CONTRIBUTING.md).

## Test plan

- [x] 9 unit tests covering: clean match, drift flagging, \`// computed\` opt-out, \`// @computed\` opt-out, standard-PK skip, camelCase↔snake_case matching, multi-DTO + multi-finding aggregation, jsdoc-doesn't-shadow-real-computed, computed marker consumed once
- [x] \`pnpm -F @slowcook-ai/cli test\` — **1087/1087** pass (was 1078; +9 new)
- [x] tsc build clean
- [ ] Smoke test against delgoosh once merged: run the helper against \`packages/dtos/src/back/peer-chat/\` + \`packages/postgres/src/migrations/*peer-chat*\` and confirm the \`lastMessagePreview\` finding surfaces

Refs: aminazar/slowcook#151 finding 4.