### PR TITLE
feat(serve): Phase 3 — slowcook serve staging with named-scenario seed reset

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -169,9 +169,9 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
 
 ### Ops (preview, dev-env, etc.)
 
-- **`serve`** [alpha] — Multi-mode dev / mock / staging on a shared box. `dev` profile is end-to-end; `mock` and `staging` ship in follow-ups.
+- **`serve`** [alpha] — Multi-mode dev / mock / staging on a shared box. `dev` bind-mounts source; `mock` runs vite-dev (auto-skip if no scripts.dev); `staging` is built-image with named-scenario seed reset.
   ```
-  slowcook serve <profile> (up|sync|down|logs|reset) [--story <id>] [--branch <name>] [--service <name>] [--follow] [--prune]
+  slowcook serve <profile> (up|sync|down|logs|reset) [--branch <name>] [--scenario <name>] [--service <name>] [--follow] [--prune]
   ```
 - **`dev-env`** [DEPRECATED] — Legacy alias for `slowcook serve dev`. Bind-mount source push + per-story preview switch. Kept for backward compat.
   ```

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -167,8 +167,8 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   // --- Ops ---
   {
     name: "serve",
-    usage: "slowcook serve <profile> (up|sync|down|logs|reset) [--story <id>] [--branch <name>] [--service <name>] [--follow] [--prune]",
-    description: "Multi-mode dev / mock / staging on a shared box. `dev` profile is end-to-end; `mock` and `staging` ship in follow-ups.",
+    usage: "slowcook serve <profile> (up|sync|down|logs|reset) [--branch <name>] [--scenario <name>] [--service <name>] [--follow] [--prune]",
+    description: "Multi-mode dev / mock / staging on a shared box. `dev` bind-mounts source; `mock` runs vite-dev (auto-skip if no scripts.dev); `staging` is built-image with named-scenario seed reset.",
     group: "ops",
     status: "alpha",
   },

--- a/packages/cli/src/commands/serve/index.ts
+++ b/packages/cli/src/commands/serve/index.ts
@@ -15,6 +15,7 @@ import { loadServeConfig, getProfile, type ServeConfig } from "./config.js";
 import { planServeDev, type DevVerbArgs, type DevVerbResult } from "./dev.js";
 import { planServeMock, type MockVerbArgs } from "./mock.js";
 import { detectMockRunnable } from "./detect.js";
+import { planServeStaging, type StagingVerbArgs } from "./staging.js";
 
 export interface ServeArgs {
   profile?: string;
@@ -22,6 +23,7 @@ export interface ServeArgs {
   branch?: string;
   story?: string;
   service?: string;
+  scenario?: string;
   follow?: boolean;
   prune?: boolean;
   repoRoot: string;
@@ -40,6 +42,7 @@ export function parseServeArgs(argv: string[]): ServeArgs {
       if (a === "--branch" && next) { args.branch = next; i++; }
       else if (a === "--story" && next) { args.story = next; i++; }
       else if (a === "--service" && next) { args.service = next; i++; }
+      else if (a === "--scenario" && next) { args.scenario = next; i++; }
       else if (a === "--cwd" && next) { args.repoRoot = next; i++; }
       else if (a === "--follow" || a === "-f") { args.follow = true; }
       else if (a === "--prune") { args.prune = true; }
@@ -61,16 +64,16 @@ Usage:
   slowcook serve <profile> <verb> [options]
 
 Profiles:
-  dev      — Phase 1 (this release). Bind-mount source for fast UI iteration.
-  mock     — Phase 2 (coming soon). Vite-dev mock app for vibe feedback loops.
-  staging  — Phase 3 (coming soon). Built-image staging + named-scenario seed reset.
+  dev      Bind-mount source for fast UI iteration.
+  mock     Vite-dev mock app for vibe-feedback loops (auto-skip if mock/ lacks scripts.dev).
+  staging  Built-image staging + named-scenario seed reset for PM walkthroughs.
 
 Verbs:
-  up                 Bring up the profile's compose overlay.
-  sync [--branch X]  Force-push branch X (or current HEAD) to the profile's source_branch.
-  down [--prune]     Stop the profile's services. --prune also drops volumes.
-  logs [--service]   Tail logs (optionally one service). --follow / -f for tail -f.
-  reset              No-op for dev/mock; seed-scenario reset for staging (Phase 3).
+  up                            Bring up the profile (compose overlay or consumer's bringup_cmd).
+  sync [--branch X]             Force-push branch X (or current HEAD) to the profile's source_branch.
+  down [--prune]                Stop the profile's services. --prune also drops volumes.
+  logs [--service] [--follow]   Tail logs (optionally one service).
+  reset [--scenario <name>]     Re-run a staging scenario's seed scripts (no-op for dev/mock).
 
 Backward-compat:
   slowcook dev-env push  ≡  slowcook serve dev sync
@@ -138,14 +141,12 @@ export async function serve(argv: string[]): Promise<void> {
       if (result.exitCode !== 0) process.exit(result.exitCode);
       return;
     }
-    case "staging":
-      console.log(
-        `[serve staging] Phase 3 stub. Mode: ${profile.mode}; scenarios: ${
-          profile.seed?.scenarios ? Object.keys(profile.seed.scenarios).join(", ") || "(none)" : "(none)"
-        }.`,
-      );
-      console.log("Phase 3 implementation tracked at task #21 in the 0.20 cut.");
+    case "staging": {
+      const result = runStagingVerb(args, config, profile);
+      for (const line of result.output) console.log(line);
+      if (result.exitCode !== 0) process.exit(result.exitCode);
       return;
+    }
     default:
       console.error(`slowcook serve: profile "${args.profile}" has no runtime in this release.`);
       process.exit(64);
@@ -179,4 +180,19 @@ function runMockVerb(args: ServeArgs, config: ServeConfig, profile: ReturnType<t
     dryRun: args.dryRun,
   };
   return planServeMock(mockArgs, config, profile);
+}
+
+function runStagingVerb(args: ServeArgs, config: ServeConfig, profile: ReturnType<typeof getProfile>): DevVerbResult {
+  if (!profile) throw new Error("unreachable");
+  const stagingArgs: StagingVerbArgs = {
+    verb: args.verb!,
+    branch: args.branch,
+    scenario: args.scenario,
+    service: args.service,
+    follow: args.follow,
+    prune: args.prune,
+    repoRoot: args.repoRoot,
+    dryRun: args.dryRun,
+  };
+  return planServeStaging(stagingArgs, config, profile);
 }

--- a/packages/cli/src/commands/serve/staging.test.ts
+++ b/packages/cli/src/commands/serve/staging.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { planServeStaging } from "./staging.js";
+import { normaliseConfig } from "./config.js";
+
+const cfg = normaliseConfig(
+  {
+    schema_version: 1,
+    profiles: {
+      staging: {
+        mode: "built-image",
+        source_branch: "main",
+        compose_overlay: "docker-compose/docker-compose.staging.yml",
+        bringup_cmd: "ssh box 'cd /opt/app && ./redeploy.sh'",
+        apps: { patient: { mode: "next-start", port: 3101 } },
+        seed: {
+          scenarios: {
+            demo: { scripts: ["packages/seeds/demo/index.ts"] },
+            enterprise: { scripts: ["packages/seeds/enterprise/index.ts"] },
+          },
+          guard_env: "STAGING_RESET_ALLOWED",
+        },
+      },
+    },
+  },
+  ".brewing/serve.yaml",
+);
+const profile = cfg.profiles.staging!;
+
+describe("planServeStaging", () => {
+  it("up uses bringup_cmd when set (Trade-off #3: consumer owns image build)", () => {
+    const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("ssh box 'cd /opt/app && ./redeploy.sh'");
+  });
+
+  it("up falls back to compose when only compose_overlay is set", () => {
+    const noBringup = { ...profile, bringup_cmd: undefined };
+    const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, noBringup);
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.staging.yml up -d");
+  });
+
+  it("up errors when neither bringup_cmd nor compose_overlay is set", () => {
+    const bare = { ...profile, bringup_cmd: undefined, compose_overlay: undefined };
+    const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, bare);
+    expect(result.exitCode).toBe(64);
+  });
+
+  it("sync with dryRun emits the planned push", () => {
+    const result = planServeStaging(
+      { verb: "sync", branch: "release/v2", repoRoot: "/tmp", dryRun: true },
+      cfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output.join("\n")).toContain("release/v2 → origin/main");
+    expect(result.output.join("\n")).toContain("git push --force origin release/v2:main");
+  });
+
+  it("down + --prune drops volumes", () => {
+    const pruned = planServeStaging({ verb: "down", repoRoot: "/tmp", prune: true }, cfg, profile);
+    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.staging.yml down -v");
+  });
+});
+
+describe("planServeStaging — reset (scenarios + guard env)", () => {
+  beforeEach(() => {
+    delete process.env["STAGING_RESET_ALLOWED"];
+  });
+  afterEach(() => {
+    delete process.env["STAGING_RESET_ALLOWED"];
+  });
+
+  it("reset without --scenario reports available scenarios", () => {
+    const result = planServeStaging({ verb: "reset", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(64);
+    expect(result.output.join("\n")).toMatch(/--scenario.*required/);
+    expect(result.output.join("\n")).toContain("demo, enterprise");
+  });
+
+  it("reset with unknown scenario reports the available list", () => {
+    process.env["STAGING_RESET_ALLOWED"] = "1";
+    const result = planServeStaging({ verb: "reset", scenario: "bogus", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(64);
+    expect(result.output.join("\n")).toContain("not found");
+    expect(result.output.join("\n")).toContain("demo, enterprise");
+  });
+
+  it("reset blocks when guard_env is unset", () => {
+    const result = planServeStaging({ verb: "reset", scenario: "demo", repoRoot: "/tmp" }, cfg, profile);
+    expect(result.exitCode).toBe(1);
+    expect(result.output.join("\n")).toContain("STAGING_RESET_ALLOWED");
+    expect(result.output.join("\n")).toContain("blocked");
+  });
+
+  it("reset --dry-run with guard_env set + valid scenario emits the planned scripts", () => {
+    process.env["STAGING_RESET_ALLOWED"] = "1";
+    const result = planServeStaging(
+      { verb: "reset", scenario: "demo", repoRoot: "/tmp", dryRun: true },
+      cfg,
+      profile,
+    );
+    expect(result.exitCode).toBe(0);
+    const joined = result.output.join("\n");
+    expect(joined).toContain("scenario=demo");
+    expect(joined).toContain("ts-node packages/seeds/demo/index.ts");
+  });
+
+  it("reset works on a profile without guard_env (no safety net)", () => {
+    const noGuard = {
+      ...profile,
+      seed: { scenarios: profile.seed!.scenarios, guard_env: undefined },
+    };
+    const result = planServeStaging(
+      { verb: "reset", scenario: "demo", repoRoot: "/tmp", dryRun: true },
+      cfg,
+      noGuard,
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/commands/serve/staging.ts
+++ b/packages/cli/src/commands/serve/staging.ts
@@ -1,0 +1,209 @@
+/**
+ * `slowcook serve staging <verb>` — Phase 3 implementation.
+ *
+ * The staging profile runs a built-image deployment for PM walkthroughs +
+ * manual QA. Distinct from `dev` (bind-mount source) and `mock` (vite-dev):
+ *
+ *   - mode: built-image (Trade-off #3 — slowcook ships zero image-build;
+ *     consumer's `bringup_cmd` does the heavy lifting).
+ *   - reset: named-scenario re-seed via `seed.scenarios: {demo: ..., ...}`
+ *     (Trade-off #5 — map shape from day 1; no single-value form).
+ *
+ * Verbs (Phase 3):
+ *   - up      — bring up the staging profile via consumer's bringup_cmd
+ *   - sync    — push the staging-tracking branch (default `main`); the
+ *               box's CI/deploy chain picks it up + rebuilds the image
+ *   - down    — stop the profile's services (volumes preserved)
+ *   - logs    — pass-through to docker-compose logs
+ *   - reset --scenario <name> — re-run the named scenario's seed scripts;
+ *               protected by the optional `seed.guard_env` env-var sentinel
+ *               to prevent accidental wipes from interactive sessions.
+ *
+ * Per design #5 "Additional decisions" — the staging seed is idempotent;
+ * each scenario's scripts MUST be re-runnable. Slowcook just invokes them
+ * via `ts-node` (Trade-off #2) inside the container.
+ */
+
+import { execSync } from "node:child_process";
+import type { ProfileConfig, ServeConfig } from "./config.js";
+import type { DevVerbResult } from "./dev.js";
+
+export interface StagingVerbArgs {
+  verb: string;
+  branch?: string;
+  scenario?: string;
+  service?: string;
+  follow?: boolean;
+  prune?: boolean;
+  repoRoot: string;
+  dryRun?: boolean;
+}
+
+export function planServeStaging(
+  args: StagingVerbArgs,
+  _config: ServeConfig,
+  profile: ProfileConfig,
+): DevVerbResult {
+  switch (args.verb) {
+    case "up":
+      return planUp(args, profile);
+    case "sync":
+      return planSync(args, profile);
+    case "down":
+      return planDown(args, profile);
+    case "logs":
+      return planLogs(args, profile);
+    case "reset":
+      return planReset(args, profile);
+    default:
+      return {
+        exitCode: 64,
+        output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`],
+      };
+  }
+}
+
+function planUp(_args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const lines: string[] = [`[serve staging up] mode: ${profile.mode}`];
+  if (profile.bringup_cmd) {
+    // Trade-off #3 — consumer's bring-up runs the show. Slowcook just shells out.
+    lines.push(`  cmd: ${profile.bringup_cmd}`);
+    return { exitCode: 0, output: lines };
+  }
+  if (profile.compose_overlay) {
+    lines.push(`  cmd: docker compose -f ${profile.compose_overlay} up -d`);
+    return { exitCode: 0, output: lines };
+  }
+  return {
+    exitCode: 64,
+    output: ["[serve staging up] neither bringup_cmd nor compose_overlay set; nothing to bring up."],
+  };
+}
+
+function planSync(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const sourceBranch = profile.source_branch;
+  let localBranch = args.branch;
+  if (!localBranch && !args.dryRun) {
+    try {
+      localBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd: args.repoRoot,
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      // handled below
+    }
+  } else if (!localBranch && args.dryRun) {
+    localBranch = "<current-branch>";
+  }
+  if (!localBranch || localBranch === "HEAD") {
+    return {
+      exitCode: 64,
+      output: ["[serve staging sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
+    };
+  }
+  const lines = [`[serve staging sync] ${localBranch} → origin/${sourceBranch} (staging-deploy CI rebuilds)`];
+  if (args.dryRun) {
+    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
+    return { exitCode: 0, output: lines };
+  }
+  try {
+    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, {
+      cwd: args.repoRoot,
+      stdio: "inherit",
+    });
+  } catch {
+    return {
+      exitCode: 1,
+      output: [...lines, `[serve staging sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
+    };
+  }
+  lines.push(`[serve staging sync] done.`);
+  return { exitCode: 0, output: lines };
+}
+
+function planDown(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  if (!profile.compose_overlay) {
+    return { exitCode: 64, output: ["[serve staging down] no compose_overlay set; nothing to stop."] };
+  }
+  const cmd = args.prune
+    ? `docker compose -f ${profile.compose_overlay} down -v`
+    : `docker compose -f ${profile.compose_overlay} down`;
+  return { exitCode: 0, output: ["[serve staging down]", `  cmd: ${cmd}`] };
+}
+
+function planLogs(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  if (!profile.compose_overlay) {
+    return { exitCode: 64, output: ["[serve staging logs] no compose_overlay set; nothing to tail."] };
+  }
+  const follow = args.follow ? "-f" : "";
+  const service = args.service ?? "";
+  return {
+    exitCode: 0,
+    output: [`  cmd: docker compose -f ${profile.compose_overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
+  };
+}
+
+/**
+ * `serve staging reset --scenario <name>` — re-run the named scenario's
+ * seed scripts. Idempotency is the seed-script author's job; slowcook
+ * just invokes them via ts-node (Trade-off #2 — runtime model locked).
+ *
+ * Guard: if `seed.guard_env` is set in the profile, the named env var
+ * must be non-empty in the caller's environment. Prevents accidental
+ * wipes from an interactive `serve staging reset`.
+ */
+function planReset(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  if (!args.scenario) {
+    const available = profile.seed?.scenarios ? Object.keys(profile.seed.scenarios) : [];
+    return {
+      exitCode: 64,
+      output: [
+        "[serve staging reset] --scenario <name> required.",
+        `  available scenarios: ${available.length ? available.join(", ") : "(none — declare seed.scenarios in serve.yaml)"}`,
+      ],
+    };
+  }
+  const scenario = profile.seed?.scenarios[args.scenario];
+  if (!scenario) {
+    const available = profile.seed?.scenarios ? Object.keys(profile.seed.scenarios) : [];
+    return {
+      exitCode: 64,
+      output: [
+        `[serve staging reset] scenario "${args.scenario}" not found in seed.scenarios.`,
+        `  available: ${available.length ? available.join(", ") : "(none)"}`,
+      ],
+    };
+  }
+  if (profile.seed?.guard_env) {
+    const guard = profile.seed.guard_env;
+    const value = process.env[guard];
+    if (!value) {
+      return {
+        exitCode: 1,
+        output: [
+          `[serve staging reset] blocked — guard env \`${guard}\` is not set.`,
+          `  set ${guard}=1 in this shell to authorise a reset.`,
+        ],
+      };
+    }
+  }
+  const lines: string[] = [`[serve staging reset] scenario=${args.scenario}`];
+  for (const script of scenario.scripts) {
+    lines.push(`  ts-node ${script}`);
+  }
+  if (args.dryRun || scenario.scripts.length === 0) {
+    return { exitCode: 0, output: lines };
+  }
+  // Real reset: shell out to ts-node for each script. Idempotency is the
+  // seed-script author's contract; slowcook bails on any non-zero exit.
+  for (const script of scenario.scripts) {
+    try {
+      execSync(`pnpm exec ts-node ${script}`, { cwd: args.repoRoot, stdio: "inherit" });
+    } catch {
+      lines.push(`[serve staging reset] script ${script} failed; aborting.`);
+      return { exitCode: 1, output: lines };
+    }
+  }
+  lines.push(`[serve staging reset] scenario=${args.scenario} complete.`);
+  return { exitCode: 0, output: lines };
+}


### PR DESCRIPTION
Implements **Phase 3 of design #5** — completes the multi-mode \`slowcook serve\` surface (Phase 1 in #169, Phase 2 in #170).

## What ships

\`slowcook serve staging <verb>\`. Verbs: \`up | sync | down | logs | reset\`.

## Trade-off resolutions wired

| # | Resolution | How |
|---|---|---|
| **#3** | Built-image channel — slowcook ships zero image-build | \`up\` shells out to consumer's \`bringup_cmd\` (default fallback: \`docker compose up -d\` on \`compose_overlay\`) |
| **#5** | Reset-scenario plurality — map shape from day 1 | \`reset --scenario <name>\` reads \`seed.scenarios[name]\`; lists available scenarios on missing/invalid flag |

## Safety net

\`seed.guard_env: STAGING_RESET_ALLOWED\` (optional) blocks \`reset\` unless that env var is set. Prevents accidental wipes from interactive sessions.

## Architecture

- \`staging.ts\` — \`planServeStaging\` (pure planner)
- \`index.ts\` — dispatcher wiring + \`--scenario\` flag parsing
- \`commands.manifest.ts\` — \`serve\` description tightened; \`--scenario\` added to usage; alpha badge retained

## Tests

10 new (bringup/compose fallback, sync, down/prune, reset with missing/unknown/blocked-by-guard/dry-run, no-guard profile). Cli total: 1144 → 1154.

## Help text updated

Per-profile descriptions now reflect end-to-end coverage (no more "coming soon" markers).

## Design #5 complete

All three phases shipped. The multi-mode surface (\`slowcook serve <profile> <verb>\`) plus the legacy \`slowcook dev-env\` alias is the full 0.20 ops surface.

## Test plan

- [ ] CI green
- [ ] Smoke: \`node dist/cli.js serve --help\` shows all three profiles + verbs
- [ ] Smoke: \`node dist/cli.js serve staging reset\` (no scenario) prints available list
- [ ] Smoke: \`STAGING_RESET_ALLOWED=1 node dist/cli.js serve staging reset --scenario demo --dry-run\` prints the planned ts-node scripts