### PR TITLE
docs(plans): 0.20 design-discussions #6 (refine-init) + #7 (spec references field)

### DIFF
--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -347,6 +347,118 @@ The originally-flagged "soak before locking" concerns are addressed by the trade
 
 ---
 
+## #6 — `slowcook refine init` spec-template starter (PROPOSED 2026-06-02)
+
+### Problem
+
+Surfaced in delgoosh#759 mimic-refine session (issue [aminazar/slowcook#173 finding #8](https://github.com/aminazar/slowcook/issues/173)).
+
+A local-pipeline agent writing a new spec from scratch has no template to start from. Today the agent copies an existing `specs/story-NNN.yaml`, hand-strips fields that don't apply, and renumbers — error-prone (the existing spec's `proposals.routes.paths` reflects its routes, not the new story's; the agent has to remember to clear those).
+
+For ~20 stories driven through mimic-refine, that's ~20× (5–10 min of mechanical copy-and-strip + remember-to-renumber). A scaffolder eliminates that overhead.
+
+### Options considered
+
+- **A** — `slowcook refine init --epic <issue-or-id>` emits a starter `specs/story-N.yaml` with: next claimed story-ID (per Design #3 tombstone work), pre-filled `source_issue` from the epic, all standard sections empty, comments explaining each section's purpose.
+- **B** — Make refine LLM-driven mode the default, no template needed (the LLM emits the whole spec from the issue body + context).
+- **C** — Doc-only: extend `docs/local-pipeline-role.md` with a copy-pasteable starter template. Agent reads + clones.
+
+### Chosen: **A** (CLI scaffolder, PROPOSED awaiting maintainer)
+
+The CLI command is small (~30 LoC), composes with existing `nextStoryId()` machinery, and reduces mechanical error. LLM-driven (B) is the right end-state but doesn't replace the local-pipeline use case. Doc (C) is the cheap fallback; ship if A is deprioritised.
+
+Concrete shape:
+
+```
+$ slowcook refine init --epic 759 --estimate medium
+Reserved story-024 (next free; story-020 through 023 in use).
+Wrote: specs/story-024.yaml
+  - source_issue: #759 (inferred from --epic)
+  - estimate: medium (from --estimate)
+  - refined_by: local-claude-pipeline@2026-06-02 (or env-derived agent ID)
+  - status: active
+  - all body sections present + empty + sectional comments
+Run `slowcook refine` (LLM mode) or hand-author the body, then file
+the corresponding GH issue via `slowcook refine submit` (existing).
+```
+
+### Rationale
+
+Skips the copy-strip-renumber dance + integrates with existing infra (`nextStoryId`, `_index.yaml`). Cheap to ship; high frequency-of-use payoff.
+
+### Scope estimate
+
+- 0.25d — command + tests
+- 0.25d — `_index.yaml` auto-append on init
+
+**~0.5d total.** Lands in 0.20 if approved.
+
+---
+
+## #7 — Spec `references` field (behaviour-source vs visual-source split) (PROPOSED 2026-06-02)
+
+### Problem
+
+Surfaced in delgoosh#759 epic refine (issue [aminazar/slowcook#173 finding #10](https://github.com/aminazar/slowcook/issues/173)).
+
+The delgoosh patient-app migration spec has a critical invariant the PM clarified mid-refine: port BEHAVIOUR (state machine, API integrations, validation, persistence) from `apps/patient/src/app/patient-onboarding/**`, but port VISUAL (look, layout, styling) from `delgoosh/design-react/src/shared/components/onboarding/**`. The two sources diverge meaningfully — the current implementation evolved past the design mock — and brew has to pick the right reference per axis or end up with the wrong shape.
+
+Today this lives as prose in `invariants:` ("port behaviour from X, visual from Y"). That's fragile: it relies on brew agents reading + correctly weighting the invariant against other invariants. Worse, plate + vibe stages don't have a clean signal to pick which source-of-truth to read.
+
+### Options considered
+
+- **A** — Add a top-level `references:` field with `behaviour`/`visual`/`api`/`tests` keys, each pointing to a path glob + rationale. Plate + vibe + brew read this field at their respective stages and prefer it over invariants prose.
+- **B** — Keep prose, add a brew prompt addendum that scans invariants for "port X from" patterns. Soft — relies on LLM correctly parsing prose.
+- **C** — A flat string field `behaviour_source` / `visual_source` (no nesting). Simpler but less expressive when there are multiple sources per axis.
+
+### Chosen: **A** (structured `references` field, PROPOSED)
+
+Concrete shape:
+
+```yaml
+references:
+  behaviour:
+    - source: apps/patient/src/app/patient-onboarding/**
+      rationale: |
+        Production-evolved state machine + API contracts. The current
+        implementation has business logic, validation rules, and
+        persistence that aren't in design-react (which was a mock).
+  visual:
+    - source: delgoosh/design-react/src/shared/components/onboarding/**
+      rationale: |
+        Original design intent + intended UX. apps/patient's visual
+        diverged during brew rounds; design-react is the source-of-truth.
+  api:
+    - source: apps/back/src/modules/patient-onboarding/**
+      rationale: Existing endpoints; no contract changes for this story.
+  tests:
+    - source: tests/integration/patient-onboarding-*.test.ts
+      rationale: Existing acceptance tests cover the behaviour above.
+```
+
+Each axis is a LIST of `{source, rationale}` pairs so a spec can compose references from multiple paths.
+
+### Rationale
+
+Structured > prose for cross-stage consumption. Plate reads `references.api`; vibe reads `references.visual`; brew reads all four. The rationale field captures the WHY so reviewers + future agents know whether the choice still applies.
+
+Spec schema bump: minor (add optional `references` map). Backward-compat: existing specs without it fall back to invariants-prose parsing (today's behaviour).
+
+### Scope estimate
+
+- 0.5d — schema bump + spec-validate update + tests
+- 0.5d — refine prompt: emit `references` block when source-of-truth differs across stages
+- 0.5d — plate + vibe + brew prompts: consume references with stage-appropriate weighting
+- 0.5d — docs
+
+**~2d total.** Lands in 0.20 if approved.
+
+### Open question
+
+Should `references` be PER-INVARIANT (each invariant points at its own source) or top-level (the whole spec's stages share sources)? Top-level matches the per-stage agent contract better; per-invariant is more granular. Lean toward top-level for v1, escalate to per-invariant if real specs hit the granularity ceiling.
+
+---
+
 ## Cross-doc references
 
 - Strategy + ideation: [`0.20-and-beyond.md`](./0.20-and-beyond.md)

--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -347,7 +347,7 @@ The originally-flagged "soak before locking" concerns are addressed by the trade
 
 ---
 
-## #6 — `slowcook refine init` spec-template starter (PROPOSED 2026-06-02)
+## #6 — `slowcook refine init` spec-template starter (DECIDED 2026-06-03)
 
 ### Problem
 
@@ -363,7 +363,7 @@ For ~20 stories driven through mimic-refine, that's ~20× (5–10 min of mechani
 - **B** — Make refine LLM-driven mode the default, no template needed (the LLM emits the whole spec from the issue body + context).
 - **C** — Doc-only: extend `docs/local-pipeline-role.md` with a copy-pasteable starter template. Agent reads + clones.
 
-### Chosen: **A** (CLI scaffolder, PROPOSED awaiting maintainer)
+### Chosen: **A**
 
 The CLI command is small (~30 LoC), composes with existing `nextStoryId()` machinery, and reduces mechanical error. LLM-driven (B) is the right end-state but doesn't replace the local-pipeline use case. Doc (C) is the cheap fallback; ship if A is deprioritised.
 
@@ -395,7 +395,7 @@ Skips the copy-strip-renumber dance + integrates with existing infra (`nextStory
 
 ---
 
-## #7 — Spec `references` field (behaviour-source vs visual-source split) (PROPOSED 2026-06-02)
+## #7 — Spec `references` field (behaviour-source vs visual-source split) (DECIDED 2026-06-03)
 
 ### Problem
 
@@ -411,7 +411,7 @@ Today this lives as prose in `invariants:` ("port behaviour from X, visual from 
 - **B** — Keep prose, add a brew prompt addendum that scans invariants for "port X from" patterns. Soft — relies on LLM correctly parsing prose.
 - **C** — A flat string field `behaviour_source` / `visual_source` (no nesting). Simpler but less expressive when there are multiple sources per axis.
 
-### Chosen: **A** (structured `references` field, PROPOSED)
+### Chosen: **A**
 
 Concrete shape:
 
@@ -453,9 +453,15 @@ Spec schema bump: minor (add optional `references` map). Backward-compat: existi
 
 **~2d total.** Lands in 0.20 if approved.
 
-### Open question
+### Granularity decision
 
-Should `references` be PER-INVARIANT (each invariant points at its own source) or top-level (the whole spec's stages share sources)? Top-level matches the per-stage agent contract better; per-invariant is more granular. Lean toward top-level for v1, escalate to per-invariant if real specs hit the granularity ceiling.
+**Top-level** for v1 (locked 2026-06-03). Each axis (behaviour / visual / api / tests) is a list of `{source, rationale}` pairs at the spec root; the whole spec's stages share the references map.
+
+- Per-stage consumption is the load-bearing use case (plate reads `references.api`; vibe reads `references.visual`; brew reads all four). Top-level matches that contract cleanly — each agent pulls one axis without walking the invariants tree.
+- Per-invariant granularity would create coupling between invariants and reference paths that's hard to refactor when the spec evolves. Today's spec invariants ARE the contract; adding a sibling-source field per invariant blurs that.
+- Escape hatch: if a real spec hits the granularity ceiling (two invariants on the same axis genuinely need different sources), split that pair into separate stories rather than reaching for per-invariant references.
+
+Per-invariant remains a fallback path; not building it now.
 
 ---
 


### PR DESCRIPTION
Two PROPOSED design entries from delgoosh dogfood (#173 items #8 + #10):

**#6 — `slowcook refine init --epic`** — spec-template scaffolder. Replaces the copy-strip-renumber dance local-pipeline agents do today. ~0.5d ship.

**#7 — Spec `references` field** — structured source-of-truth declarations (behaviour / visual / api / tests). Surfaced from delgoosh#759 Story 022 where patient onboarding has split sources (behaviour from one path, visual from another). Today's prose invariants can't express the split cleanly. ~2d ship.

Both PROPOSED; maintainer review before promoting to DECIDED.