### PR TITLE
docs(patterns): non-destructive-parallel-port + pre-build-code-sharing (from #173)

### DIFF
--- a/docs/patterns/non-destructive-parallel-port.md
+++ b/docs/patterns/non-destructive-parallel-port.md
@@ -1,0 +1,100 @@
+# Pattern: non-destructive parallel port
+
+> Surfaced from delgoosh dogfood, 2026-06-02 (epic #759). Captures
+> the convention that emerged for "rewrite this app in a different
+> framework alongside the existing one so PMs can compare and we can
+> cherry-pick during cut-over."
+
+## When to use
+
+A PM asks: *migrate app X to framework Y, keep app X running for
+side-by-side comparison.*
+
+The naive read is "replace `apps/X/` with the new code." That's
+destructive — you lose the comparison surface and PRs become massive
+"rewrite everything" diffs that can't be reviewed incrementally.
+
+The non-destructive parallel port keeps the existing app intact and
+creates a new sibling.
+
+## Convention
+
+### Directory naming
+
+| What you have | What you create | Why |
+|---|---|---|
+| `apps/X/` (current) | `apps/X-v2/` OR `apps/X-spa/` OR `apps/X-vite/` | Suffix indicates intent (versioned bump, technology, framework); leaves room for the eventual rename when the new one supersedes the old |
+| ditto, integrated multi-role variant | `apps/Y/` where Y describes the role grouping (e.g. `apps/spa-patient` + `apps/spa-therapist`) | Lets you split or merge the routing model from the old shape |
+
+### Port allocation
+
+The new app(s) MUST listen on distinct host ports from the originals
+so both run side-by-side. Reserve a range explicitly:
+
+```
+3001  apps/patient            (existing)
+3002  apps/therapist          (existing)
+3006  apps/spa-patient        (new)
+3007  apps/spa-therapist      (new)
+```
+
+Document the table in a comment in the relevant `docker-compose.*.yml`
+or `.brewing/serve.yaml`.
+
+### Shared code
+
+If the new apps share infrastructure (auth, design system, primitives),
+prefer **pre-build sharing via path alias** over a workspace package
+unless you need an enforced API boundary:
+
+```yaml
+# Each new app's vite.config.ts:
+resolve:
+  alias:
+    '@shared': path.resolve(__dirname, '../../packages/shared-spa/src')
+```
+
+The shared dir is a plain code directory — no `package.json`, no
+`workspace:*` deps. This avoids `pnpm install` churn and keeps the
+mental model "files my app can import."
+
+See `docs/patterns/pre-build-code-sharing.md` for the full rationale.
+
+### What stays + what goes
+
+- **Existing app code** — STAYS untouched. Don't even tidy it up
+  during the migration; that confuses the diff.
+- **Existing app's container + port** — STAYS in `docker-compose.production.yml`.
+  The new app gets its own entry alongside.
+- **CI** — both apps build; CI failures on either gate the PR.
+- **README** — add a short note pointing at the parallel app + its
+  reference issue so future contributors don't accidentally start work
+  on the deprecated one.
+
+### When to remove the old app
+
+After the new app reaches feature parity AND has been in production
+behind a feature flag or domain split for at least one release cycle.
+A separate "remove `apps/X/`" PR closes the migration; don't combine
+removal with the last visual-parity PR.
+
+## brew prompt addendum
+
+When refine emits a spec with `migration: parallel_port` set in the
+manifest, brew should:
+
+1. Refuse to modify the source app's files (`apps/X/**` is frozen for
+   the duration of the migration story).
+2. Default the new app's dir name to `apps/<source>-<framework>`
+   unless the spec overrides.
+3. Reserve a new port and document it in compose + serve.yaml.
+4. Add a README entry to the new app's directory linking back to the
+   source app + the epic issue.
+
+## Open questions
+
+- How long should the parallel state persist before the source app is
+  removed? PM-decided; not a slowcook concern.
+- What if the source app gets a bug fix during the migration? The fix
+  also lands on the new app via cherry-pick — convention to be
+  formalised as a separate doc.

--- a/docs/patterns/pre-build-code-sharing.md
+++ b/docs/patterns/pre-build-code-sharing.md
@@ -1,0 +1,106 @@
+# Pattern: pre-build code sharing (path alias, not workspace package)
+
+> Surfaced from delgoosh dogfood, 2026-06-02 (epic #759). Two new
+> Vite-React SPAs needed to share auth + primitives + design-system.
+> The instinct was a workspace package. The right answer was a plain
+> code directory + path alias.
+
+## When pre-build sharing is the right tool
+
+Two or more apps in the same monorepo share internal infrastructure
+(types, hooks, providers, UI primitives) AND:
+
+- All consumers are inside this monorepo
+- No consumer publishes to a registry
+- No API-boundary enforcement is needed (`export *` from any file is fine)
+- Versioning of shared code doesn't need to be independent
+
+In that case, the workspace-package machinery (`packages/foo/package.json`
++ `dependencies: { "@repo/foo": "workspace:*" }` per consumer +
+`exports` map + version bumps) is overhead with no benefit.
+
+## When the workspace package IS the right tool
+
+- The shared package will be published to npm
+- You need a strict API boundary (only what's in `index.ts` is public)
+- The shared package has its own test suite + lifecycle scripts
+- Multiple repos consume it
+
+## How
+
+### Shared dir
+
+```
+packages/shared-spa/
+├── src/
+│   ├── lib/{api,auth}.ts
+│   ├── components/...
+│   └── design-system/...
+└── public/  (assets the apps want to host)
+```
+
+No `package.json`, no `tsconfig.json` (consumers' tsconfig includes
+the source).
+
+### Consumer config
+
+Each consumer app's `vite.config.ts` (or webpack, etc.):
+
+```ts
+resolve: {
+  alias: {
+    '@shared': path.resolve(__dirname, '../../packages/shared-spa/src'),
+  },
+}
+```
+
+Each consumer's `tsconfig.json` paths:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@shared/*": ["../../packages/shared-spa/src/*"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "../../packages/shared-spa/src/**/*.ts",
+    "../../packages/shared-spa/src/**/*.tsx"
+  ]
+}
+```
+
+Each consumer's Tailwind `content` glob (if applicable):
+
+```ts
+content: [
+  './src/**/*.{ts,tsx}',
+  '../../packages/shared-spa/src/**/*.{ts,tsx}',
+]
+```
+
+### Consumption looks identical to a workspace package
+
+```ts
+import { useAuth } from '@shared/lib/auth';
+import { Button } from '@shared/components/ui/button';
+```
+
+## Bundle outcome
+
+Same as workspace-package import. The bundler (Vite/webpack) walks the
+alias, resolves the source files, includes them in each app's output
+chunk. If two apps share `Button`, each app's bundle has its own copy
+of `Button` — same as it would with a workspace package.
+
+For runtime sharing across apps (one bundle loaded once, multiple apps
+consume), you need **module federation** which is a separate pattern.
+
+## brew prompt addendum
+
+When emitting shared code for two or more consumers in the same
+monorepo, brew should default to the pre-build path-alias pattern.
+Switch to workspace package only when one of the "right tool"
+conditions above applies.


### PR DESCRIPTION
Two new pattern docs surfaced from the delgoosh dogfood (epic delgoosh/monorepo#759). Addresses items #9 and #11 of the feedback in #173.

## non-destructive-parallel-port

Convention for "rewrite this app in a different framework alongside the existing one." Covers directory naming (suffix), port allocation, what stays untouched during the migration, when to remove the old app. Includes a brew prompt addendum for handling `migration: parallel_port` in spec manifests.

## pre-build-code-sharing

When the new path-alias pattern beats a workspace-package for shared monorepo code. Concrete Vite + tsconfig + Tailwind config recipe. Includes a brew prompt addendum to default to path-alias unless a strict-API or external-consumer condition applies.

## Why docs and not code

Both patterns are conventions, not code changes. Codifying them lets brew agents reach for the right shape without re-deriving the trade-offs every time. Future work (separate PRs): wire the brew prompt addendums into the LLM templates.