### PR TITLE
docs(README): refresh root Status + rewrite cli README as evergreen surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,18 @@
 
 ## Status
 
-**0.19.0 stable** (cut 2026-05-27) — the knowledge-layer arc + chef-on-brew-halt loop + α.51-α.67 hardening. Every consumer repo now carries `.brewing/repo-knowledge/{auto,curated}/` — a deterministic extraction of code shape (entities, routes, mock types, brand tokens, …) plus git-history-mined organizational memory (commit conventions, co-changes, fix-recipe seeds, ownership). Surfaced to refine + visible to any AI agent (slowcook or not — Claude Code, Cursor, etc.) via an `AGENTS.md` managed block. Empirical: on a NestJS/TypeORM consumer, refine zero-hallucinated backend routes + field names + enum values that the pre-knowledge-layer pipeline had invented.
+**0.19.5 stable** (cut 2026-06-01) — post-0.19.0 hardening batch. Five point releases over the 0.19.1 → 0.19.5 arc landed the post-emit refine lint chain (`validateEntityFieldReferences`, `validateComponentReuseShape`, `validateRouteCollisions`, `validatePlateDtoColumns`), `slowcook check spec` for PR-amendment safety, `slowcook cost log` for non-Actions agents, the chef DTO-rename surface grep, the brew dual-path + mirror-stories prompt tightening, and managed-block additions (`upsert-agent-docs`) for multi-agent choreography, no-import-stub, doc-audience, and combined-PR patterns. All four 0.20 design discussions are locked + documented in [`docs/plans/0.20-design-discussions.md`](./docs/plans/0.20-design-discussions.md): per-framework backend-adapter packages, `slowcook mirror` codegen, story-ID tombstones, recipe-emitted `brew_strategy`.
+
+The 0.19.0 foundation — `.brewing/repo-knowledge/{auto,curated}/` deterministic code-shape extraction + git-history-mined organizational memory, surfaced to refine + visible to any AI agent via an `AGENTS.md` managed block — remains the bedrock. Empirical baseline: on a NestJS/TypeORM consumer, refine zero-hallucinated backend routes + field names + enum values that the pre-knowledge-layer pipeline had invented.
 
 | Package | Version | Brings |
 |---|---|---|
-| `@slowcook-ai/cli` | `0.19.0` (latest) | knowledge layer: `refresh-knowledge` (auto digests + git-history mining), `upsert-agent-docs` (AGENTS.md managed block), `knowledge add` CLI; full chef-on-brew-halt loop; refine NestJS backend grounding; navigator scope+hallucination discipline; chef owns test infrastructure |
-| `@slowcook-ai/llm-anthropic` | `0.16.0` (latest) | prompts updated for navigator + chef discipline + refine backend digest; version-stamp leaks stripped from prompt bodies |
-| `@slowcook-ai/stack-ts` | `0.9.9` (latest) | `playwright-list` reporter accepted; degrades to `[]` |
+| `@slowcook-ai/cli` | `0.19.5` (latest) | full post-emit refine lint chain + `check spec` + `cost log` + managed-block additions + `on-brew-merged` non-main-branch warning + knowledge layer |
+| `@slowcook-ai/llm-anthropic` | `0.16.3` (latest) | chef DTO-rename surface grep + brew dual-path + brew mirror-stories addendum |
+| `@slowcook-ai/forge-github` | `0.12.3` (latest) | (no changes since 0.19.4) |
+| `@slowcook-ai/stack-ts` | `0.9.9` (latest) | (no changes since 0.19.0) |
 
-**Adopting:** `npm install @slowcook-ai/cli@0.19.0`. Pin in your `.brewing/slowcook-cli-version`. First-run consumers get the full knowledge-layer bedrock automatically via `slowcook init`.
+**Adopting:** `npm install @slowcook-ai/cli@0.19.5`. Pin in your `.brewing/slowcook-cli-version`. First-run consumers get the full knowledge-layer bedrock automatically via `slowcook init`.
 
 **Milestone 2026-05-27 — knowledge layer + chef-on-brew-halt loop closed (cli α.51 → α.65):** Eleven alphas shipped over two days. Highlights: chef stops hallucinating spec fields (α.51); brew `legacy` renamed to `freehand` with navigator default-on (α.52); chef-drift parse-tolerant (α.53); chef owns test infrastructure incl. vitest.config + package.json devDeps (α.54); navigator gets scope + hallucination discipline (α.55); chef-on-brew-halt loop fully wired: halt artifact → enrichment from iteration_diffs → checkout brew_branch → push fix as PR (α.56-α.60); refine sees NestJS/TypeORM backend digest (α.61); ten disk-cached repo-knowledge digests + curated git-history-mined files (α.62-α.63); AGENTS.md managed block (α.64); init wires the whole bedrock automatically (α.65). Empirical wins from dogfood consumers: chef wrote a real layout component (not className-padded regex bait); refine cited exact mock file paths + brand-token vocabulary + cross-story context — zero hallucinations vs the α.61 baseline that invented routes.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,210 +1,79 @@
 # @slowcook-ai/cli
 
