### PR TITLE
docs(plans): lock 0.20 designs #3 (story-ID tombstone) + #4 (brew_strategy)

### DIFF
--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -90,13 +90,114 @@ Known pushback: option D assumes refine + brew actively push parametrization at 
 
 ---
 
-## #3 — story-ID claim/release mechanism (PENDING)
+## #3 — story-ID claim/release mechanism (DECIDED 2026-06-01)
 
-Surfaced in #146 finding #1 + #145 finding #3. Design discussion to follow.
+### Problem
 
-## #4 — `brew_complexity` spec field (PENDING)
+Surfaced in #146 finding #1 + #145 finding #3.
 
-Surfaced in #145 finding #4. Design discussion to follow.
+Two failure modes:
+1. **Collision** — two agents (or one agent + one human) refining specs in parallel may pick the same story-ID. `nextStoryId()` exists internally but isn't exposed to mimic agents, and isn't atomic (two callers racing both see "N+1 is free").
+2. **Retirement** — when a story is superseded (delgoosh story-007 was closed-as-superseded), the ID is permanently retired by social convention but slowcook has no machinery to model it. Future refines have to manually skip past 007. If they don't, two specs share an ID across git history.
+
+### Options considered
+
+- **A** — tombstone forever. Retired specs move to `specs/_retired/story-N.yaml`; `nextStoryId()` walks both directories; numbers grow monotonically.
+- **B** — recycle. `slowcook stories release <id>` allows reuse of the lowest released ID on the next claim.
+- **C** — fork chain. Superseding spec carries `supersedes: story-007` metadata; story-007 file stays + gets a `superseded_by:` field; numbers still grow.
+- **D** — derive ID from source GH issue number. No claim/release needed because the mapping is stable.
+
+### Chosen: **A** (tombstone) with directory-based ledger
+
+- `specs/_retired/story-N.yaml` — moved-not-deleted retired spec. Front-matter prepended with `retired_reason:` + (optional) `superseded_by:`.
+- `nextStoryId(repoRoot)` extends to walk BOTH `specs/story-*.yaml` AND `specs/_retired/story-*.yaml`, picks max + 1.
+- `slowcook reserve-story-id --source-issue <N>` — atomic file-create. Calls `nextStoryId()`, creates `specs/story-N.yaml` with placeholder front-matter (claim), returns the ID. Other agents racing will see the placeholder file + pick max+2.
+- `slowcook stories release <id> --reason <text> [--superseded-by <other-id>]` — moves `specs/story-N.yaml` to `specs/_retired/story-N.yaml`, prepends front-matter fields.
+- `slowcook stories status` (the already-approved #146 #6 command) lists both active + retired.
+
+### Rationale
+
+Tombstones match how humans think about retired identifiers (don't reuse PR numbers, don't reuse issue numbers, don't reuse story-IDs). The growth concern is theoretical — 3-digit space is plenty.
+
+B is rejected because future-history grep ambiguity is a real cost: "story-007" in an old PR comment becomes ambiguous if 007 was recycled. C is rejected because we already have `related_specs[].relationship: supersedes` and C is a more-cluttered version of that — plus tombstone + `supersedes` field compose cleanly. D is rejected because conversational "story-15" is genuinely better than "story-658" for humans, and the stable-mapping benefit is small.
+
+The directory-based ledger is cleaner than a single `_retired.yaml` file: each retired spec keeps its full content + history; no schema duplication; git blame still works.
+
+### Scope estimate
+
+- 0.5d — `nextStoryId()` extends to walk `_retired/`
+- 0.25d — `slowcook reserve-story-id --source-issue` (atomic file create + tests)
+- 0.5d — `slowcook stories release` command + tests
+- 0.25d — wire into `slowcook stories status` (already-approved, gets `--include-retired` flag)
+
+**~1.5d total.** Lands in 0.20.
+
+---
+
+## #4 — `brew_complexity` spec field (DECIDED 2026-06-01)
+
+### Problem
+
+Surfaced in #145 finding #4.
+
+The existing `estimate: small/medium/large` field is a refine-time intuition hint. Brew doesn't read it. Today's story-006 (peer-chat) was `estimate: medium` per refine, but actual brew was ~1500 LoC across backend + frontend + WebSocket gateway + migration + DTOs + client-api + tests. Brew ran as a single mono-iteration; no auto-multifurcation, no pair-brew, no human-escalation.
+
+Agent's ask: define `brew_complexity: low/medium/high/x-large` so brew can pick strategy (auto-multifurcate, pair-brew, escalate).
+
+### Options considered
+
+- **A** — add `brew_complexity` as a new spec field alongside `estimate`. Author or recipe sets it. Brew reads it to pick strategy.
+- **B** — replace `estimate` with `brew_complexity`. One canonical field. Breaking schema change.
+- **C** — derive at brew start from test surface (file count + assert count + dependency graph), no spec field.
+- **D** — recipe agent emits `brew_strategy: single | multifurcate | pair-brew | escalate-to-human` directly in `recipe/manifests/<story>.json`; brew consumes the directive.
+
+### Chosen: **D** (recipe emits `brew_strategy`, no complexity field)
+
+The agent's underlying ask is "make brew pick the right strategy automatically." Complexity is the intermediate representation, never directly consumed. Skip the intermediate; encode the strategy directly.
+
+Concrete shape:
+
+```jsonc
+// recipe/manifests/story-006.json (emitted by recipe agent)
+{
+  "brew_strategy": "multifurcate",
+  "brew_strategy_reason": "backend + frontend + websocket gateway each have >5 test files; brew should split per-surface",
+  "brew_strategy_split": [
+    { "label": "backend-handlers", "test_globs": ["packages/back/**/*.handler.test.ts"] },
+    { "label": "frontend",          "test_globs": ["apps/patient/**/*.test.tsx"] },
+    { "label": "websocket",         "test_globs": ["packages/back/**/peer-chat.gateway.test.ts"] }
+  ]
+}
+```
+
+- **Recipe prompt addendum** — after testgen + vibe land, recipe picks ONE of `{single, multifurcate, pair-brew, escalate-to-human}` and writes it to the manifest.
+- **Brew strategy router** — at iteration 0, brew reads `brew_strategy` and dispatches:
+  - `single` → today's default behavior
+  - `multifurcate` → split tests by `brew_strategy_split`, open one sub-PR per split
+  - `pair-brew` → invoke the pair-brew navigator (cli α.8+)
+  - `escalate-to-human` → halt + emit a human-review-required comment on the issue
+- **PM override** — optional `brew_strategy:` field in `specs/story-N.yaml` overrides recipe's choice.
+
+### Rationale
+
+D pushes the strategy decision to the place that has the most information: recipe agent has seen the test surface, the file-touch list, the dependency graph. PM doesn't need to estimate complexity; the data is already in the manifest. PM CAN override (rare case) when they know structural complexity not captured in test count.
+
+A is rejected because two overlapping fields (`estimate` + `brew_complexity`) will confuse consumers + drift in meaning. B is rejected because breaking `estimate` is expensive for the value. C is too rigid — no PM override path, no semantic record of WHY the strategy was picked.
+
+The naming distinction matters: `brew_strategy` says what brew should DO; `brew_complexity` would say what brew SHOULD ASSESS. The directive-not-assessment framing keeps the strategy router simple.
+
+### Scope estimate
+
+- 0.5d — recipe prompt addendum + manifest schema bump
+- 1d — brew strategy router (dispatch by strategy) + tests
+- 0.5d — `brew_strategy:` PM-override field in spec yaml + validator
+- 0.5d — empirical dogfood on next medium+ story
+
+**~2.5d total.** Lands in 0.20.
+
+### Open question deferred to 0.21
+
+The `multifurcate` split heuristic: "tests by directory" works for delgoosh's NestJS-CQRS + apps/ layout but isn't universal. Stack-ts apps with co-located test files break the heuristic. Defer per-stack `multifurcateBy(adapter)` callout to 0.21 once `backend-adapter` lands (Design #1).
 
 ---
 


### PR DESCRIPTION
Resolves the remaining two design items parked from the local-claude-pipeline session batches. Companion to #162 (designs #1 + #2).

## Design #3 — story-ID claim/release: **tombstone** (option A)

- Retired specs move to \`specs/_retired/story-N.yaml\` (move-not-delete; preserves history + git blame).
- \`nextStoryId()\` walks both \`specs/story-*.yaml\` + \`specs/_retired/story-*.yaml\`; picks max + 1. Numbers never recycle.
- \`slowcook reserve-story-id --source-issue <N>\` — atomic file-create (claim). Race-safe.
- \`slowcook stories release <id> --reason <text> [--superseded-by <id>]\` — moves spec to \`_retired/\`, stamps front-matter.
- Folds into the already-approved \`slowcook stories status\` CLI (#146 #6) via \`--include-retired\` flag.

**~1.5d total.** Closes #146 finding #1 + #145 finding #3.

## Design #4 — brew_complexity field: **recipe emits brew_strategy** (option D)

No complexity field. Recipe agent emits \`brew_strategy\` directly into \`recipe/manifests/<story>.json\` after testgen + vibe land:

\`\`\`jsonc
{
  \"brew_strategy\": \"multifurcate\",
  \"brew_strategy_reason\": \"backend + frontend + websocket gateway each have >5 test files\",
  \"brew_strategy_split\": [...]
}
\`\`\`

Brew strategy router at iteration 0 dispatches \`single | multifurcate | pair-brew | escalate-to-human\`. PM-override \`brew_strategy:\` field in spec yaml for the rare structural case.

**~2.5d total.** Closes #145 finding #4.

## Cross-doc

All four 0.20 design discussions are now resolved. Implementation slots into 0.20 alongside the agent-harness items in \`0.20-decisions.md\`.

Companion doc: \`docs/plans/0.20-design-discussions.md\` (created in #162, extended here).