### PR TITLE
feat(stories): `slowcook stories status` — per-story pipeline-stage table (sc#146 #6)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { fixtures } from "./commands/fixtures/index.js";
 import { refreshKnowledge } from "./commands/refresh-knowledge.js";
 import { upsertAgentDocs } from "./commands/upsert-agent-docs.js";
 import { knowledgeAdd } from "./commands/knowledge-add.js";
+import { stories } from "./commands/stories/index.js";
 import { costLog } from "./commands/cost-log.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
@@ -83,6 +84,7 @@ Usage:
   slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]
   slowcook budget [show|set|rm] [--monthly <usd>] [--start-day <1-31>] [--story <usd>] [--cwd <path>]
   slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]
+  slowcook stories status [--cwd <path>] [--owner <login>] [--repo <name>] [--json]
   slowcook version
   slowcook help
 
@@ -116,6 +118,7 @@ Commands available in ${VERSION}:
   dispatch           Trigger a slowcook GitHub Actions workflow remotely (brew / testgen / refine).
   budget             (0.19.0-α.35) Manage the project monthly budget for the fuel gauge. \`budget set --monthly 50\` writes .brewing/budget.yaml; no args shows config + month-to-date spend.
   brand              (0.19.0-α.40, sc#82 Phase 4) Design-system foundation agent. Reads a brand brief (\`.brewing/brand.yaml\` or \`--brief\`) and emits mock/src/design-system/{tokens.ts, css.ts}. Runs once per project; \`--refresh\` overwrites.
+  stories            (0.19.5-α, sc#146 #6) Per-story pipeline-stage table. \`stories status\` reads specs/_index.yaml + queries the forge for slowcook-* labelled PRs and renders a story × stage matrix (refine / testgen / vibe / brew / chef). Falls back to branch-name matching for local-pipeline PRs that don't carry slowcook labels.
 
 Coming in later versions:
   review, dashboard
@@ -152,6 +155,12 @@ async function main(): Promise<void> {
       if (sub === "add") { await knowledgeAdd(args.slice(2)); return; }
       console.error(`unknown knowledge subcommand: ${sub ?? "(none)"}. try \`slowcook knowledge add --help\``);
       process.exit(64);