-CLI for the slowcook brewing harness. Installs the `slowcook` binary.
+The `slowcook` CLI — TDD-first agentic development harness. Turns a detailed user story into frozen tests, then lets agents iterate under strict guardrails until every test is green.
 
-> ⚠️ **Active development — expect breaking changes.** Slowcook is pre-1.0 and the architecture itself is iterating in public. The 0.15 line was scrapped mid-cut and replaced by today's 0.16 mock-app architecture. CLI commands, file layouts, prompt contracts, and the package surface can and will change between alpha versions.
+> ⚠️ **Active development — expect breaking changes.** Slowcook is pre-1.0 and the architecture itself is iterating in public. CLI commands, file layouts, prompt contracts, and the package surface can and will change between point versions.
 >
 > If you're adopting slowcook today: pin exact versions in your consumer (`.brewing/slowcook-cli-version`), read each release entry in [the changelog](https://github.com/aminazar/slowcook/blob/main/CHANGELOG.md) before bumping, and treat it as a partnership — feedback from real consumers is what drives the next cut.
 
 ## Install
 
 ```bash
-# Stable line (0.13.x today; story-flow + bug-flow + chef orchestrator)
 npm i -D @slowcook-ai/cli
-
-# 0.16 alpha track (singular mock app + element-anchored review)
-npm i -D @slowcook-ai/cli@alpha @slowcook-ai/mock-runtime@latest
 ```
 
-The `latest` tag points at the most recent stable cut; the `alpha` tag points at the in-progress 0.16 architecture. The two are NOT installable together — pick one per consumer.
-
-## Commands (v0.4)
-
-### `slowcook refine` (first agent)
-
-Drives a GitHub issue through a clarifying-question loop until a frozen spec is emitted as a draft PR. Enforces the issue-level ratchet: new issues must not silently duplicate or contradict earlier decisions.
+Or pin a specific version (recommended for consumers):
 
 ```bash
-npx slowcook refine --issue <number> [options]
+npm i -D @slowcook-ai/cli@0.19.5
 ```
 
-**Required environment:**
+The `latest` tag points at the most recent stable cut. Stamp your pinned version in `.brewing/slowcook-cli-version` after `slowcook init`.
 
-- `ANTHROPIC_API_KEY` — for the refinement and relationship-analysis LLM calls
-- `GITHUB_TOKEN` — with `contents: write`, `issues: write`, `pull-requests: write`
+## Start here
 
-**Options:**
+If you're an AI agent (Claude Code, Cursor, etc.) or a developer driving slowcook in a consumer repo, the canonical pipeline reference is **[AGENTS.md](https://github.com/aminazar/slowcook/blob/main/AGENTS.md)** at the repo root. It has the decision tree, the pipeline at a glance, per-command quick reference, and an empirical pitfalls list that saves real money + time on your first session.
 
-| Flag | Default | Description |
-|---|---|---|
-| `--issue <number>` | required | GitHub issue number |
-| `--cwd <path>` | `.` | Repo working directory |
-| `--owner <login>` | parsed from git remote | Repo owner |
-| `--repo <name>` | parsed from git remote | Repo name |
-| `--base <branch>` | `main` | Base branch for the draft spec PR |
-| `--refine-model <id>` | `claude-opus-4-7` | Model for the refinement loop |
-| `--relationship-model <id>` | `claude-sonnet-4-5` | Model for relationship analysis |
+This README covers install + the top-level command surface. AGENTS.md covers WHEN to reach for which command, the pipeline flow, and the failure modes you're likely to hit.
 
-**Behaviour per invocation:**
+## Quick command reference
 
