### PR TITLE
feat(serve): Phase 2 — slowcook serve mock with auto-skip detection

### DIFF
--- a/packages/cli/src/commands/serve/detect.test.ts
+++ b/packages/cli/src/commands/serve/detect.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectMockRunnable } from "./detect.js";
+
+describe("detectMockRunnable", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "slowcook-mock-detect-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports exists:false when mock/ is absent", () => {
+    const out = detectMockRunnable(dir);
+    expect(out.exists).toBe(false);
+    expect(out.hasDevScript).toBe(false);
+    expect(out.reason).toMatch(/mock\//);
+  });
+
+  it("reports hasDevScript:false when scripts.dev is missing", () => {
+    mkdirSync(join(dir, "mock"));
+    writeFileSync(join(dir, "mock", "package.json"), JSON.stringify({ name: "mock", scripts: { build: "vite build" } }));
+    const out = detectMockRunnable(dir);
+    expect(out.exists).toBe(true);
+    expect(out.hasDevScript).toBe(false);
+    expect(out.reason).toMatch(/scripts\.dev/);
+  });
+
+  it("reports hasDevScript:true + returns the script command", () => {
+    mkdirSync(join(dir, "mock"));
+    writeFileSync(join(dir, "mock", "package.json"), JSON.stringify({ name: "mock", scripts: { dev: "vite" } }));
+    const out = detectMockRunnable(dir);
+    expect(out.exists).toBe(true);
+    expect(out.hasDevScript).toBe(true);
+    expect(out.devScript).toBe("vite");
+  });
+
+  it("surfaces JSON parse errors with the failing path", () => {
+    mkdirSync(join(dir, "mock"));
+    writeFileSync(join(dir, "mock", "package.json"), "not json {");
+    const out = detectMockRunnable(dir);
+    expect(out.exists).toBe(true);
+    expect(out.hasDevScript).toBe(false);
+    expect(out.reason).toMatch(/not valid JSON/);
+  });
+});

--- a/packages/cli/src/commands/serve/detect.ts
+++ b/packages/cli/src/commands/serve/detect.ts
@@ -1,0 +1,68 @@
+/**
+ * Profile auto-detection — Trade-off #4 resolution.
+ *
+ * `serve mock` is only meaningful if the consumer's `mock/` package is
+ * vite-runnable (has `scripts.dev`). If it isn't, slowcook prints a
+ * notice + exits 0 instead of trying to bring up an unrunnable profile.
+ *
+ * Exported as a pure function so the index.ts dispatcher + future
+ * `slowcook serve mock init` scaffolding can reuse the same check.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface MockRunnableResult {
+  /** Whether `mock/` exists at all. */
+  exists: boolean;
+  /** Whether `mock/package.json` declares `scripts.dev`. */
+  hasDevScript: boolean;
+  /** The dev script's command, when present. */
+  devScript?: string;
+  /** When `false`, a one-line reason suitable for `console.log`. */
+  reason?: string;
+}
+
+/**
+ * Inspect `<repoRoot>/mock/package.json` and report whether the
+ * consumer has a vite-runnable mock app.
+ *
+ * Why this check: many slowcook consumers have a `mock/` directory
+ * that's only used as a vibe-time artefact (no runtime). For those
+ * consumers, `serve mock up` would fail trying to docker-compose a
+ * non-existent vite-dev process. Skip cleanly instead.
+ */
+export function detectMockRunnable(repoRoot: string): MockRunnableResult {
+  const pkgPath = join(repoRoot, "mock", "package.json");
+  if (!existsSync(pkgPath)) {
+    return {
+      exists: false,
+      hasDevScript: false,
+      reason: "mock/ directory absent — `serve mock` requires a runnable mock app.",
+    };
+  }
+  let pkg: { scripts?: Record<string, string> };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch (e) {
+    return {
+      exists: true,
+      hasDevScript: false,
+      reason: `mock/package.json is not valid JSON: ${(e as Error).message}`,
+    };
+  }
+  const devScript = pkg.scripts?.dev;
+  if (!devScript) {
+    return {
+      exists: true,
+      hasDevScript: false,
+      reason:
+        "mock/package.json has no `scripts.dev` — declare one (e.g. `vite`) to enable the `serve mock` profile.",
+    };
+  }
+  return {
+    exists: true,
+    hasDevScript: true,
+    devScript,
+  };
+}

