### PR TITLE
docs(plans): promote design #5 (slowcook serve) PROPOSED → DECIDED

### DIFF
--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -201,7 +201,7 @@ The `multifurcate` split heuristic: "tests by directory" works for delgoosh's Ne
 
 ---
 
-## #5 — `slowcook serve` — multi-mode dev / mock / staging on a shared box (PROPOSED 2026-06-01)
+## #5 — `slowcook serve` — multi-mode dev / mock / staging on a shared box (DECIDED 2026-06-01)
 
 ### Problem
 
@@ -224,7 +224,7 @@ Naming: user-floated `slowcook box {init,sync,up,down,logs}` first; revised to `
 - **C** — keep `dev-env` as-is for the dev profile; ship `slowcook mock` and `slowcook staging` as sibling commands. Three namespaces.
 - **D** — slowcook ships no runtime command for this; just publish a docs/recipe page + a reusable GH Action (`slowcook-ai/serve-action@v1`) consumers reference in their own workflows.
 
-### Chosen: **B** (proposed — awaiting maintainer + dogfood)
+### Chosen: **B**
 
 - **`slowcook serve <profile>`** — top-level command. Profiles are declared in `.brewing/dev-env.yaml` (renamed to `.brewing/serve.yaml`, with backward-compat read of the old path). Built-in profile names: `dev`, `mock`, `staging`. Consumers can declare custom profiles (`e2e`, `loadtest`, etc.) following the same shape.
 - **Subcommands per profile:**
@@ -292,13 +292,19 @@ Naming: user-floated `slowcook box {init,sync,up,down,logs}` first; revised to `
 - Frameworks vary too much for a one-size-fits-all dev compose (NestJS dev vs ts-node-dev vs nest start --watch; Next dev vs Vite dev vs Astro dev). Slowcook ships the *plumbing* (sync, bring-up, logs, reset); the consumer ships the overlay.
 - This mirrors the existing `dev-env` design (the consumer wires `docker-compose.production.yml` + `docker-compose.dev.yml`; slowcook orchestrates).
 
-### Open trade-offs (resolve before DECIDED)
+### Trade-off resolutions (locked)
 
-1. **`serve.yaml` vs `dev-env.yaml` filename** — renaming costs consumer migrations. Could keep the existing path forever (`dev-env.yaml`) and just rename the command, or rename file + ship a one-shot `slowcook serve init --from-dev-env` migrator. Lean toward keeping the filename to minimise migration cost; the command name + concept rename is enough.
-2. **Seed-script execution model** — `scripts: [packages/seeds/demo/*.ts]` assumes the seed scripts can run inside the staging container. For consumers whose seeds need backend DI / module context, slowcook may need a `seed_runner: nest-cli | ts-node | docker-exec` hint. Defer to follow-up; default to `ts-node` + document the escape hatch.
-3. **Mode `built-image` push channel** — `docker image push` to a private registry vs ssh-tar an image vs a self-hosted runner that builds in place. Probably "use whatever the consumer's existing dev-deploy uses"; slowcook just calls into the consumer's bring-up script. Don't ship image-build itself.
-4. **Mock-profile usefulness threshold** — only valuable if the consumer's `mock/` package is a vite-runnable app (today delgoosh's is). If `mock/` is a static export consumed at vibe time only, the `mock` profile is dead weight. Detect at `serve init`: if `mock/package.json` has `"scripts.dev"`, scaffold it; else skip.
-5. **Reset-scenario plurality** — `staging` may want multiple named scenarios (`demo`, `enterprise-tier`, `low-volume`, `post-incident`). The proposed `seed.scenario` is a single value; the resolved shape may be `seed.scenarios: { demo: { scripts: [...] }, ... }` with `serve staging reset --scenario demo`.
+1. **Filename** — **keep `dev-env.yaml`**. Rename the command + concept only. `slowcook serve` reads both `.brewing/serve.yaml` (new) and `.brewing/dev-env.yaml` (legacy) forever; new consumers get the new path via `slowcook init`. Zero migration cost for existing consumers.
+2. **Seed runner** — **`ts-node` only for v1**. No `seed_runner` enum. Consumers whose seeds need backend DI shell out from their seed script (`exec("nest exec ...")`). Add the runner field when a real consumer files an ask.
+3. **`built-image` push channel** — **slowcook ships zero image-build pipeline**. The `built-image` profile mode just calls into the consumer's existing bring-up script (`bringup_cmd:` in profile config). Same posture as `dev-env` today (consumer owns the overlay; slowcook orchestrates).
+4. **Mock-profile detection** — **auto-skip via `mock/package.json#scripts.dev`**. `slowcook serve mock init` scaffolds the profile only if the consumer's `mock/` has a `dev` script. Silent skip otherwise; no dead-weight profile.
+5. **Reset-scenario shape** — **map from day 1**. Drop the single-value `seed.scenario` form. The shape is `seed.scenarios: { demo: {scripts: [...]}, enterprise: {...}, post-incident: {...} }`; `serve staging reset --scenario demo` picks one. Cheaper to use the flexible shape now than migrate later.
+
+### Additional decisions (out of scope when proposal landed; locked at DECIDED)
+
+- **Compose-only for v1.** The runtime adapter is docker-compose. Plain docker / k8s / fly machines / podman are post-1.0 plug-points (`runner_adapter:` field deferred).
+- **`bind-mount-source` mode** uses **rsync to a host directory + anonymous-volume `node_modules` in the compose overlay** (not bind-mount-directly-into-compose). Avoids node_modules collision on macOS + chmod surprises. Resolved choice documented in Tranche 1's `serve dev` README.
+- **Tranches all in 0.20.** Originally Tranches 2+3 were 0.21 candidates; promoted to 0.20 per maintainer ask to deliver the full dev+mock+staging surface together.
 
 ### Prior art
 