-1. Reads the issue (body + labels + comments) and all currently-active specs.
-2. Runs a relationship analysis: `new_or_independent | overlap | contradiction`.
-3. Acts on the verdict:
-   - **overlap** — posts a comment naming the overlapping spec ids, applies `blocked-overlap` label, exits.
-   - **contradiction** without `change-of-mind` label — posts a blocker comment, applies `blocked-contradiction` label, exits.
-   - **contradiction** with `change-of-mind` label — proceeds; the spec's `supersedes` field is populated.
-   - **new / independent** — proceeds to the refinement loop.
-4. Runs one round of refinement: either posts clarifying questions (and exits; next invocation picks up on the next PM comment) OR emits the spec YAML, writes `specs/story-N.yaml` and updates `specs/_index.yaml`, commits + pushes a branch, opens a draft PR, applies `spec-ready` label.
-
-Re-run on every new PM comment in the issue (via a GitHub Actions workflow triggered by `issue_comment` + `issues` events).
-
-### `slowcook init`
-
-Scaffold slowcook configuration in a consumer project. Writes `.brewing/*`, `.github/workflows/slowcook.yml`, and a `CODEOWNERS` section. Idempotent — re-running skips existing files unless `--force`.
+The pipeline is **refine → testgen → vibe → plate → recipe → brew → chef**. Each stage is an agent invocation that consumes the previous stage's output + commits its own PR.
 
 ```bash
-npx slowcook init [--owner <handle>] [--force] [--dry-run] [--cwd <path>]
+# Pipeline (agent-driven)
+npx slowcook refine            # GitHub issue → frozen spec PR
+npx slowcook testgen           # spec → failing test PR
+npx slowcook vibe              # spec → mockup PR
+npx slowcook plate             # mockup + tests → review-overlay annotations
+npx slowcook recipe            # tests + mockup → brew manifest
+npx slowcook brew              # iterate src/ until all tests pass
+npx slowcook chef              # post-merge drift-fix / orchestration
+
+# Setup + plumbing
+npx slowcook init              # scaffold .brewing/ + .github/workflows/ in a consumer repo
+npx slowcook refresh-knowledge # rebuild .brewing/repo-knowledge/ (auto digests + git-history mining)
+npx slowcook upsert-agent-docs # write the managed AGENTS.md block in consumer
+
+# Guards + checks
+npx slowcook guard             # frozen-paths check between two refs (CI)
+npx slowcook manifest verify   # confirm the recorded test set still resolves
+npx slowcook check spec        # re-run refine validators on a spec yaml (PR-amendment safety)
+npx slowcook recon             # pre-brew structural backstop
+
+# Knowledge + accounting
+npx slowcook knowledge add     # add a curated entry to .brewing/repo-knowledge/curated/
+npx slowcook cost log          # stamp a cost marker on a story (non-Actions agents)
 ```
 
-**Options:**
+Run `npx slowcook <command> --help` for per-command flags. All commands accept `--cwd <path>` to operate against a directory other than `.`.
 
-| Flag | Default | Description |
-|---|---|---|
-| `--cwd <path>` | `.` | Target project directory |
-| `--owner <handle>` | detected from git remote | CODEOWNERS handle/team (e.g. `@your-handle`, `@acme/frontend`) |
-| `--force` | false | Overwrite existing slowcook files |
-| `--dry-run` | false | Print the plan without writing anything |
+## Required environment
 
-**Stack detection (0.3):** reads `package.json`. Requires Vitest in `devDependencies`. If Playwright is present, it's noted as a warning and left out of `stack.json` until slowcook supports Playwright discovery.
+Most pipeline commands invoke the Anthropic API and act on GitHub:
 
-**CODEOWNERS handling:** uses `# --- slowcook:frozen-paths BEGIN/END ---` markers so re-running or adopting slowcook in a repo that already has a `CODEOWNERS` is safe.
+- `ANTHROPIC_API_KEY` — LLM calls (refine, testgen, vibe, plate, recipe, brew, chef)
+- `GITHUB_TOKEN` — `contents: write`, `issues: write`, `pull-requests: write` for PR + comment work
 
-**Exit codes:**
+`slowcook init`, `guard`, `manifest`, and `check` run locally without API/network access.
 
-- `0` — success (or dry-run completed)
-- `2` — script error (no `package.json`, vitest not found, invalid JSON)
+## What ships in this package
 
-### `slowcook guard`
+- `slowcook` binary (entry point: `dist/cli.js`)
+- Pipeline commands listed above
+- Programmatic API exports for the validators (`validateEntityFieldReferences`, `validateComponentReuseShape`, `validateRouteCollisions`, `validatePlateDtoColumns`) — useful if you want to wire the lint chain into a custom CI
 
