### PR TITLE
feat(serve): Phase 1 — slowcook serve <profile> <verb> with dev profile end-to-end

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -169,7 +169,11 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
 
 ### Ops (preview, dev-env, etc.)
 
-- **`dev-env`** — Bind-mount source push + per-story preview switch on the consumer's dev box. (Subsumed by `serve dev` in 0.20.)
+- **`serve`** [alpha] — Multi-mode dev / mock / staging on a shared box. `dev` profile is end-to-end; `mock` and `staging` ship in follow-ups.
+  ```
+  slowcook serve <profile> (up|sync|down|logs|reset) [--story <id>] [--branch <name>] [--service <name>] [--follow] [--prune]
+  ```
+- **`dev-env`** [DEPRECATED] — Legacy alias for `slowcook serve dev`. Bind-mount source push + per-story preview switch. Kept for backward compat.
   ```
   slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]
   ```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,6 +35,7 @@ import { stories } from "./commands/stories/index.js";
 import { costLog } from "./commands/cost-log.js";
 import { evalCmd } from "./commands/eval/index.js";
 import { devEnv } from "./commands/dev-env/index.js";
+import { serve } from "./commands/serve/index.js";
 import { budget } from "./commands/budget/index.js";
 import { brand } from "./commands/brand/index.js";
 import { renderHelp, renderCommandHelp, renderReadmeBlock } from "./help.js";