@@ -328,17 +334,16 @@ Three tranches; each lands independently.
 - `staging reset` with prod-guard + audit-log
 - Dogfood on delgoosh staging (TBD; needs separate box or shared-box port allocation)
 
-**~6.5d total across 0.20 + 0.21.** Tranche 1 likely lands in 0.20 alongside Design #1 (backend-adapter); Tranches 2 + 3 are 0.21 candidates.
+**~6.5d total.** All three phases ship in 0.20. Phase 1 first (establishes the profile-config schema all three consume); Phases 2 + 3 sequence after Phase 1 lands but can run in parallel branches.
 
-### Status — what unblocks DECIDED
+### Why DECIDED (not staying PROPOSED)
 
-This entry is **PROPOSED**, not DECIDED, because:
+Maintainer explicit call 2026-06-01: deliver dev + mock + staging together, don't slow-walk Phases 2 + 3 behind dogfood signal. Reasoning: the consumer asks for the same shared-box-multi-profile pattern are already concrete (delgoosh has the prototype for dev via PR #737/#738; vibe-feedback loop needs the mock profile; PM demo workflow needs the staging profile with pre-seeded scenarios). Building all three to one consistent shape now is cheaper than retrofitting later.
 
-- The naming choice (`serve` vs extending `dev-env`) is reversible but consumer-facing — worth a 1-week soak before locking.
-- The shared-box-with-port-namespacing assumption hasn't been dogfooded; staging on a separate box may turn out to be the right default after we try sharing.
-- The `built-image` channel needs one concrete consumer use case to design against; delgoosh doesn't have staging yet so the design is speculative.
-
-Recommended next step before DECIDED: empirically dogfood Tranche 1 on delgoosh (we already have the prototype via PR #737/#738). If it generalises cleanly to a second consumer, lock the design + ship Tranche 1; revisit 2 + 3 with concrete asks.
+The originally-flagged "soak before locking" concerns are addressed by the trade-off resolutions above:
+- Naming (`serve` vs extending `dev-env`) — locked; `dev-env` becomes the bound subcommand under `serve dev` with backward-compat aliases.
+- Shared-box-with-port-namespacing — locked as default; consumers who outgrow it can run separate boxes per profile (`ssh.host_secret` per-profile overrides supported).
+- `built-image` channel speculation — eliminated by Trade-off #3: slowcook calls into consumer's `bringup_cmd`; no opinion on the channel itself.
 
 ---
 


### PR DESCRIPTION
Maintainer call 2026-06-01: deliver dev + mock + staging together in 0.20. Trade-offs all locked. Implementation kicks off in three sequential phases: serve dev → serve mock → serve staging.

See updated entry #5 in docs/plans/0.20-design-discussions.md.