-Checks for frozen-path violations between two git refs. Intended for CI.
-
-```bash
-npx slowcook guard --base origin/main --head HEAD
-```
-
-**Options:**
-
-| Flag | Default | Description |
-|---|---|---|
-| `--base <ref>` | `origin/main` | Base git ref to compare from |
-| `--head <ref>` | `HEAD` | Head git ref to compare to |
-| `--override` | false | Report violations but exit 0 (audit-only) |
-| `--config <path>` | `.brewing/frozen-paths.json` | Config file location |
-
-**Exit codes:**
-
-- `0` — no violations (or `--override` was set and violations existed)
-- `1` — violations detected
-- `2` — script error (missing config, git failure)
-
-**Config file** — a JSON file the consumer project ships, typically at `.brewing/frozen-paths.json`:
-
-```json
-{
-  "directories": ["tests/", "tests-fixtures/"],
-  "files": ["vitest.config.ts", "playwright.config.ts"],
-  "partial": {
-    "package.json": {
-      "frozen_key_paths": ["scripts.test", "scripts.e2e"]
-    }
-  }
-}
-```
-
-- `directories` — prefix match; anything under these paths is frozen.
-- `files` — exact path match.
-- `partial` — for files where only certain JSON keys are frozen (e.g., only `scripts.test*` in `package.json`).
-
-### Use in GitHub Actions
-
-```yaml
-# .github/workflows/frozen-paths-guard.yml
-name: frozen-paths-guard
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-
-jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - name: Run guard
-        env:
-          HAS_OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'override-freeze') }}
-        run: |
-          ARGS="--base origin/${{ github.base_ref }} --head HEAD"
-          if [ "$HAS_OVERRIDE" = "true" ]; then ARGS="$ARGS --override"; fi
-          npx --yes @slowcook-ai/cli@latest guard $ARGS
-```
-
-The guard emits `::error file=...::` annotations and writes to `$GITHUB_STEP_SUMMARY` when run in GitHub Actions.
-
-### `slowcook manifest` (record / verify)
-
-Captures the set of discoverable tests so agents can't silently remove or exclude them. 0.2 supports Vitest; Playwright is coming later.
-
-```bash
-# Record a snapshot of every test currently discoverable
-npx slowcook manifest record
-
-# Verify later that the recorded set still fully resolves
-npx slowcook manifest verify
-```
-
-**Options (both subcommands):**
-
-| Flag | Default | Description |
-|---|---|---|
-| `--stack-config <path>` | `.brewing/stack.json` | Consumer stack config |
-| `--manifest <path>` | `.brewing/manifests/all.json` (or `.brewing/manifests/story-<id>.json` if `--story`) | Where to write / read the manifest |
-| `--story <id>` | none | Tag manifest with a story id (enables per-story freezing) |
-| `--cwd <path>` | `.` | Working directory for discovery commands |
-
-**Config file** — `.brewing/stack.json` declares how to discover tests per suite:
-
-```json
-{
-  "language": "typescript",
-  "test": {
-    "backend": {
-      "runner": "vitest",
-      "run_command": "npx vitest run",
-      "discover_command": "npx vitest list",
-      "reporter_format": "vitest-list-lines"
-    }
-  }
-}
-```
-
-**Exit codes:**
-
-- `record`: `0` manifest written, `2` script error (bad config, suite discovery failed)
-- `verify`: `0` manifest matches (new tests since record are informational), `1` recorded tests no longer discoverable, `2` script error
-
-**Use in GitHub Actions** — after the frozen-paths guard:
-
-```yaml
-      - name: Verify test manifest
-        run: npx --yes @slowcook-ai/cli@latest manifest verify
-```
-
-## Coming in later versions
-
-See the [monorepo README](../../README.md) for the roadmap.
+The companion packages (`@slowcook-ai/core`, `@slowcook-ai/llm-anthropic`, `@slowcook-ai/forge-github`, `@slowcook-ai/stack-ts`, `@slowcook-ai/mock-runtime`) install transitively as workspace deps. The cli is the only one you `npm i` directly.
 
 ## License
 


### PR DESCRIPTION
Two README-drift fixes surfaced when reviewing the npm-facing surface of @slowcook-ai/cli.

## packages/cli/README.md (the bigger problem)

Was stuck at **\"Commands (v0.4)\"** — documented only \`refine\` + \`init\` + \`guard\` + \`manifest\`. Missing every command shipped since: testgen, vibe, plate, recipe, brew, chef, knowledge, refresh-knowledge, recon, refactor, cost log, check spec, upsert-agent-docs. Install section claimed \"Stable line (0.13.x today)\" while we're at 0.19.5.

**Rewritten as a thin evergreen surface:**
- Install + version-stamping guidance
- Top-level command index (refine → testgen → vibe → plate → recipe → brew → chef pipeline + plumbing + guards + knowledge)
- Required-env section
- Pointer to **AGENTS.md** for the canonical pipeline reference

Stops drifting on every release because it stops trying to be exhaustive.

## README.md root

Status section was at 0.19.0. Bumped to 0.19.5; added the post-0.19.0 hardening batch summary (validator chain + check spec + cost log + managed-block adds); referenced the 0.20 design-discussions doc.

## Why this matters

npm consumers see \`packages/cli/README.md\` when they install. Right now it tells them slowcook is a four-command tool from a year ago. Fixing this is the cheap step before doing any marketing work on adoption.