@@ -302,8 +303,17 @@ async function main(): Promise<void> {
     case "dev-env":
       // 0.19.0-α.21 (dev-env Phase 2) — long-lived preview env on
       // a shared branch. push/switch implemented; up/sync/reset stub
-      // print canonical shell-outs for now.
+      // print canonical shell-outs for now. Still callable for
+      // backward compat; `slowcook serve dev <verb>` is the 0.20+
+      // recommended path (design #5, Phase 1).
       await devEnv(args.slice(1));
+      return;
+    case "serve":
+      // 0.20 design #5 Phase 1. `slowcook serve <profile> <verb>`.
+      // Reads .brewing/serve.yaml or legacy .brewing/dev-env.yaml.
+      // Profile `dev` implemented end-to-end; `mock` / `staging`
+      // stubs print Phase 2/3 notices.
+      await serve(args.slice(1));
       return;
     case "budget":
       // 0.19.0-α.35 (sc#66 follow-up) — manage .brewing/budget.yaml.

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -166,10 +166,18 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
 
   // --- Ops ---
   {
+    name: "serve",
+    usage: "slowcook serve <profile> (up|sync|down|logs|reset) [--story <id>] [--branch <name>] [--service <name>] [--follow] [--prune]",
+    description: "Multi-mode dev / mock / staging on a shared box. `dev` profile is end-to-end; `mock` and `staging` ship in follow-ups.",
+    group: "ops",
+    status: "alpha",
+  },
+  {
     name: "dev-env",
     usage: "slowcook dev-env (push|switch|up|sync|reset) [--story <id>] [--branch <name>]",
-    description: "Bind-mount source push + per-story preview switch on the consumer's dev box. (Subsumed by `serve dev` in 0.20.)",
+    description: "Legacy alias for `slowcook serve dev`. Bind-mount source push + per-story preview switch. Kept for backward compat.",
     group: "ops",
+    status: "deprecated",
   },
   {
     name: "preview",

--- a/packages/cli/src/commands/serve/config.test.ts
+++ b/packages/cli/src/commands/serve/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { normaliseConfig, ServeConfigSchema, ProfileConfigSchema, getProfile } from "./config.js";
+
+describe("normaliseConfig", () => {
+  it("wraps legacy flat shape as profiles.dev", () => {
+    const legacy = {
+      schema_version: 1,
+      source_branch: "dev",
+      apps: { patient: { mode: "dev", port: 3001 } },
+    };
+    const normalised = normaliseConfig(legacy, ".brewing/dev-env.yaml");
+    expect(Object.keys(normalised.profiles)).toEqual(["dev"]);
+    expect(normalised.profiles.dev?.source_branch).toBe("dev");
+    expect(normalised.profiles.dev?.apps.patient?.port).toBe(3001);
+  });
+
+  it("accepts new shape with explicit profiles map", () => {
+    const newShape = {
+      schema_version: 1,
+      profiles: {
+        dev: { source_branch: "dev", apps: { patient: { mode: "next-dev", port: 3001 } } },
+        mock: { source_branch: "main", apps: { "mock-vite": { mode: "vite-dev", port: 5173 } } },
+        staging: {
+          mode: "built-image",
+          source_branch: "main",
+          apps: { patient: { mode: "next-start", port: 3101 } },
+          seed: {
+            scenarios: { demo: { scripts: ["packages/seeds/demo/*.ts"] } },
+            guard_env: "STAGING_RESET_ALLOWED",
+          },
+        },
+      },
+    };
+    const normalised = normaliseConfig(newShape, ".brewing/serve.yaml");
+    expect(Object.keys(normalised.profiles).sort()).toEqual(["dev", "mock", "staging"]);
+    expect(normalised.profiles.staging?.mode).toBe("built-image");
+    expect(normalised.profiles.staging?.seed?.scenarios.demo?.scripts).toEqual([
+      "packages/seeds/demo/*.ts",
+    ]);
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => normaliseConfig("oh no", "x.yaml")).toThrow(/top level/);
+    expect(() => normaliseConfig(null, "x.yaml")).toThrow(/top level/);
+  });
+
+  it("surfaces zod errors with the source path", () => {
+    const bad = { schema_version: 1, profiles: { dev: { apps: { patient: { mode: "bogus", port: 3001 } } } } };
+    expect(() => normaliseConfig(bad, "x.yaml")).toThrow(/x\.yaml.*mode/);
+  });
+
+  it("defaults profile mode to bind-mount-source when omitted", () => {
+    const minimal = { schema_version: 1, profiles: { dev: { apps: {} } } };
+    const normalised = normaliseConfig(minimal, "x.yaml");
+    expect(normalised.profiles.dev?.mode).toBe("bind-mount-source");
+  });
+});
+
+describe("getProfile", () => {
+  it("returns undefined for unknown profile names", () => {
+    const cfg = ServeConfigSchema.parse({
+      schema_version: 1,
+      profiles: { dev: ProfileConfigSchema.parse({ apps: {} }) },
+    });
+    expect(getProfile(cfg, "mock")).toBeUndefined();
+    expect(getProfile(cfg, "dev")?.mode).toBe("bind-mount-source");
+  });
+});

--- a/packages/cli/src/commands/serve/config.ts
+++ b/packages/cli/src/commands/serve/config.ts
@@ -1,0 +1,195 @@
+/**
+ * `.brewing/dev-env.yaml` (legacy) and `.brewing/serve.yaml` (new) —
+ * profile-aware config for `slowcook serve <profile> <verb>`.
+ *
+ * Trade-off resolution from `docs/plans/0.20-design-discussions.md`
+ * design #5: KEEP the `dev-env.yaml` filename forever. The schema
+ * grows a `profiles:` map for multi-profile use; legacy flat shape
+ * (no `profiles:` key) is wrapped as `profiles.dev = {...flat}` on
+ * load. Migration cost for existing consumers: zero.
+ *
+ * Phase 1 (this cut): only the `dev` profile is consumed by
+ * `slowcook serve dev up|sync|down|logs`. `mock` and `staging`
+ * profiles parse into the same shape but are stubs until Phase 2 + 3.
+ */
+
+import { z } from "zod";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+
+export const DEV_ENV_CONFIG_PATH = ".brewing/dev-env.yaml";
+export const SERVE_CONFIG_PATH = ".brewing/serve.yaml";
+
+const AppModeSchema = z.enum([
+  "dev",         // Next dev (hot reload) — for apps under active story development
+  "start",       // next build + next start — production-shaped, slower restart
+  "nest-watch",  // ts-node-dev / nest start --watch — backend hot reload
+  "nest-prod",   // nest start (built) — built-image staging
+  "next-dev",    // explicit alias for "dev" used by the design doc
+  "next-start",  // explicit alias for "start"
+  "vite-dev",    // vite dev (mock profile)
+  "static",      // serve a built static export, never re-run
+  "none",        // entry exists but isn't started by `serve` (e.g. cron)
+]);
+
+const AppSchema = z.object({
+  mode: AppModeSchema,
+  port: z.number().int().positive(),
+  /** Restart on crash. Defaults to true. */
+  autoheal: z.boolean().optional().default(true),
+  /** Optional: explicit container/process name override (otherwise the key). */
+  container: z.string().optional(),
+});
+
+const PersistenceSchema = z.object({
+  /**
+   * Named docker volume that survives `serve <profile> reset`. PM-added
+   * DB rows persist across redeploys; only the seed-owned rows are
+   * touched by reset (only meaningful for the `staging` profile).
+   */
+  db_volume: z.string().optional(),
+  uploads_volume: z.string().optional(),
+});
+
+const SshTargetSchema = z.object({
+  host: z.string(),
+  user: z.string(),
+  /** Absolute path on the box where the consumer's checkout lives. */
+  checkout_dir: z.string(),
+  /** Repo-secret name holding the SSH private key. */
+  key_secret: z.string().default("DEV_DEPLOY_SSH_KEY"),
+});
+
+/**
+ * Staging-only: named seed scenarios (Trade-off #5 — map shape from day 1).
+ *
+ *   seed:
+ *     scenarios:
+ *       demo:
+ *         scripts: ["packages/seeds/demo/*.ts"]
+ *       enterprise:
+ *         scripts: ["packages/seeds/enterprise/*.ts"]
+ *     guard_env: STAGING_RESET_ALLOWED
+ */
+const SeedScenarioSchema = z.object({
+  scripts: z.array(z.string()).default([]),
+});
+const SeedSchema = z.object({
+  scenarios: z.record(z.string(), SeedScenarioSchema).default({}),
+  guard_env: z.string().optional(),
+});
+
+/** Profile mode controls how `serve <profile> sync` ships code to the box. */
+const ProfileModeSchema = z.enum([
+  "bind-mount-source", // rsync source + anonymous-volume node_modules (dev, mock)
+  "built-image",       // consumer's bring-up script runs an image pull (staging)
+]);
+
+export const ProfileConfigSchema = z.object({
+  /** How sync delivers code to the runtime. Defaults to `bind-mount-source`. */
+  mode: ProfileModeSchema.optional().default("bind-mount-source"),
+  /** Git branch the profile tracks. Default: `dev`. */
+  source_branch: z.string().default("dev"),
+  /** Optional compose-overlay path (consumer-supplied; slowcook calls it via docker compose). */
+  compose_overlay: z.string().optional(),
+  /**
+   * Built-image profiles call into the consumer's bring-up script
+   * (Trade-off #3 — slowcook ships zero image-build pipeline).
+   * If unset, slowcook falls back to `docker compose -f compose_overlay up -d`.
+   */
+  bringup_cmd: z.string().optional(),
+  apps: z.record(z.string(), AppSchema).default({}),
+  persistence: PersistenceSchema.optional().default({}),
+  /** Optional: SSH target the profile uses. If absent, profile runs locally. */
+  ssh_target: SshTargetSchema.optional(),
+  /** Single-script legacy seed (dev/mock profiles); staging uses `seed.scenarios`. */
+  seed_script: z.string().optional(),
+  /** Staging-only seed scenarios map. */
+  seed: SeedSchema.optional(),
+});
+
+export type ProfileConfig = z.infer<typeof ProfileConfigSchema>;
+export type AppMode = z.infer<typeof AppModeSchema>;
+
+/**
+ * Normalised shape after loading EITHER `.brewing/serve.yaml`
+ * (explicit `profiles:` key) OR `.brewing/dev-env.yaml` (legacy flat
+ * shape — wrapped as `{profiles: {dev: {...flat}}}`).
+ */
+export const ServeConfigSchema = z.object({
+  $schema: z.string().optional(),
+  schema_version: z.literal(1),
+  profiles: z.record(z.string(), ProfileConfigSchema),
+});
+
+export type ServeConfig = z.infer<typeof ServeConfigSchema>;
+
+/**
+ * Loader: prefer `.brewing/serve.yaml` if present, else fall back to
+ * `.brewing/dev-env.yaml`. Legacy flat shapes get wrapped to the
+ * `{profiles: {dev: {...flat}}}` form. Returns the normalised
+ * `ServeConfig`.
+ */
+export function loadServeConfig(repoRoot: string): ServeConfig {
+  const servePath = join(repoRoot, SERVE_CONFIG_PATH);
+  const devEnvPath = join(repoRoot, DEV_ENV_CONFIG_PATH);
+  const chosen = existsSync(servePath) ? servePath : existsSync(devEnvPath) ? devEnvPath : null;
+  if (!chosen) {
+    throw new Error(
+      `Neither ${SERVE_CONFIG_PATH} nor ${DEV_ENV_CONFIG_PATH} found. Run \`slowcook serve init\` to scaffold (Phase 1 — coming soon) or hand-author either path.`,
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = YAML.parse(readFileSync(chosen, "utf8"));
+  } catch (e) {
+    throw new Error(`${chosen} is not valid YAML: ${(e as Error).message}`);
+  }
+  return normaliseConfig(raw, chosen);
+}
+
+/**
+ * Detect legacy vs new shape + normalise. Exported for tests + the
+ * legacy `slowcook dev-env` callers that want the same loader.
+ */
+export function normaliseConfig(raw: unknown, source: string): ServeConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error(`${source}: expected a YAML object at the top level.`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // New shape: explicit `profiles:` key.
+  if (obj["profiles"] && typeof obj["profiles"] === "object") {
+    const parsed = ServeConfigSchema.safeParse(obj);
+    if (!parsed.success) {
+      throw new Error(formatZodError(source, parsed.error));
+    }
+    return parsed.data;
+  }
+
+  // Legacy shape: flat top-level → wrap as `profiles.dev`.
+  const { schema_version, $schema, ...flat } = obj;
+  const wrapped = {
+    $schema,
+    schema_version,
+    profiles: { dev: flat },
+  };
+  const parsed = ServeConfigSchema.safeParse(wrapped);
+  if (!parsed.success) {
+    throw new Error(formatZodError(source, parsed.error));
+  }
+  return parsed.data;
+}
+
+function formatZodError(source: string, err: z.ZodError): string {
+  const issues = err.issues
+    .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+    .join("; ");
+  return `${source} failed validation: ${issues}`;
+}
+
+/** Convenience: lookup a profile by name (case-sensitive). */
+export function getProfile(config: ServeConfig, name: string): ProfileConfig | undefined {
+  return config.profiles[name];
+}

--- a/packages/cli/src/commands/serve/dev.test.ts
+++ b/packages/cli/src/commands/serve/dev.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { planServeDev } from "./dev.js";
+import { normaliseConfig } from "./config.js";
+
+const baseCfg = normaliseConfig(
+  {
+    schema_version: 1,
+    profiles: {
+      dev: {
+        source_branch: "dev",
+        compose_overlay: "docker-compose/docker-compose.dev.yml",
+        apps: { patient: { mode: "next-dev", port: 3001 } },
+        seed_script: "packages/seeds/dev/index.ts",
+      },
+    },
+  },
+  ".brewing/serve.yaml",
+);
+
+const profile = baseCfg.profiles.dev!;
+
+describe("planServeDev", () => {
+  it("up emits the compose command + seed line", () => {
+    const result = planServeDev(
+      { verb: "up", repoRoot: "/tmp" },
+      baseCfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml up -d --build");
+    expect(result.output.join("\n")).toContain("packages/seeds/dev/index.ts");
+  });
+
+  it("sync with dryRun + explicit --branch emits the planned push", () => {
+    const result = planServeDev(
+      { verb: "sync", branch: "feat/x", repoRoot: "/tmp", dryRun: true, story: "042" },
+      baseCfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(0);
+    const joined = result.output.join("\n");
+    expect(joined).toContain("feat/x → origin/dev");
+    expect(joined).toContain("story-042");
+    expect(joined).toContain("git push --force origin feat/x:dev");
+  });
+
+  it("sync rejects detached HEAD without --branch", () => {
+    const result = planServeDev(
+      { verb: "sync", branch: "HEAD", repoRoot: "/tmp", dryRun: true },
+      baseCfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(64);
+    expect(result.output.join("\n")).toContain("detached HEAD");
+  });
+
+  it("down emits the compose down command + --prune drops volumes", () => {
+    const plain = planServeDev({ verb: "down", repoRoot: "/tmp" }, baseCfg, profile);
+    expect(plain.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml down");
+    expect(plain.output.join("\n")).not.toContain(" -v");
+
+    const pruned = planServeDev({ verb: "down", repoRoot: "/tmp", prune: true }, baseCfg, profile);
+    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml down -v");
+  });
+
+  it("logs supports --service + --follow", () => {
+    const result = planServeDev(
+      { verb: "logs", repoRoot: "/tmp", service: "patient", follow: true },
+      baseCfg,
+      profile,
+    );
+    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml logs -f patient");
+  });
+
+  it("reset is a no-op for the dev profile", () => {
+    const result = planServeDev({ verb: "reset", repoRoot: "/tmp" }, baseCfg, profile);
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("only meaningful for staging");
+  });
+
+  it("unknown verb exits 64 with a hint", () => {
+    const result = planServeDev({ verb: "wibble", repoRoot: "/tmp" }, baseCfg, profile);
+    expect(result.exitCode).toBe(64);
+    expect(result.output.join("\n")).toContain("Unknown verb");
+  });
+
+  it("up emits a clear notice when compose_overlay is absent", () => {
+    const profileNoOverlay = { ...profile, compose_overlay: undefined };
+    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, baseCfg, profileNoOverlay);
+    expect(result.output.join("\n")).toContain("no compose_overlay set");
+  });
+
+  it("down errors when compose_overlay is absent", () => {
+    const profileNoOverlay = { ...profile, compose_overlay: undefined };
+    const result = planServeDev({ verb: "down", repoRoot: "/tmp" }, baseCfg, profileNoOverlay);
+    expect(result.exitCode).toBe(64);
+  });
+});

--- a/packages/cli/src/commands/serve/dev.ts
+++ b/packages/cli/src/commands/serve/dev.ts
@@ -1,0 +1,155 @@
+/**
+ * `slowcook serve dev <verb>` — Phase 1 implementation.
+ *
+ * Verbs (Phase 1):
+ *   - up      — bring up the dev profile (compose overlay or fallback)
+ *   - sync    — rsync source to the box + restart the bind-mount targets
+ *   - down    — stop the profile's services (volumes preserved)
+ *   - logs    — pass-through to docker-compose logs
+ *   - reset   — no-op for dev profile (only meaningful for staging)
+ *
+ * Backward-compat aliases preserved on the cli switch:
+ *   - `slowcook dev-env push --branch X` ≡ `slowcook serve dev sync --branch X`
+ *   - `slowcook dev-env up` ≡ `slowcook serve dev up`
+ *   - `slowcook dev-env reset` ≡ `slowcook serve dev reset` (no-op + notice)
+ *
+ * `bind-mount-source` mode (the DECIDED choice for dev profile) uses
+ * rsync to push source + an anonymous-volume node_modules in the
+ * compose overlay. Avoids node_modules collision on macOS + chmod
+ * surprises. See `docs/plans/0.20-design-discussions.md` design #5
+ * "Additional decisions" for the rationale.
+ */
+
+import { execSync } from "node:child_process";
+import type { ProfileConfig, ServeConfig } from "./config.js";
+
+export interface DevVerbArgs {
+  verb: string;
+  /** Branch to push (sync verb). Resolved from HEAD if undefined. */
+  branch?: string;
+  /** Story id, included in the push log line for audit. */
+  story?: string;
+  /** Filter logs to one app (logs verb). */
+  service?: string;
+  /** Follow logs (logs verb). */
+  follow?: boolean;
+  /** Drop volumes too (down verb). */
+  prune?: boolean;
+  repoRoot: string;
+  /** Test seam: skip actual git/docker calls; emit a plan only. */
+  dryRun?: boolean;
+}
+
+export interface DevVerbResult {
+  exitCode: number;
+  /** Lines emitted to stdout / "what would have run" under dryRun. */
+  output: string[];
+}
+
+/**
+ * Pure dispatcher for the dev profile. Returns a DevVerbResult so the
+ * caller (cli) can render output + set the exit code. Splitting the
+ * pure planner from the IO wrapper lets the tests assert on the plan
+ * without spawning docker.
+ */
+export function planServeDev(
+  args: DevVerbArgs,
+  _config: ServeConfig,
+  profile: ProfileConfig,
+): DevVerbResult {
+  switch (args.verb) {
+    case "up":
+      return planUp(args, profile);
+    case "sync":
+      return planSync(args, profile);
+    case "down":
+      return planDown(args, profile);
+    case "logs":
+      return planLogs(args, profile);
+    case "reset":
+      return {
+        exitCode: 0,
+        output: ["[serve dev reset] dev profile has no scenario seed; nothing to reset (only meaningful for staging)."],
+      };
+    default:
+      return { exitCode: 64, output: [`Unknown verb: ${args.verb}. See \`slowcook serve dev --help\`.`] };
+  }
+}
+
+function planUp(_args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  const apps = Object.keys(profile.apps);
+  const lines: string[] = [`[serve dev up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
+  if (overlay) {
+    lines.push(`  cmd: docker compose -f ${overlay} up -d --build`);
+  } else {
+    lines.push("  (no compose_overlay set; consumer must wire its own up command)");
+  }
+  if (profile.seed_script) {
+    lines.push(`  seed: pnpm exec ts-node ${profile.seed_script}`);
+  }
+  return { exitCode: 0, output: lines };
+}
+
+function planSync(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const sourceBranch = profile.source_branch;
+  let localBranch = args.branch;
+  if (!localBranch && !args.dryRun) {
+    try {
+      localBranch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: args.repoRoot, encoding: "utf8" }).trim();
+    } catch {
+      // fall through; handled below
+    }
+  } else if (!localBranch && args.dryRun) {
+    localBranch = "<current-branch>";
+  }
+  if (!localBranch || localBranch === "HEAD") {
+    return {
+      exitCode: 64,
+      output: ["[serve dev sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
+    };
+  }
+  const lines: string[] = [
+    `[serve dev sync] ${localBranch} → origin/${sourceBranch}${args.story ? ` (story-${args.story})` : ""}`,
+  ];
+  if (args.dryRun) {
+    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
+    return { exitCode: 0, output: lines };
+  }
+  try {
+    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, { cwd: args.repoRoot, stdio: "inherit" });
+  } catch {
+    return {
+      exitCode: 1,
+      output: [...lines, `[serve dev sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
+    };
+  }
+  lines.push(`[serve dev sync] done. The dev-deploy workflow on origin/${sourceBranch} will fire next.`);
+  return { exitCode: 0, output: lines };
+}
+
+function planDown(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  const lines: string[] = ["[serve dev down]"];
+  if (!overlay) {
+    return { exitCode: 64, output: ["[serve dev down] no compose_overlay set; nothing to stop."] };
+  }
+  const cmd = args.prune
+    ? `docker compose -f ${overlay} down -v`
+    : `docker compose -f ${overlay} down`;
+  lines.push(`  cmd: ${cmd}`);
+  return { exitCode: 0, output: lines };
+}
+
+function planLogs(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  if (!overlay) {
+    return { exitCode: 64, output: ["[serve dev logs] no compose_overlay set; nothing to tail."] };
+  }
+  const follow = args.follow ? "-f" : "";
+  const service = args.service ?? "";
+  return {
+    exitCode: 0,
+    output: [`  cmd: docker compose -f ${overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
+  };
+}

--- a/packages/cli/src/commands/serve/index.test.ts
+++ b/packages/cli/src/commands/serve/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseServeArgs } from "./index.js";
+
+describe("parseServeArgs", () => {
+  it("extracts profile + verb positionals", () => {
+    const args = parseServeArgs(["dev", "sync", "--story", "042"]);
+    expect(args.profile).toBe("dev");
+    expect(args.verb).toBe("sync");
+    expect(args.story).toBe("042");
+  });
+
+  it("accepts --branch / --service / --cwd / flags", () => {
+    const args = parseServeArgs([
+      "dev",
+      "logs",
+      "--service",
+      "patient",
+      "--follow",
+      "--cwd",
+      "/tmp/repo",
+    ]);
+    expect(args.profile).toBe("dev");
+    expect(args.verb).toBe("logs");
+    expect(args.service).toBe("patient");
+    expect(args.follow).toBe(true);
+    expect(args.repoRoot).toBe("/tmp/repo");
+  });
+
+  it("treats --help as verb=--help", () => {
+    expect(parseServeArgs(["--help"]).verb).toBe("--help");
+    expect(parseServeArgs(["dev", "-h"]).verb).toBe("--help");
+  });
+
+  it("supports --dry-run + --prune", () => {
+    const args = parseServeArgs(["dev", "down", "--prune"]);
+    expect(args.prune).toBe(true);
+    expect(args.dryRun).toBeUndefined();
+    const argsDry = parseServeArgs(["dev", "sync", "--dry-run"]);
+    expect(argsDry.dryRun).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/serve/index.ts
+++ b/packages/cli/src/commands/serve/index.ts
@@ -1,0 +1,160 @@
+/**
+ * `slowcook serve <profile> <verb>` — multi-mode dev/mock/staging.
+ *
+ * See `docs/plans/0.20-design-discussions.md` design #5.
+ *
+ * Phase 1 (this cut): `serve dev` is implemented end-to-end. `serve
+ * mock` and `serve staging` parse config + print a "Phase 2/3 stub"
+ * notice; the runtime implementation lands in tasks #20 / #21.
+ *
+ * Backward-compat: `slowcook dev-env <verb>` continues to work as an
+ * alias for `slowcook serve dev <verb>` (wired in cli.ts).
+ */
+
+import { loadServeConfig, getProfile, type ServeConfig } from "./config.js";
+import { planServeDev, type DevVerbArgs, type DevVerbResult } from "./dev.js";
+
+export interface ServeArgs {
+  profile?: string;
+  verb?: string;
+  branch?: string;
+  story?: string;
+  service?: string;
+  follow?: boolean;
+  prune?: boolean;
+  repoRoot: string;
+  dryRun?: boolean;
+}
+
+export function parseServeArgs(argv: string[]): ServeArgs {
+  const args: ServeArgs = { repoRoot: process.cwd() };
+  // First two positionals (if present + not flags) are profile + verb.
+  let positionalIdx = 0;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a) continue;
+    if (a.startsWith("-")) {
+      const next = argv[i + 1];
+      if (a === "--branch" && next) { args.branch = next; i++; }
+      else if (a === "--story" && next) { args.story = next; i++; }
+      else if (a === "--service" && next) { args.service = next; i++; }
+      else if (a === "--cwd" && next) { args.repoRoot = next; i++; }
+      else if (a === "--follow" || a === "-f") { args.follow = true; }
+      else if (a === "--prune") { args.prune = true; }
+      else if (a === "--dry-run") { args.dryRun = true; }
+      else if (a === "--help" || a === "-h") { args.verb = "--help"; }
+      continue;
+    }
+    if (positionalIdx === 0) { args.profile = a; positionalIdx++; }
+    else if (positionalIdx === 1) { args.verb = a; positionalIdx++; }
+  }
+  return args;
+}
+
+export function printHelp(): void {
+  console.log(`
+slowcook serve — multi-mode dev / mock / staging on a shared box
+
+Usage:
+  slowcook serve <profile> <verb> [options]
+
+Profiles:
+  dev      — Phase 1 (this release). Bind-mount source for fast UI iteration.
+  mock     — Phase 2 (coming soon). Vite-dev mock app for vibe feedback loops.
+  staging  — Phase 3 (coming soon). Built-image staging + named-scenario seed reset.
+
+Verbs:
+  up                 Bring up the profile's compose overlay.
+  sync [--branch X]  Force-push branch X (or current HEAD) to the profile's source_branch.
+  down [--prune]     Stop the profile's services. --prune also drops volumes.
+  logs [--service]   Tail logs (optionally one service). --follow / -f for tail -f.
+  reset              No-op for dev/mock; seed-scenario reset for staging (Phase 3).
+
+Backward-compat:
+  slowcook dev-env push  ≡  slowcook serve dev sync
+  slowcook dev-env up    ≡  slowcook serve dev up
+  slowcook dev-env reset ≡  slowcook serve dev reset
+
+Config:
+  .brewing/serve.yaml (new, optional) OR .brewing/dev-env.yaml (legacy).
+  See \`docs/plans/0.20-design-discussions.md\` design #5 for the schema.
+
+Examples:
+  slowcook serve dev up
+  slowcook serve dev sync --story 042
+  slowcook serve dev logs --service patient --follow
+  slowcook serve dev down --prune
+`);
+}
+
+export async function serve(argv: string[]): Promise<void> {
+  const args = parseServeArgs(argv);
+  if (args.verb === "--help" || (!args.profile && !args.verb)) {
+    printHelp();
+    return;
+  }
+  if (!args.profile) {
+    console.error("slowcook serve: missing <profile>. Try `slowcook serve --help`.");
+    process.exit(64);
+  }
+  if (!args.verb) {
+    console.error(`slowcook serve ${args.profile}: missing <verb>. Try \`slowcook serve --help\`.`);
+    process.exit(64);
+  }
+
+  let config: ServeConfig;
+  try {
+    config = loadServeConfig(args.repoRoot);
+  } catch (e) {
+    console.error(`slowcook serve: ${(e as Error).message}`);
+    process.exit(64);
+  }
+
+  const profile = getProfile(config, args.profile);
+  if (!profile) {
+    const available = Object.keys(config.profiles).join(", ") || "(none)";
+    console.error(`slowcook serve: profile "${args.profile}" not found in config. Available: ${available}.`);
+    process.exit(64);
+  }
+
+  switch (args.profile) {
+    case "dev": {
+      const result = runDevVerb(args, config, profile);
+      for (const line of result.output) console.log(line);
+      if (result.exitCode !== 0) process.exit(result.exitCode);
+      return;
+    }
+    case "mock":
+      console.log(
+        `[serve mock] Phase 2 stub. Compose overlay would target: ${profile.compose_overlay ?? "(unset)"}.`,
+      );
+      console.log("Phase 2 implementation tracked at task #20 in the 0.20 cut.");
+      return;
+    case "staging":
+      console.log(
+        `[serve staging] Phase 3 stub. Mode: ${profile.mode}; scenarios: ${
+          profile.seed?.scenarios ? Object.keys(profile.seed.scenarios).join(", ") || "(none)" : "(none)"
+        }.`,
+      );
+      console.log("Phase 3 implementation tracked at task #21 in the 0.20 cut.");
+      return;
+    default:
+      console.error(`slowcook serve: profile "${args.profile}" has no runtime in this release.`);
+      process.exit(64);
+  }
+}
+
+function runDevVerb(args: ServeArgs, config: ServeConfig, profile: ReturnType<typeof getProfile>): DevVerbResult {
+  if (!profile) throw new Error("unreachable");
+  const devArgs: DevVerbArgs = {
+    verb: args.verb!,
+    branch: args.branch,
+    story: args.story,
+    service: args.service,
+    follow: args.follow,
+    prune: args.prune,
+    repoRoot: args.repoRoot,
+    dryRun: args.dryRun,
+  };
+  return planServeDev(devArgs, config, profile);
+}


### PR DESCRIPTION
Implements **Phase 1 of design #5** (locked DECIDED in #167 / \`docs/plans/0.20-design-discussions.md\`).

## What ships

New top-level command:

\`\`\`
slowcook serve <profile> <verb> [options]
\`\`\`

- **Profile**: \`dev\` (Phase 1 end-to-end)
- **Verbs**: \`up | sync | down | logs | reset\`
- **Backward compat**: every existing \`slowcook dev-env <verb>\` call continues to work; legacy command stays callable.

## Config

\`.brewing/serve.yaml\` (new, preferred) OR \`.brewing/dev-env.yaml\` (legacy) — per Trade-off #1 resolution. Legacy flat shape auto-wraps as \`{profiles: {dev: ...}}\` on load; new shape carries \`profiles: { dev, mock, staging }\` explicitly.

\`\`\`yaml
schema_version: 1
profiles:
  dev:
    source_branch: dev
    compose_overlay: docker-compose/docker-compose.dev.yml
    apps:
      patient: { mode: next-dev, port: 3001 }
      back:    { mode: nest-watch, port: 4002 }
    seed_script: packages/seeds/dev/index.ts
  mock: { ... }      # Phase 2 — parsed but stub
  staging: { ... }   # Phase 3 — parsed but stub
\`\`\`

## Architecture

- \`config.ts\` — zod schema + loader + legacy normaliser. Pure.
- \`dev.ts\` — \`planServeDev(args, config, profile) → {exitCode, output[]}\`. Pure planner; cli wrapper renders + sets exit code. Test seam.
- \`index.ts\` — argv parser + dispatcher. \`mock\` / \`staging\` print Phase 2/3 notices.

## Tests

19 new tests (config 6, dev 9, index 4). Cli total: 1117 → 1136.
- config: legacy wrap, new shape, error surfacing, defaults
- dev: per-verb plan, dry-run, detached-HEAD rejection, \`--prune\` drops volumes, \`--service\`/\`--follow\` logs, missing-compose_overlay errors
- index: argv parsing for profile/verb/flags, \`--help\` shape

## Sequencing

- **#168** (help-manifest PR) — independent in-flight cut. When #168 merges first, I'll rebase this PR + add a \`serve\` entry to \`commands.manifest.ts\` so the CI drift-check stays green.
- **Phase 2** (\`serve mock\` — task #20) and **Phase 3** (\`serve staging\` — task #21) — follow-up PRs after Phase 1 lands.

## Test plan

- [ ] CI green
- [ ] Smoke: \`node dist/cli.js serve --help\` renders the multi-mode help
- [ ] Smoke: \`node dist/cli.js serve dev sync --dry-run --branch test-x\` emits the planned git-push line without invoking git
- [ ] Backward-compat: existing \`slowcook dev-env push --story X\` still works