+    }
+    case "stories": {
+      // `slowcook stories status [...]` — 0.19.5-α (sc#146 #6)
+      // Per-story pipeline-stage table. See packages/cli/src/commands/stories/.
+      await stories(args.slice(1));
+      return;
     }
     case "cost": {
       // `slowcook cost log --story <id> --usd <n> --agent <name> [...]`

--- a/packages/cli/src/commands/stories/index.ts
+++ b/packages/cli/src/commands/stories/index.ts
@@ -1,0 +1,294 @@
+/**
+ * `slowcook stories <subcommand>` — 0.19.5-α (sc#146 #6).
+ *
+ * Subcommands:
+ *   - `status` — per-story stage table (refine / testgen / vibe / brew / chef)
+ *
+ * Future subcommands tracked in sc#146:
+ *   - `release` — release a story-id after supersede (parked, needs design)
+ *
+ * Stage detection delegates to the pure helper in `./status.ts`. This
+ * file is just the IO wrapper: read `specs/_index.yaml`, query the
+ * forge for PRs, render.
+ */
+
+import { execSync } from "node:child_process";
+import { readIndex } from "../refine/spec-yaml.js";
+import { GitHubAdapter } from "@slowcook-ai/forge-github";
+import {
+  buildStoriesStatus,
+  renderStoriesStatusTable,
+  type PullRequestFact,
+} from "./status.js";
+import { Octokit } from "@octokit/rest";
+
+interface StatusArgs {
+  repoRoot: string;
+  owner: string | undefined;
+  repo: string | undefined;
+  /** Render the table, exit 0. Future: --json for machine-readable. */
+  format: "table" | "json";
+}
+
+export async function stories(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  switch (sub) {
+    case "status":
+      return runStatus(argv.slice(1));
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      printHelp();
+      return;
+    default:
+      console.error(`Unknown stories subcommand: ${sub}`);
+      printHelp();
+      process.exit(64);
+  }
+}
+
+async function runStatus(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const index = readIndex(args.repoRoot);
+  const stories = index.stories ?? {};
+  const storyIds = Object.keys(stories);
+  if (storyIds.length === 0) {
+    console.log("(no stories in specs/_index.yaml)");
+    return;
+  }
+
+  // Resolve owner/repo from git remote if not passed.
+  const { owner, repo } = resolveOwnerRepo(args);
+  let prs: PullRequestFact[] = [];
+  const token = process.env["GITHUB_TOKEN"] ?? process.env["GH_TOKEN"];
+  if (owner && repo && token) {
+    try {
+      prs = await fetchAllRelevantPRs({ owner, repo, token });
+    } catch (e) {
+      console.error(
+        `Warning: failed to fetch PRs (${(e as Error).message}). Status table will report all stages as absent.`
+      );
+      prs = [];
+    }
+  } else if (!token) {
+    console.error(
+      "Warning: GITHUB_TOKEN / GH_TOKEN not set. Status table will report all stages as absent.\n" +
+        "  Set the env var to query the forge; story metadata still renders from specs/_index.yaml."
+    );
+  }
+
+  const rows = buildStoriesStatus(index, prs);
+  if (args.format === "json") {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  process.stdout.write(renderStoriesStatusTable(rows));
+}
+
+interface FetchArgs {
+  owner: string;
+  repo: string;
+  token: string;
+}
+
+/**
+ * Fetch every PR that's relevant to the slowcook pipeline for this
+ * consumer. Two sources, unioned by PR number:
+ *
+ * 1. **Branch-prefix search** (`head:slowcook/`) — catches all slowcook-
+ *    shaped branches whether or not the PR carries slowcook-* labels.
+ *    This is the primary source — local-pipeline PRs (per
+ *    `docs/local-pipeline-role.md`) frequently lack labels but always
+ *    use the branch convention.
+ * 2. **Label scan** — catches any slowcook PRs (bot or human) that
+ *    DID get labelled but happen to NOT live on a slowcook/ branch
+ *    (e.g. a Bijan-cumulative branch with a slowcook-spec label).
+ *
+ * The branch search uses GitHub's search API (single endpoint, single
+ * page for most consumers). The label scan uses the issues endpoint
+ * per-label (one paginated request per label).
+ */
+async function fetchAllRelevantPRs(args: FetchArgs): Promise<PullRequestFact[]> {
+  const octokit = new Octokit({
+    auth: args.token,
+    userAgent: "slowcook-ai/cli",
+  });
+  const byNumber = new Map<number, PullRequestFact>();
+
+  // 1. Branch-prefix search.
+  try {
+    const q = `is:pr repo:${args.owner}/${args.repo} head:slowcook/`;
+    const found = await octokit.paginate(octokit.search.issuesAndPullRequests, {
+      q,
+      per_page: 100,
+    });
+    for (const item of found) {
+      if (!item.pull_request) continue;
+      const labels = (item.labels ?? [])
+        .map((l) => (typeof l === "string" ? l : l.name ?? ""))
+        .filter((s): s is string => typeof s === "string" && s.length > 0);
+      // search API result doesn't give us head.ref or merged_at — need a
+      // pulls.get to fill these in. Batch via Promise.all later if perf
+      // becomes a concern.
+      let headBranch = "";
+      let merged = false;
+      try {
+        const { data: pr } = await octokit.pulls.get({
+          owner: args.owner,
+          repo: args.repo,
+          pull_number: item.number,
+        });
+        headBranch = pr.head?.ref ?? "";
+        merged = Boolean(pr.merged_at);
+      } catch {
+        // Best-effort — keep title/state from the search result.
+      }
+      byNumber.set(item.number, {
+        number: item.number,
+        title: item.title,
+        labels,
+        headBranch,
+        state: item.state === "closed" ? "closed" : "open",
+        merged,
+      });
+    }
+  } catch (e) {
+    console.error(
+      `Warning: branch-prefix search failed (${(e as Error).message}). Continuing with label scan only.`
+    );
+  }
+
+  // 2. Label scan — catches any slowcook PR that lacks a slowcook/
+  //    branch but DID get labelled.
+  const labels = [
+    "slowcook-spec",
+    "slowcook-tests",
+    "slowcook-mockup",
+    "slowcook-brew",
+    "slowcook-chef",
+  ];
+  for (const label of labels) {
+    try {
+      const issues = await octokit.paginate(octokit.issues.listForRepo, {
+        owner: args.owner,
+        repo: args.repo,
+        state: "all",
+        labels: label,
+        per_page: 100,
+      });
+      for (const issue of issues) {
+        if (!issue.pull_request) continue;
+        if (byNumber.has(issue.number)) {
+          // Already counted — merge labels in case we missed one.
+          const existing = byNumber.get(issue.number)!;
+          if (!existing.labels.includes(label)) existing.labels.push(label);
+          continue;
+        }
+        let headBranch = "";
+        let merged = false;
+        try {
+          const { data: pr } = await octokit.pulls.get({
+            owner: args.owner,
+            repo: args.repo,
+            pull_number: issue.number,
+          });
+          headBranch = pr.head?.ref ?? "";
+          merged = Boolean(pr.merged_at);
+        } catch {
+          // Best-effort.
+        }
+        byNumber.set(issue.number, {
+          number: issue.number,
+          title: issue.title,
+          labels: (issue.labels ?? [])
+            .map((l) => (typeof l === "string" ? l : l.name ?? ""))
+            .filter((s): s is string => typeof s === "string" && s.length > 0),
+          headBranch,
+          state: issue.state === "closed" ? "closed" : "open",
+          merged,
+        });
+      }
+    } catch {
+      // Label may not exist on the repo (e.g. consumer never used vibe).
+      // Skip silently — fine to be missing some categories.
+    }
+  }
+  return Array.from(byNumber.values());
+}
+
+function parseArgs(argv: string[]): StatusArgs {
+  const out: StatusArgs = {
+    repoRoot: process.cwd(),
+    owner: undefined,
+    repo: undefined,
+    format: "table",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === "--cwd" && next) { out.repoRoot = next; i++; }
+    else if (a === "--owner" && next) { out.owner = next; i++; }
+    else if (a === "--repo" && next) { out.repo = next; i++; }
+    else if (a === "--json") { out.format = "json"; }
+    else if (a === "--help" || a === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function resolveOwnerRepo(args: StatusArgs): { owner: string | undefined; repo: string | undefined } {
+  if (args.owner && args.repo) return { owner: args.owner, repo: args.repo };
+  // Detect from git remote.
+  try {
+    const url = execSync("git remote get-url origin", {
+      cwd: args.repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const m =
+      url.match(/github\.com[:/]([^/]+)\/([^/.]+)(?:\.git)?$/);
+    if (m) {
+      return { owner: args.owner ?? m[1], repo: args.repo ?? m[2] };
+    }
+  } catch {
+    // not a git repo, or no origin — fine
+  }
+  return { owner: args.owner, repo: args.repo };
+}
+
+// Silence the unused-import warning when stories status doesn't need
+// the adapter directly. Keep the import handy for future subcommands
+// (e.g. `stories close --pr N` could use addIssueLabels).
+void GitHubAdapter;
+
+function printHelp(): void {
+  console.log(`
+slowcook stories — per-story status across the slowcook pipeline (0.19.5-α)
+
+Usage:
+  slowcook stories status [--cwd <path>] [--owner <login>] [--repo <name>] [--json]
+
+Subcommands:
+  status   Render a table of story id × pipeline stage (refine / testgen
+           / vibe / brew / chef). Reads specs/_index.yaml + queries the
+           forge for PRs labelled with the slowcook-* stage labels.
+
+           Cell semantics:
+             ✓ — merged PR exists for this stage
+             → — open PR exists for this stage
+             ✗ — PR was opened but closed unmerged
+             — — no PR found for this stage
+
+           With --json, emits the same data as machine-readable JSON.
+
+Environment:
+  GITHUB_TOKEN | GH_TOKEN  Required to query the forge. Without it,
+                           the table renders from specs/_index.yaml
+                           only and reports all stages as absent.
+
+Refs: aminazar/slowcook#146 finding 6.
+`);
+}

--- a/packages/cli/src/commands/stories/status.test.ts
+++ b/packages/cli/src/commands/stories/status.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import type { SpecIndex } from "@slowcook-ai/core";
+import {
+  buildStoriesStatus,
+  renderStoriesStatusTable,
+  type PullRequestFact,
+} from "./status.js";
+
+function index(stories: Record<string, { title: string; status?: "draft" | "active" | "superseded"; source_issue?: string }>): SpecIndex {
+  const out: SpecIndex = { schema_version: 1, stories: {} };
+  for (const [k, v] of Object.entries(stories)) {
+    out.stories[k] = {
+      title: v.title,
+      status: v.status ?? "active",
+      source_issue: v.source_issue,
+      supersedes: [],
+      superseded_by: null,
+    };
+  }
+  return out;
+}
+
+function pr(opts: Partial<PullRequestFact> & { number: number }): PullRequestFact {
+  return {
+    number: opts.number,
+    title: opts.title ?? "",
+    labels: opts.labels ?? [],
+    headBranch: opts.headBranch ?? "",
+    state: opts.state ?? "open",
+    merged: opts.merged ?? false,
+  };
+}
+
+describe("buildStoriesStatus — sc#146 #6", () => {
+  it("returns an empty table when the index has no stories", () => {
+    const rows = buildStoriesStatus(index({}), []);
+    expect(rows).toEqual([]);
+  });
+
+  it("marks every stage absent when no PRs match the story", () => {
+    const rows = buildStoriesStatus(
+      index({ "006": { title: "Peer chat" } }),
+      []
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.storyId).toBe("006");
+    expect(rows[0]!.stages).toEqual({
+      refine: "absent",
+      testgen: "absent",
+      vibe: "absent",
+      brew: "absent",
+      chef: "absent",
+    });
+  });
+
+  it("marks a stage 'merged' when a labelled merged PR matches by title", () => {
+    const rows = buildStoriesStatus(
+      index({ "006": { title: "Peer chat" } }),
+      [
+        pr({
+          number: 727,
+          title: "feat(back): brew story-006 — peer-chat backend",
+          labels: ["slowcook-brew"],
+          headBranch: "slowcook/brew/story-006-1234",
+          state: "closed",
+          merged: true,
+        }),
+      ]
+    );
+    expect(rows[0]!.stages.brew).toBe("merged");
+    expect(rows[0]!.stages.testgen).toBe("absent");
+  });
+
+  it("marks a stage 'open' when the matching PR is open + not merged", () => {
+    const rows = buildStoriesStatus(
+      index({ "010": { title: "Therapist calendar" } }),
+      [
+        pr({
+          number: 800,
+          title: "tests: story-010 — therapist calendar",
+          labels: ["slowcook-tests"],
+          headBranch: "slowcook/tests/story-010",
+          state: "open",
+          merged: false,
+        }),
+      ]
+    );
+    expect(rows[0]!.stages.testgen).toBe("open");
+  });
+
+  it("marks a stage 'closed_unmerged' when the matching PR closed without merge", () => {
+    const rows = buildStoriesStatus(
+      index({ "007": { title: "Therapist login" } }),
+      [
+        pr({
+          number: 692,
+          title: "spec: story-007 — therapist login",
+          labels: ["slowcook-spec"],
+          headBranch: "slowcook/spec/story-007",
+          state: "closed",
+          merged: false,
+        }),
+      ]
+    );
+    expect(rows[0]!.stages.refine).toBe("closed_unmerged");
+  });
+
+  it("falls back to branch-name when labels are absent (local-pipeline pattern)", () => {
+    const rows = buildStoriesStatus(
+      index({ "006": { title: "Peer chat" } }),
+      [
+        // Local-pipeline PR may not carry slowcook-* labels — match
+        // by the slowcook/<kind>/story-N branch shape instead.
+        pr({
+          number: 727,
+          title: "feat(back): brew story-006",
+          labels: [], // intentionally no slowcook-* label
+          headBranch: "slowcook/brew/story-006-9999",
+          state: "closed",
+          merged: true,
+        }),
+      ]
+    );
+    expect(rows[0]!.stages.brew).toBe("merged");
+  });
+
+  it("matches multiple stages independently for the same story", () => {
+    const rows = buildStoriesStatus(
+      index({ "009": { title: "Patient appointments" } }),
+      [
+        pr({
+          number: 688,
+          title: "spec: story-009 — patient appointments",
+          labels: ["slowcook-spec"],
+          headBranch: "slowcook/spec/story-009",
+          state: "closed",
+          merged: true,
+        }),
+        pr({
+          number: 696,
+          title: "tests: story-009 — patient appointments",
+          labels: ["slowcook-tests"],
+          headBranch: "slowcook/tests/story-009",
+          state: "closed",
+          merged: true,
+        }),
+        pr({
+          number: 701,
+          title: "feat(patient): brew story-009",
+          labels: ["slowcook-brew"],
+          headBranch: "slowcook/brew/story-009-1234",
+          state: "closed",
+          merged: true,
+        }),
+      ]
+    );
+    expect(rows[0]!.stages).toEqual({
+      refine: "merged",
+      testgen: "merged",
+      vibe: "absent",
+      brew: "merged",
+      chef: "absent",
+    });
+  });
+
+  it("doesn't cross-match — a PR for story-006 doesn't bleed into story-016 row", () => {
+    const rows = buildStoriesStatus(
+      index({ "006": { title: "Six" }, "016": { title: "Sixteen" } }),
+      [
+        pr({
+          number: 727,
+          title: "feat: brew story-006",
+          labels: ["slowcook-brew"],
+          headBranch: "slowcook/brew/story-006-1234",
+          state: "closed",
+          merged: true,
+        }),
+      ]
+    );
+    const r006 = rows.find((r) => r.storyId === "006")!;
+    const r016 = rows.find((r) => r.storyId === "016")!;
+    expect(r006.stages.brew).toBe("merged");
+    expect(r016.stages.brew).toBe("absent");
+  });
+
+  it("sorts rows by story id lexicographically", () => {
+    const rows = buildStoriesStatus(
+      index({ "017": { title: "X" }, "005": { title: "Y" }, "010": { title: "Z" } }),
+      []
+    );
+    expect(rows.map((r) => r.storyId)).toEqual(["005", "010", "017"]);
+  });
+});
+
+describe("renderStoriesStatusTable", () => {
+  it("renders an empty-state line when no rows", () => {
+    expect(renderStoriesStatusTable([])).toMatch(/no stories/);
+  });
+
+  it("renders a header row + a divider + one line per story", () => {
+    const out = renderStoriesStatusTable(
+      buildStoriesStatus(
+        index({ "006": { title: "Peer chat" } }),
+        [
+          pr({
+            number: 727,
+            title: "feat: brew story-006",
+            labels: ["slowcook-brew"],
+            headBranch: "slowcook/brew/story-006-x",
+            state: "closed",
+            merged: true,
+          }),
+        ]
+      )
+    );
+    expect(out).toMatch(/Story/);
+    expect(out).toMatch(/refine/);
+    expect(out).toMatch(/006/);
+    expect(out).toMatch(/Peer chat/);
+    // Brew column for story 006 should have ✓ (merged glyph).
+    expect(out).toMatch(/✓/);
+    expect(out).toMatch(/Legend/);
+  });
+});

--- a/packages/cli/src/commands/stories/status.ts
+++ b/packages/cli/src/commands/stories/status.ts
@@ -1,0 +1,219 @@
+/**
+ * `slowcook stories status` pure helper — 0.19.5-α (sc#146 #6).
+ *
+ * Cross-references the consumer's `specs/_index.yaml` against PR/label
+ * facts to produce a per-story stage table. Pure function — no fs, no
+ * network. The CLI wrapper (`./index.ts`) gathers the inputs.
+ *
+ * Stage mapping (per slowcook conventions):
+ *
+ * | Stage   | Slowcook label evidence       |
+ * |---------|-------------------------------|
+ * | refine  | a `slowcook-spec` PR exists   |
+ * | testgen | a `slowcook-tests` PR exists  |
+ * | vibe    | a `slowcook-mockup` PR exists |
+ * | brew    | a `slowcook-brew` PR exists   |
+ * | chef    | a `slowcook-chef` PR exists   |
+ *
+ * Per-stage cell semantics:
+ *
+ * - `✓`  — a PR with the matching label exists AND is merged
+ * - `→`  — a PR with the matching label exists AND is open
+ * - `✗`  — a PR was opened but closed unmerged
+ * - `—`  — no PR found for this stage
+ *
+ * For consumers running the local-pipeline pattern (see
+ * `docs/local-pipeline-role.md`), the slowcook labels may not be
+ * applied to human-driven PRs. In that case the helper falls back
+ * to matching by PR-branch-name (`slowcook/<kind>/story-N` →
+ * stage=<kind>).
+ *
+ * Gantt-style stage-by-stage output is parked for a follow-up
+ * (sc#146 #6 acceptance: "Defer the Gantt-style output to a follow-up.
+ * Just ship the underlying table first.").
+ */
+
+import type { SpecIndex, SpecIndexEntry } from "@slowcook-ai/core";
+
+export type StoriesStatusCell = "merged" | "open" | "closed_unmerged" | "absent";
+
+export interface StoriesStatusRow {
+  storyId: string;
+  title: string;
+  status: SpecIndexEntry["status"];
+  sourceIssue: string | undefined;
+  /** Per-stage status. Stages: refine / testgen / vibe / brew / chef. */
+  stages: Record<"refine" | "testgen" | "vibe" | "brew" | "chef", StoriesStatusCell>;
+}
+
+export interface PullRequestFact {
+  number: number;
+  title: string;
+  /** Source-of-truth labels on the PR. */
+  labels: string[];
+  /** Branch name; used as the fallback signal when labels are absent. */
+  headBranch: string;
+  /** "open" | "closed". */
+  state: "open" | "closed";
+  /** True iff the PR is closed AND was merged. */
+  merged: boolean;
+}
+
+const STAGE_LABEL_MAP: Record<
+  "refine" | "testgen" | "vibe" | "brew" | "chef",
+  string
+> = {
+  refine: "slowcook-spec",
+  testgen: "slowcook-tests",
+  vibe: "slowcook-mockup",
+  brew: "slowcook-brew",
+  chef: "slowcook-chef",
+};
+
+/**
+ * Branch-name → stage map, used when labels are absent (the
+ * local-pipeline pattern doesn't always apply labels to human PRs).
+ *
+ * `slowcook/<kind>/story-N` → kind.
+ */
+const BRANCH_KIND_TO_STAGE: Record<string, "refine" | "testgen" | "vibe" | "brew" | "chef"> = {
+  spec: "refine",
+  tests: "testgen",
+  mockup: "vibe",
+  brew: "brew",
+  chef: "chef",
+};
+
+/**
+ * Build the status table for every story in the index.
+ *
+ * @param specIndex - the parsed `specs/_index.yaml` content
+ * @param pullRequests - all PRs in the repo (merged + open + closed-unmerged).
+ *                       The CLI wrapper passes the union of label-matched
+ *                       results; pass an empty array if GH access is
+ *                       unavailable + the row will report all stages as
+ *                       absent (still useful for spec-only summary).
+ */
+export function buildStoriesStatus(
+  specIndex: SpecIndex,
+  pullRequests: PullRequestFact[]
+): StoriesStatusRow[] {
+  const rows: StoriesStatusRow[] = [];
+  const stories = specIndex.stories ?? {};
+  for (const [storyId, entry] of Object.entries(stories)) {
+    rows.push({
+      storyId,
+      title: entry.title,
+      status: entry.status,
+      sourceIssue: entry.source_issue,
+      stages: {
+        refine: stageStateForStory(storyId, "refine", pullRequests),
+        testgen: stageStateForStory(storyId, "testgen", pullRequests),
+        vibe: stageStateForStory(storyId, "vibe", pullRequests),
+        brew: stageStateForStory(storyId, "brew", pullRequests),
+        chef: stageStateForStory(storyId, "chef", pullRequests),
+      },
+    });
+  }
+  // Sort by story id ascending (lexicographic — works because ids are
+  // zero-padded strings in the convention).
+  rows.sort((a, b) => a.storyId.localeCompare(b.storyId));
+  return rows;
+}
+
+function stageStateForStory(
+  storyId: string,
+  stage: "refine" | "testgen" | "vibe" | "brew" | "chef",
+  prs: PullRequestFact[]
+): StoriesStatusCell {
+  const label = STAGE_LABEL_MAP[stage];
+  // Story id appears in PR title (slowcook bot convention) OR in branch
+  // name (slowcook/<kind>/story-N pattern).
+  const storyTitleRe = new RegExp(`\\bstory-${escapeRegex(storyId)}\\b`);
+  const storyBranchRe = new RegExp(`/story-${escapeRegex(storyId)}(?:-|$|/)`);
+  const matches = prs.filter((pr) => {
+    const titleMatches = storyTitleRe.test(pr.title);
+    const branchMatches = storyBranchRe.test(pr.headBranch);
+    if (!titleMatches && !branchMatches) return false;
+    // Stage match: label OR branch-kind fallback.
+    if (pr.labels.includes(label)) return true;
+    // Fallback: branch shaped slowcook/<kind>/story-N — derive stage.
+    const branchKind = pr.headBranch.match(/^slowcook\/([a-z]+)\//)?.[1];
+    if (branchKind && BRANCH_KIND_TO_STAGE[branchKind] === stage) return true;
+    return false;
+  });
+  if (matches.length === 0) return "absent";
+  if (matches.some((m) => m.merged)) return "merged";
+  if (matches.some((m) => m.state === "open")) return "open";
+  return "closed_unmerged";
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Render a status row set as an ASCII-art table. Used by the CLI
+ * wrapper's stdout. Pure function — no colour codes, no terminal
+ * width detection.
+ */
+export function renderStoriesStatusTable(rows: StoriesStatusRow[]): string {
+  if (rows.length === 0) return "(no stories in specs/_index.yaml)\n";
+  const cellGlyph: Record<StoriesStatusCell, string> = {
+    merged: "✓",
+    open: "→",
+    closed_unmerged: "✗",
+    absent: "—",
+  };
+  // Column widths (story id, title — truncate title at 50 chars).
+  const storyW = Math.max(5, ...rows.map((r) => r.storyId.length));
+  const titleW = Math.min(
+    50,
+    Math.max(5, ...rows.map((r) => Math.min(50, r.title.length)))
+  );
+  const stageW = 8; // "testgen" is widest header (7 chars) — add 1 for spacing
+  const sep = (w: number) => "─".repeat(w);
+  const header =
+    pad("Story", storyW) +
+    "  " +
+    pad("Title", titleW) +
+    "  " +
+    "refine".padEnd(stageW) +
+    "testgen".padEnd(stageW) +
+    "vibe".padEnd(stageW) +
+    "brew".padEnd(stageW) +
+    "chef".padEnd(stageW);
+  const divider =
+    sep(storyW) +
+    "  " +
+    sep(titleW) +
+    "  " +
+    sep(stageW - 1) + " " +
+    sep(stageW - 1) + " " +
+    sep(stageW - 1) + " " +
+    sep(stageW - 1) + " " +
+    sep(stageW - 1);
+  const lines = [header, divider];
+  for (const row of rows) {
+    const truncatedTitle =
+      row.title.length > titleW ? row.title.slice(0, titleW - 1) + "…" : row.title;
+    lines.push(
+      pad(row.storyId, storyW) +
+        "  " +
+        pad(truncatedTitle, titleW) +
+        "  " +
+        cellGlyph[row.stages.refine].padEnd(stageW) +
+        cellGlyph[row.stages.testgen].padEnd(stageW) +
+        cellGlyph[row.stages.vibe].padEnd(stageW) +
+        cellGlyph[row.stages.brew].padEnd(stageW) +
+        cellGlyph[row.stages.chef].padEnd(stageW)
+    );
+  }
+  lines.push("");
+  lines.push("Legend: ✓ merged · → open · ✗ closed-unmerged · — absent");
+  return lines.join("\n") + "\n";
+}
+
+function pad(s: string, w: number): string {
+  return s.length >= w ? s : s + " ".repeat(w - s.length);
+}


### PR DESCRIPTION
## Summary

New CLI subcommand \`slowcook stories status\`. Reads the consumer's \`specs/_index.yaml\` and queries the forge for slowcook-pipeline PRs across every stage (refine / testgen / vibe / brew / chef), then renders a story × stage matrix.

Closes issue #146 finding 6. Gantt-style output deferred to a follow-up per maintainer triage ("Just ship the underlying table first.").

## Why

Hand-crafted survey of "which stories are at which stage" requires grepping \`specs/\` + cross-referencing GH labels + checking PR-merge status — every time. Once a consumer has > ~5 active stories the manual pass gets slow and error-prone. This subcommand makes it one command.

## Example output (from the delgoosh dogfood)

```
Story  Title                                               refine  testgen vibe    brew    chef
─────  ──────────────────────────────────────────────────  ─────── ─────── ─────── ─────── ───────
006    Patient peer-chat with assigned therapist: backen…  ✓       ✓       →       ✓       —
017    Therapist messaging connects to backend chat syst…  ✓       ✓       —       —       —
…

Legend: ✓ merged · → open · ✗ closed-unmerged · — absent
```

Detected 44 slowcook-shaped PRs on the dogfood; populated the matrix for all 12 stories.

## PR-discovery strategy (two sources, unioned)

1. **Branch-prefix search** (\`head:slowcook/\`) — catches local-pipeline PRs (per \`docs/local-pipeline-role.md\`) that often LACK slowcook-* labels but always use the branch convention.
2. **Label scan** (one paginated call per stage label) — catches bot PRs (or hand-applied labels) that live on non-slowcook branches.

Both sources hit \`pulls.get\` per PR to fill in headBranch + merged-at (search API doesn't return them). Could batch into \`Promise.all\` if perf becomes a concern; deliberately sequential for clarity in v1.

## File layout

- \`packages/cli/src/commands/stories/status.ts\` — pure helper (\`buildStoriesStatus\` + \`renderStoriesStatusTable\`). No fs, no network.
- \`packages/cli/src/commands/stories/index.ts\` — CLI wrapper (reads \`specs/_index.yaml\`, queries forge, renders). Best-effort: works without a token (renders story metadata only + reports all stages absent + prints a clear warning).
- \`packages/cli/src/commands/stories/status.test.ts\` — 11 unit tests.

Dispatch wired in \`cli.ts\` (\`slowcook stories <sub>\` → \`stories(args.slice(1))\`); USAGE updated; help string includes cell-semantics legend.

## Decisions

- **No GH \`octokit\` dep change** — used the existing \`@octokit/rest\` already in the workspace. \`GitHubAdapter\`'s \`listIssuesByLabel\` filters PRs OUT; for stories status we WANT the PRs, so the wrapper uses raw octokit. Adapter unchanged.
- **Branch fallback** is in the pure helper, not the fetch layer — so unit tests can exercise label-less PRs without mocking GitHub.
- **No \`--story\` filter** — the table is small enough that filtering is a future ergonomic.
- **\`--json\`** ships in v1 so downstream tooling can consume the output.
- **\`stories\` dispatch namespace** — sibling of \`knowledge\`, \`cost\`. Future \`stories release\` (sc#146 #1, parked for design) lands here too.

## Test plan

- [x] 11 unit tests against the pure helper covering: empty index, all-absent, label match (merged/open/closed-unmerged), branch fallback, multi-stage, cross-match isolation, lexicographic sort, render empty state, render full row
- [x] \`pnpm -F @slowcook-ai/cli test\` — **1089/1089** pass (was 1078; +11 new)
- [x] tsc build clean
- [x] Smoke-tested against delgoosh — branch-prefix search returned 44 PRs, table populated for all 12 stories
- [ ] CI build-test workflow

Refs: aminazar/slowcook#146 finding 6.