--- a/packages/cli/src/commands/serve/index.ts
+++ b/packages/cli/src/commands/serve/index.ts
@@ -13,6 +13,8 @@
 
 import { loadServeConfig, getProfile, type ServeConfig } from "./config.js";
 import { planServeDev, type DevVerbArgs, type DevVerbResult } from "./dev.js";
+import { planServeMock, type MockVerbArgs } from "./mock.js";
+import { detectMockRunnable } from "./detect.js";
 
 export interface ServeArgs {
   profile?: string;
@@ -124,12 +126,18 @@ export async function serve(argv: string[]): Promise<void> {
       if (result.exitCode !== 0) process.exit(result.exitCode);
       return;
     }
-    case "mock":
-      console.log(
-        `[serve mock] Phase 2 stub. Compose overlay would target: ${profile.compose_overlay ?? "(unset)"}.`,
-      );
-      console.log("Phase 2 implementation tracked at task #20 in the 0.20 cut.");
+    case "mock": {
+      // Trade-off #4: auto-skip if mock/ isn't vite-runnable.
+      const detect = detectMockRunnable(args.repoRoot);
+      if (!detect.hasDevScript) {
+        console.log(`[serve mock] skipped — ${detect.reason}`);
+        return;
+      }
+      const result = runMockVerb(args, config, profile);
+      for (const line of result.output) console.log(line);
+      if (result.exitCode !== 0) process.exit(result.exitCode);
       return;
+    }
     case "staging":
       console.log(
         `[serve staging] Phase 3 stub. Mode: ${profile.mode}; scenarios: ${
@@ -157,4 +165,18 @@ function runDevVerb(args: ServeArgs, config: ServeConfig, profile: ReturnType<ty
     dryRun: args.dryRun,
   };
   return planServeDev(devArgs, config, profile);
+}
+
+function runMockVerb(args: ServeArgs, config: ServeConfig, profile: ReturnType<typeof getProfile>): DevVerbResult {
+  if (!profile) throw new Error("unreachable");
+  const mockArgs: MockVerbArgs = {
+    verb: args.verb!,
+    branch: args.branch,
+    service: args.service,
+    follow: args.follow,
+    prune: args.prune,
+    repoRoot: args.repoRoot,
+    dryRun: args.dryRun,
+  };
+  return planServeMock(mockArgs, config, profile);
 }

--- a/packages/cli/src/commands/serve/mock.test.ts
+++ b/packages/cli/src/commands/serve/mock.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { planServeMock } from "./mock.js";
+import { normaliseConfig } from "./config.js";
+
+const cfg = normaliseConfig(
+  {
+    schema_version: 1,
+    profiles: {
+      mock: {
+        source_branch: "main",
+        compose_overlay: "docker-compose/docker-compose.mock.yml",
+        apps: { "mock-vite": { mode: "vite-dev", port: 5173 } },
+      },
+    },
+  },
+  ".brewing/serve.yaml",
+);
+const profile = cfg.profiles.mock!;
+
+describe("planServeMock", () => {
+  it("up emits the compose command + a reachable URL hint", () => {
+    const result = planServeMock({ verb: "up", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(0);
+    const joined = result.output.join("\n");
+    expect(joined).toContain("docker compose -f docker-compose/docker-compose.mock.yml up -d --build");
+    expect(joined).toContain(":5173");
+  });
+
+  it("up falls back to pnpm filter when compose_overlay is unset", () => {
+    const noOverlay = { ...profile, compose_overlay: undefined };
+    const result = planServeMock({ verb: "up", repoRoot: "/tmp" }, cfg, noOverlay);
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("pnpm --filter ./mock dev");
+  });
+
+  it("sync with dryRun + --branch emits the planned push", () => {
+    const result = planServeMock(
+      { verb: "sync", branch: "feat/mockup-42", repoRoot: "/tmp", dryRun: true },
+      cfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("feat/mockup-42 → origin/main");
+    expect(result.output.join("\n")).toContain("git push --force origin feat/mockup-42:main");
+  });
+
+  it("sync rejects detached HEAD without --branch", () => {
+    const result = planServeMock({ verb: "sync", branch: "HEAD", repoRoot: "/tmp", dryRun: true }, cfg, profile);
+    expect(result.exitCode).toBe(64);
+    expect(result.output.join("\n")).toContain("detached HEAD");
+  });
+
+  it("down + --prune drops volumes", () => {
+    const plain = planServeMock({ verb: "down", repoRoot: "/tmp" }, cfg, profile);
+    expect(plain.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml down");
+    expect(plain.output.join("\n")).not.toContain(" -v");
+
+    const pruned = planServeMock({ verb: "down", repoRoot: "/tmp", prune: true }, cfg, profile);
+    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml down -v");
+  });
+
+  it("logs supports --service + --follow", () => {
+    const result = planServeMock(
+      { verb: "logs", repoRoot: "/tmp", service: "mock-vite", follow: true },
+      cfg,
+      profile,
+    );
+    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml logs -f mock-vite");
+  });
+
+  it("reset is a no-op for mock", () => {
+    const result = planServeMock({ verb: "reset", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("only meaningful for staging");
+  });
+
+  it("unknown verb exits 64 with a hint", () => {
+    const result = planServeMock({ verb: "wibble", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(64);
+  });
+
+  it("down errors when compose_overlay is absent", () => {
+    const noOverlay = { ...profile, compose_overlay: undefined };
+    expect(planServeMock({ verb: "down", repoRoot: "/tmp" }, cfg, noOverlay).exitCode).toBe(64);
+  });
+});

--- a/packages/cli/src/commands/serve/mock.ts
+++ b/packages/cli/src/commands/serve/mock.ts
@@ -1,0 +1,151 @@
+/**
+ * `slowcook serve mock <verb>` — Phase 2 implementation.
+ *
+ * The mock profile runs the consumer's `mock/` package as a vite-dev
+ * server on a shared box, so the PM + designer + vibe-feedback loop
+ * all hit the same artefact at the same URL. Mock-vite runs alongside
+ * `serve dev` on the same host with distinct ports + profile-prefixed
+ * container names (per design #5).
+ *
+ * Verbs (Phase 2):
+ *   - up      — bring up the mock profile (vite-dev compose overlay)
+ *   - sync    — force-push the mock-tracking branch (default `main`) so
+ *               the box pulls the latest mockups
+ *   - down    — stop the mock services (volumes preserved)
+ *   - logs    — pass-through to docker-compose logs
+ *   - reset   — no-op (mock has no scenario seed)
+ *
+ * Auto-skip per Trade-off #4: if the consumer's `mock/package.json`
+ * has no `scripts.dev`, slowcook prints a notice + exits 0 instead of
+ * trying to bring up an unrunnable vite-dev. Detection runs from
+ * `index.ts`'s dispatcher before this module is called.
+ */
+
+import { execSync } from "node:child_process";
+import type { ProfileConfig, ServeConfig } from "./config.js";
+import type { DevVerbResult } from "./dev.js";
+
+export interface MockVerbArgs {
+  verb: string;
+  branch?: string;
+  service?: string;
+  follow?: boolean;
+  prune?: boolean;
+  repoRoot: string;
+  dryRun?: boolean;
+}
+
+/**
+ * Pure planner for the mock profile. Same shape as `planServeDev` so
+ * the cli wrapper can render output uniformly.
+ */
+export function planServeMock(
+  args: MockVerbArgs,
+  _config: ServeConfig,
+  profile: ProfileConfig,
+): DevVerbResult {
+  switch (args.verb) {
+    case "up":
+      return planUp(args, profile);
+    case "sync":
+      return planSync(args, profile);
+    case "down":
+      return planDown(args, profile);
+    case "logs":
+      return planLogs(args, profile);
+    case "reset":
+      return {
+        exitCode: 0,
+        output: ["[serve mock reset] mock profile has no scenario seed; nothing to reset (only meaningful for staging)."],
+      };
+    default:
+      return {
+        exitCode: 64,
+        output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`],
+      };
+  }
+}
+
+function planUp(_args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  const apps = Object.keys(profile.apps);
+  const lines: string[] = [`[serve mock up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
+  if (overlay) {
+    lines.push(`  cmd: docker compose -f ${overlay} up -d --build`);
+  } else {
+    lines.push(
+      "  (no compose_overlay set; falling back to `pnpm --filter ./mock dev` if mock/ is vite-runnable)",
+    );
+  }
+  // PM + designer reference URL: surface the vite port if exactly one app.
+  if (apps.length === 1) {
+    const vitePort = profile.apps[apps[0]!]!.port;
+    lines.push(`  vite dev URL (once up): http://<your-box>:${vitePort}`);
+  }
+  return { exitCode: 0, output: lines };
+}
+
+function planSync(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const sourceBranch = profile.source_branch;
+  let localBranch = args.branch;
+  if (!localBranch && !args.dryRun) {
+    try {
+      localBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd: args.repoRoot,
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      // handled below
+    }
+  } else if (!localBranch && args.dryRun) {
+    localBranch = "<current-branch>";
+  }
+  if (!localBranch || localBranch === "HEAD") {
+    return {
+      exitCode: 64,
+      output: ["[serve mock sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
+    };
+  }
+  const lines = [`[serve mock sync] ${localBranch} → origin/${sourceBranch}`];
+  if (args.dryRun) {
+    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
+    return { exitCode: 0, output: lines };
+  }
+  try {
+    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, {
+      cwd: args.repoRoot,
+      stdio: "inherit",
+    });
+  } catch {
+    return {
+      exitCode: 1,
+      output: [...lines, `[serve mock sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
+    };
+  }
+  lines.push(`[serve mock sync] done. The mock-deploy workflow on origin/${sourceBranch} will fire next.`);
+  return { exitCode: 0, output: lines };
+}
+
+function planDown(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  if (!overlay) {
+    return { exitCode: 64, output: ["[serve mock down] no compose_overlay set; nothing to stop."] };
+  }
+  const cmd = args.prune
+    ? `docker compose -f ${overlay} down -v`
+    : `docker compose -f ${overlay} down`;
+  return { exitCode: 0, output: ["[serve mock down]", `  cmd: ${cmd}`] };
+}
+
+function planLogs(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const overlay = profile.compose_overlay;
+  if (!overlay) {
+    return { exitCode: 64, output: ["[serve mock logs] no compose_overlay set; nothing to tail."] };
+  }
+  const follow = args.follow ? "-f" : "";
+  const service = args.service ?? "";
+  return {
+    exitCode: 0,
+    output: [`  cmd: docker compose -f ${overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
+  };
+}


### PR DESCRIPTION
Implements **Phase 2 of design #5** (Phase 1 shipped in #169).

## What ships

\`slowcook serve mock <verb>\` wires the mock profile end-to-end. Verbs: \`up | sync | down | logs | reset\`.

## Trade-off #4 — auto-skip when mock isn't vite-runnable

\`detect.ts\` walks \`<repoRoot>/mock/package.json\` and reports whether the consumer has a vite-runnable mock. Three cases:

| State | Behavior |
|---|---|
| \`mock/\` absent | skip with \`mock/ directory absent\` |
| exists, no \`scripts.dev\` | skip with \`declare scripts.dev to enable\` |
| exists with \`scripts.dev\` | proceed to runtime |

Detection runs in \`index.ts\` BEFORE \`planServeMock\` is called; planner stays filesystem-pure.

## Architecture

- \`mock.ts\` — \`planServeMock\` (pure planner)
- \`detect.ts\` — \`detectMockRunnable\` (pure filesystem probe)
- \`index.ts\` — dispatcher with auto-skip + compose-overlay fallback to \`pnpm --filter ./mock dev\`

The vite port for single-app profiles is surfaced as a URL hint in the \`up\` output (PM/designer hand-off ergonomics).

## Tests

13 new (mock 9, detect 4). Cli total: 1131 → 1144.

## Test plan

- [ ] CI green
- [ ] Smoke on a consumer with vite-runnable mock: \`serve mock up\` emits the docker-compose command + URL hint
- [ ] Smoke on a consumer WITHOUT vite-runnable mock: \`serve mock up\` exits 0 with the skip notice