### PR TITLE
docs(plans): 0.20 design #5 — `slowcook serve` multi-mode (dev + mock + staging)

### DIFF
--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -201,6 +201,147 @@ The `multifurcate` split heuristic: "tests by directory" works for delgoosh's Ne
 
 ---
 
+## #5 — `slowcook serve` — multi-mode dev / mock / staging on a shared box (PROPOSED 2026-06-01)
+
+### Problem
+
+Surfaced from delgoosh fast-iteration work (delgoosh PR #737, #738; June 2026).
+
+Three distinct "live preview" lifecycles exist for a single repo, and each pushes consumers to hand-roll the same plumbing:
+
+1. **Live-dev** — bind-mount `dev` branch source into a `next dev` container so UI/route edits propagate in <30s without a docker rebuild. Today's `slowcook dev-env push` ships the source-push half; the runtime overlay (which compose service to swap, which port to map, which env to inject) is per-consumer hand-rolled.
+2. **Mock-vite** — a vite mock server (PM/designer feedback loop for vibe artefacts) on the same box, served at a different port, mirroring the consumer's `mock/` package output. Today: not addressed by slowcook at all.
+3. **Staging** — a fully-built container set with a pre-seeded demo dataset for PM-driven walkthroughs + manual QA. Reset to a known state on each redeploy. Today: not addressed by slowcook.
+
+All three need the same plumbing: SSH credential storage, source-push or image-push, compose-overlay bring-up, log access, reset/teardown. Each consumer that wires these up writes a slightly different version, drifts, and re-derives the same gotchas (`Dockerfile.<app>` missing `COPY public/`, dev-overlay needs anonymous-volume node_modules, `next dev` listens on `0.0.0.0` not `localhost`).
+
+Naming: user-floated `slowcook box {init,sync,up,down,logs}` first; revised to `slowcook serve` because "box" describes infrastructure and "serve" describes intent — and `serve` reads naturally as `slowcook serve dev`, `slowcook serve mock`, `slowcook serve staging`.
+
+### Options considered
+
+- **A** — extend the existing `slowcook dev-env` command with two more `mode` enum values (`mock`, `staging`) + per-mode subcommands. One namespace.
+- **B** — net-new `slowcook serve <profile>` command that subsumes `dev-env`'s `up/sync/reset` lifecycle ops; keep `dev-env push/switch` as a thin alias for the `dev` profile's source-sync.
+- **C** — keep `dev-env` as-is for the dev profile; ship `slowcook mock` and `slowcook staging` as sibling commands. Three namespaces.
+- **D** — slowcook ships no runtime command for this; just publish a docs/recipe page + a reusable GH Action (`slowcook-ai/serve-action@v1`) consumers reference in their own workflows.
+
+### Chosen: **B** (proposed — awaiting maintainer + dogfood)
+
+- **`slowcook serve <profile>`** — top-level command. Profiles are declared in `.brewing/dev-env.yaml` (renamed to `.brewing/serve.yaml`, with backward-compat read of the old path). Built-in profile names: `dev`, `mock`, `staging`. Consumers can declare custom profiles (`e2e`, `loadtest`, etc.) following the same shape.
+- **Subcommands per profile:**
+  - `slowcook serve <profile> up [--service <name>]` — bring up the profile's compose overlay (subset of services if `--service`).
+  - `slowcook serve <profile> sync [--branch <name>]` — source-sync (today's `dev-env push` generalised to any profile that's source-bound).
+  - `slowcook serve <profile> reset [--scenario <name>]` — re-seed (only meaningful for `staging`; no-op for `dev`).
+  - `slowcook serve <profile> logs [--service <name> --follow]` — pass-through to docker-compose logs.
+  - `slowcook serve <profile> down` — stop the profile's services (leave volumes; explicit `--prune` to drop them).
+- **Configuration shape:**
+  ```yaml
+  # .brewing/serve.yaml (was dev-env.yaml; both paths supported)
+  ssh:
+    host_secret: DELGOOSH_DEV_SSH_HOST   # name of GH-secret OR env-var
+    user_secret: DELGOOSH_DEV_SSH_USER
+    key_secret:  DELGOOSH_DEV_SSH_KEY
+    target_dir:  /opt/delgoosh-dev       # where source/images land on the box
+  profiles:
+    dev:
+      mode: bind-mount-source            # source rsync, no rebuild
+      source_branch: dev                 # which git branch tracks this profile
+      compose_overlay: docker-compose/docker-compose.dev.yml
+      apps:
+        patient:   { mode: next-dev,   port: 3001 }
+        therapist: { mode: next-dev,   port: 3002 }
+        back:      { mode: nest-watch, port: 4002 }
+      seed: none
+    mock:
+      mode: bind-mount-source
+      source_branch: main                # mock reflects merged trunk by default
+      compose_overlay: docker-compose/docker-compose.mock.yml
+      apps:
+        mock-vite: { mode: vite-dev, port: 5173 }
+      seed: none
+    staging:
+      mode: built-image                  # `docker image push` from CI, not rsync
+      source_branch: main                # promoted from main via release tag
+      compose_overlay: docker-compose/docker-compose.staging.yml
+      apps:
+        patient:   { mode: next-start, port: 3101 }
+        therapist: { mode: next-start, port: 3102 }
+        back:      { mode: nest-prod,  port: 4102 }
+      seed:
+        scenario: demo
+        scripts:
+          - packages/seeds/demo/*.ts     # idempotent re-seed
+        guard_env: STAGING_RESET_ALLOWED # safety belt
+  ```
+- **Credential storage** — slowcook respects GH Secrets when run under Actions; respects local env (set via `direnv` or `.envrc`) when run interactively. The config file references secrets by *name* not value (`host_secret: DELGOOSH_DEV_SSH_HOST`), so the same `serve.yaml` works in CI + local without leaking. A future `slowcook serve init` may offer `--from-ssh-config <host-alias>` to bootstrap from `~/.ssh/config`.
+- **Shared-box-by-default with port-namespacing** — the three profiles can coexist on a single host because each profile's apps own distinct host ports (3001/3002/3003 for dev, 5173 for mock, 3101/3102 for staging). The container names are also profile-prefixed to prevent collision (`<repo>-dev-patient`, `<repo>-staging-patient`).
+- **Consumer-supplied compose overlays** — slowcook does NOT ship a "one true compose overlay." Each profile points at a consumer-owned `docker-compose/<profile>.yml`. Slowcook provides a `slowcook serve <profile> init` that scaffolds a starter overlay from the consumer's detected app modes (similar to `dev-env init`'s stub today).
+
+### Rationale
+
+**B over A** — extending `dev-env`'s flat `mode` enum quickly conflates two orthogonal axes: lifecycle (push-source vs push-image vs reset-seed) and source-of-truth (which branch tracks this env). Profiles separate them cleanly; `dev-env`'s current `push/switch` map naturally onto the `dev` profile's `sync` action and stay backward-compat as aliases.
+
+**B over C** — three sibling commands (`slowcook mock`, `slowcook staging`, `slowcook dev-env`) duplicate the SSH-config + compose-overlay plumbing three times. The verb-profile split keeps shared plumbing in one place and lets consumers add custom profiles (e2e, loadtest, perf) without slowcook owning every verb.
+
+**B over D** — a GH-Action-only solution works for the CI path but doesn't help the human in the loop (PM bringing up staging from their laptop for a walkthrough, dev sshing for a quick `reset --scenario demo`). The CLI is the load-bearing surface; the action wraps it.
+
+**Why "serve" not "deploy" not "box":**
+- `deploy` already means "promote to production." Using it for fast-iteration push muddies the distinction. (Aligns with user's pushback against `slowcook box`.)
+- `box` describes infra; `serve` describes intent. The same verb works whether the profile runs on a remote box, a docker-desktop on the dev's laptop, or (eventually) a managed slowcook-hosted preview environment.
+
+**Why consumer-owned overlays:**
+- Frameworks vary too much for a one-size-fits-all dev compose (NestJS dev vs ts-node-dev vs nest start --watch; Next dev vs Vite dev vs Astro dev). Slowcook ships the *plumbing* (sync, bring-up, logs, reset); the consumer ships the overlay.
+- This mirrors the existing `dev-env` design (the consumer wires `docker-compose.production.yml` + `docker-compose.dev.yml`; slowcook orchestrates).
+
+### Open trade-offs (resolve before DECIDED)
+
+1. **`serve.yaml` vs `dev-env.yaml` filename** — renaming costs consumer migrations. Could keep the existing path forever (`dev-env.yaml`) and just rename the command, or rename file + ship a one-shot `slowcook serve init --from-dev-env` migrator. Lean toward keeping the filename to minimise migration cost; the command name + concept rename is enough.
+2. **Seed-script execution model** — `scripts: [packages/seeds/demo/*.ts]` assumes the seed scripts can run inside the staging container. For consumers whose seeds need backend DI / module context, slowcook may need a `seed_runner: nest-cli | ts-node | docker-exec` hint. Defer to follow-up; default to `ts-node` + document the escape hatch.
+3. **Mode `built-image` push channel** — `docker image push` to a private registry vs ssh-tar an image vs a self-hosted runner that builds in place. Probably "use whatever the consumer's existing dev-deploy uses"; slowcook just calls into the consumer's bring-up script. Don't ship image-build itself.
+4. **Mock-profile usefulness threshold** — only valuable if the consumer's `mock/` package is a vite-runnable app (today delgoosh's is). If `mock/` is a static export consumed at vibe time only, the `mock` profile is dead weight. Detect at `serve init`: if `mock/package.json` has `"scripts.dev"`, scaffold it; else skip.
+5. **Reset-scenario plurality** — `staging` may want multiple named scenarios (`demo`, `enterprise-tier`, `low-volume`, `post-incident`). The proposed `seed.scenario` is a single value; the resolved shape may be `seed.scenarios: { demo: { scripts: [...] }, ... }` with `serve staging reset --scenario demo`.
+
+### Prior art
+
+- **Vercel Preview Environments** — per-PR preview URL, ephemeral. Slowcook `serve` profiles are *long-lived per-environment* not per-PR; the `dev-env push --story` operation gives per-story preview within the long-lived `dev` profile (same URL, different branch).
+- **Coolify / Dokku / Caprover** — self-hosted PaaS layers. Adjacent but heavier: they own the runtime + reverse proxy. `slowcook serve` is thinner: it expects docker-compose on the box + adds the *agent-pipeline-aware* operations (per-story push, seed reset by named scenario, brew-PR → preview URL).
+- **GitHub Codespaces** — ephemeral dev env per dev. Different problem; codespaces don't solve "shared box for PM + designer + QA all looking at the same artefact."
+- **Render / Railway preview envs** — paid, hosted. Slowcook `serve` targets self-hosted infra (consumer-owned box) by default; a hosted-slowcook offering could later wrap the same commands against managed infra (per the 0.20 OSS/commercial split).
+
+### Scope estimate
+
+Three tranches; each lands independently.
+
+**Tranche 1 — `serve dev` (replaces `dev-env up/sync/reset` stubs)** — 2d
+- Profile config schema (zod) + `dev` profile only
+- `serve dev up/sync/down/logs` subcommands (extend existing dev-env code)
+- Backward-compat alias `dev-env push` → `serve dev sync`
+- One dogfood on delgoosh (replace this proposal's prototype PR #737/#738 plumbing)
+
+**Tranche 2 — `serve mock`** — 1.5d
+- Vite-dev compose overlay scaffolding (`serve mock init`)
+- Mock-profile docs (where vibe artefacts surface)
+- Dogfood on delgoosh's `mock/` package
+
+**Tranche 3 — `serve staging`** — 3d (the heaviest)
+- Built-image profile mode (image-pull on box vs source-rsync)
+- Seed-scenario shape + idempotent re-seed wrapper
+- `staging reset` with prod-guard + audit-log
+- Dogfood on delgoosh staging (TBD; needs separate box or shared-box port allocation)
+
+**~6.5d total across 0.20 + 0.21.** Tranche 1 likely lands in 0.20 alongside Design #1 (backend-adapter); Tranches 2 + 3 are 0.21 candidates.
+
+### Status — what unblocks DECIDED
+
+This entry is **PROPOSED**, not DECIDED, because:
+
+- The naming choice (`serve` vs extending `dev-env`) is reversible but consumer-facing — worth a 1-week soak before locking.
+- The shared-box-with-port-namespacing assumption hasn't been dogfooded; staging on a separate box may turn out to be the right default after we try sharing.
+- The `built-image` channel needs one concrete consumer use case to design against; delgoosh doesn't have staging yet so the design is speculative.
+
+Recommended next step before DECIDED: empirically dogfood Tranche 1 on delgoosh (we already have the prototype via PR #737/#738). If it generalises cleanly to a second consumer, lock the design + ship Tranche 1; revisit 2 + 3 with concrete asks.
+
+---
+
 ## Cross-doc references
 
 - Strategy + ideation: [`0.20-and-beyond.md`](./0.20-and-beyond.md)


### PR DESCRIPTION
## Summary

Adds entry #5 to \`docs/plans/0.20-design-discussions.md\`: **\`slowcook serve\`** — a multi-mode (dev / mock / staging) live-preview surface that generalises the plumbing consumers hand-roll today.

**Status: PROPOSED, not DECIDED.** Three open trade-offs flagged; awaiting maintainer review + a dogfood validation pass before locking.

### Motivation

Surfaced from delgoosh PR #737 (docker-compose.dev.yml overlay) and #738 (.github/workflows/dev-fast-sync.yml). Building the fast-iteration loop there made it clear that the same plumbing (SSH creds, source/image push, compose-overlay bring-up, log access, reset/teardown) gets re-derived for every "live preview" lifecycle a consumer wants:

1. **Live-dev** — bind-mount \`dev\` branch into \`next dev\` for <30s push→browser-refresh loop
2. **Mock-vite** — designer/PM vibe-feedback loop running on the same box
3. **Staging** — built-image deploy with pre-seeded demo data + idempotent reset

Today's \`slowcook dev-env\` covers half of #1; #2 and #3 are entirely consumer-rolled.

### Shape

- New top-level command \`slowcook serve <profile> <verb>\` (\`up\`/\`sync\`/\`reset\`/\`logs\`/\`down\`).
- Profiles declared in \`.brewing/serve.yaml\` (backward-compat read of \`.brewing/dev-env.yaml\`).
- Built-in profile types: \`dev\` (bind-mount source), \`mock\` (vite-dev), \`staging\` (built-image + seed scenario). Consumers can declare custom profiles (\`e2e\`, \`loadtest\`).
- Consumer-owned compose overlays per profile; slowcook ships orchestration plumbing only.
- Shared-box-by-default with profile-prefixed container names + distinct port allocations to prevent collision.

### Naming

User-floated \`slowcook box\` first; revised to \`slowcook serve\`:
- \`deploy\` already means "promote to production" — using it for fast-iteration push muddies the distinction.
- \`box\` describes infra, \`serve\` describes intent. Works for remote box, docker-desktop, or future managed previews.

### Tranches

- **Tranche 1 (\`serve dev\`, replaces dev-env up/sync/reset stubs)** — ~2d, 0.20 candidate
- **Tranche 2 (\`serve mock\`)** — ~1.5d, 0.21
- **Tranche 3 (\`serve staging\`)** — ~3d, 0.21 (heaviest — built-image channel + seed-scenario model)

### Open trade-offs (need maintainer call before DECIDED)

1. \`serve.yaml\` vs \`dev-env.yaml\` filename — consumer-migration cost
2. Seed-script execution model (\`ts-node\` default + escape hatch?)
3. \`built-image\` channel (registry push vs ssh-tar vs in-place runner build)
4. Mock-profile detection threshold (skip if consumer's \`mock/\` isn't vite-runnable)
5. Multi-scenario reset (\`demo\` / \`enterprise\` / \`post-incident\` etc.)

### What this PR is NOT

- Not implementation. This is a design entry; ship as separate PRs gated on this entry moving to DECIDED.
- Not a rewrite of \`dev-env\`. Tranche 1 keeps \`dev-env push/switch\` as backward-compat aliases for \`serve dev sync\`.

## Test plan

- [ ] Maintainer reads entry #5 against the existing #1-#4 style — does the shape match?
- [ ] Trade-offs 1-5 each get a thumbs-up or pushback comment
- [ ] If accepted as direction → move status to DECIDED + spin Tranche 1 spec into \`specs/\` for normal pipeline ingest

## Cross-refs

- delgoosh PR #737 (compose overlay) — prototype
- delgoosh PR #738 (fast-sync workflow) — prototype
- slowcook \`docs/plans/dev-env-checkpoint-phase-3.md\` — existing dev-env phase context

🤖 Generated with [Claude Code](https://claude.com/claude-code)