### PR TITLE
fix(serve): execute commands (sc#173 #1) + compose-file layering (sc#173 #2) + cut 0.19.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## 0.19.7 — `slowcook serve` execution layer + compose-file layering (sc#173)
+
+Cut 2026-06-03. `@slowcook-ai/cli` 0.19.7 only.
+
+Dogfood feedback on the 0.19.6 `slowcook serve` release (issue sc#173, delgoosh local-pipeline session 2026-06-01) surfaced two correctness gaps in the planners. Both fixed here.
+
+- **sc#173 finding #1 — `serve <profile> up` actually executes.** Previously the planners emitted `cmd: docker compose -f ... up -d` into `output[]` and exited without running it, even when `profile.ssh_target` was set. Operators had to copy-paste + ssh themselves. Now planners populate `result.commands[]` with structured `ShellCommand` records; the cli wrapper invokes `runCommands()` which wraps `remote: true` commands in `ssh user@host 'cd <checkout_dir> && <cmd>'` and executes via `execSync`. `--dry-run` prints the wrapped form without executing.
+
+  Local-only commands like `git push` (sync verb) declare `remote: false` so they're never ssh-wrapped. Stdio is inherited so operators see docker / git output in real time.
+
+- **sc#173 finding #2 — multi-file compose + `--build` suppression.** New `compose_files: [string]` field on the profile schema; takes precedence over `compose_overlay` when both are set. Real consumers (delgoosh, etc.) put long-lived services (postgres, networks, depends_on chain) in `docker-compose.production.yml` and the dev overlay ONLY redefines the bind-mounted services. Emitting just `-f overlay.yml` skipped the base + broke the `depends_on` graph.
+
+  The `--build` flag is now suppressed for `bind-mount-source` mode (the whole point of bind-mount is skipping the build loop). Still passed for `built-image` mode.
+
+  New `composeFiles(profile)` and `shouldBuildOnUp(profile)` helpers, both pure + exported for testing.
+
+- **`runner.ts` + `ShellCommand`**: introduces the structured-command layer. Pure `resolveCommand()` returns the wire-shape string (with ssh-wrap applied when applicable); `runCommands()` executes a list, bailing on first failure. Six new unit tests cover the local / remote / single-quote-escape / dry-run paths.
+
+- **Backward-compat**: every existing `slowcook serve` invocation continues to work. The legacy single-file `compose_overlay` field still resolves through `composeFiles()`. Existing `.brewing/dev-env.yaml` consumers can adopt `compose_files` incrementally.
+
+Findings #3–#7 from the same dogfood (autosync workflow scaffold, dynamic source-branch resolver, alpine-vs-debian for native modules, dev-mode side-effects audit pattern, mock-detect verbosity) tracked as follow-ups; some are net-new design discussions, some are doc-shaped.
+
+Test count: 1154 → 1169.
+
+---
+
 ## 0.19.6 — `slowcook serve` multi-mode + help-manifest single-source
 
 Cut 2026-06-01. `@slowcook-ai/cli` 0.19.6 only.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands/serve/config-helpers.test.ts
+++ b/packages/cli/src/commands/serve/config-helpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { composeFiles, shouldBuildOnUp, ProfileConfigSchema, normaliseConfig } from "./config.js";
+
+const parse = (p: object) => ProfileConfigSchema.parse(p);
+
+describe("composeFiles", () => {
+  it("returns compose_files when set (multi-`-f` shape)", () => {
+    const p = parse({
+      apps: {},
+      compose_files: ["docker-compose.production.yml", "docker-compose.dev.yml"],
+    });
+    expect(composeFiles(p)).toEqual([
+      "docker-compose.production.yml",
+      "docker-compose.dev.yml",
+    ]);
+  });
+
+  it("falls back to compose_overlay when only the legacy field is set", () => {
+    const p = parse({ apps: {}, compose_overlay: "docker-compose.dev.yml" });
+    expect(composeFiles(p)).toEqual(["docker-compose.dev.yml"]);
+  });
+
+  it("prefers compose_files over compose_overlay when both are set", () => {
+    const p = parse({
+      apps: {},
+      compose_files: ["a.yml", "b.yml"],
+      compose_overlay: "should-be-ignored.yml",
+    });
+    expect(composeFiles(p)).toEqual(["a.yml", "b.yml"]);
+  });
+
+  it("returns empty when neither is set", () => {
+    expect(composeFiles(parse({ apps: {} }))).toEqual([]);
+  });
+});
+
+describe("shouldBuildOnUp", () => {
+  it("returns false for bind-mount-source mode (default — sc#173 #2)", () => {
+    expect(shouldBuildOnUp(parse({ apps: {} }))).toBe(false);
+    expect(shouldBuildOnUp(parse({ apps: {}, mode: "bind-mount-source" }))).toBe(false);
+  });
+
+  it("returns true for built-image mode", () => {
+    expect(shouldBuildOnUp(parse({ apps: {}, mode: "built-image" }))).toBe(true);
+  });
+});
+
+describe("normaliseConfig — compose_files round-trip", () => {
+  it("preserves compose_files through legacy wrapping", () => {
+    // Legacy (flat) shape can carry compose_files too — get wrapped into profiles.dev.
+    const legacy = {
+      schema_version: 1,
+      apps: {},
+      compose_files: ["base.yml", "dev.yml"],
+    };
+    const cfg = normaliseConfig(legacy, ".brewing/dev-env.yaml");
+    expect(cfg.profiles.dev?.compose_files).toEqual(["base.yml", "dev.yml"]);
+  });
+});

--- a/packages/cli/src/commands/serve/config.ts
+++ b/packages/cli/src/commands/serve/config.ts
@@ -91,7 +91,24 @@ export const ProfileConfigSchema = z.object({
   mode: ProfileModeSchema.optional().default("bind-mount-source"),
   /** Git branch the profile tracks. Default: `dev`. */
   source_branch: z.string().default("dev"),
-  /** Optional compose-overlay path (consumer-supplied; slowcook calls it via docker compose). */
+  /**
+   * One or more compose files passed as `-f <path>` in declared order.
+   * The canonical pattern for `bind-mount-source` profiles:
+   *
+   *   compose_files:
+   *     - docker-compose.production.yml   # base: postgres, networks, depends_on chain
+   *     - docker-compose.dev.yml          # overlay: bind-mount overrides
+   *
+   * Real consumers (delgoosh, etc.) define their long-lived services
+   * (postgres / temporal / non-swapped apps) in a base compose and the
+   * dev/staging overlays ONLY redefine the services that swap. Emitting
+   * just `-f overlay.yml` skips the base, breaking `depends_on`.
+   *
+   * Takes precedence over `compose_overlay` if both are set. Reported
+   * as a dogfood gap on serve 0.19.6 (sc#173 finding #2).
+   */
+  compose_files: z.array(z.string()).optional(),
+  /** Single compose-overlay path (legacy). Use `compose_files` for base+overlay layering. */
   compose_overlay: z.string().optional(),
   /**
    * Built-image profiles call into the consumer's bring-up script
@@ -192,4 +209,29 @@ function formatZodError(source: string, err: z.ZodError): string {
 /** Convenience: lookup a profile by name (case-sensitive). */
 export function getProfile(config: ServeConfig, name: string): ProfileConfig | undefined {
   return config.profiles[name];
+}
+
+/**
+ * Return the ordered list of compose files for `docker compose -f ... -f ...`.
+ * Prefers `compose_files` (the multi-file shape sc#173 #2 surfaced); falls
+ * back to `compose_overlay` (legacy single-file). Empty when neither is set.
+ */
+export function composeFiles(profile: ProfileConfig): string[] {
+  if (profile.compose_files && profile.compose_files.length > 0) return profile.compose_files;
+  if (profile.compose_overlay) return [profile.compose_overlay];
+  return [];
+}
+
+/**
+ * Whether `docker compose up` should pass `--build`.
+ *
+ * - `bind-mount-source`: NEVER. The whole point of the mode is to skip
+ *   docker build (rsync source into a bind-mounted container). Passing
+ *   `--build` triggers a rebuild that takes minutes per up. sc#173 #2.
+ * - `built-image`: usually no — the consumer's bring-up rebuilds out of
+ *   band. But the explicit `--build` from `up` is conventional for
+ *   built-image so the local docker daemon picks up image edits.
+ */
+export function shouldBuildOnUp(profile: ProfileConfig): boolean {
+  return profile.mode === "built-image";
 }

--- a/packages/cli/src/commands/serve/dev.test.ts
+++ b/packages/cli/src/commands/serve/dev.test.ts
@@ -16,19 +16,51 @@ const baseCfg = normaliseConfig(
   },
   ".brewing/serve.yaml",
 );
-
 const profile = baseCfg.profiles.dev!;
 
 describe("planServeDev", () => {
-  it("up emits the compose command + seed line", () => {
-    const result = planServeDev(
-      { verb: "up", repoRoot: "/tmp" },
-      baseCfg,
-      profile,
-    );
+  it("up emits the compose-up command + seed command", () => {
+    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, baseCfg, profile);
     expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml up -d --build");
-    expect(result.output.join("\n")).toContain("packages/seeds/dev/index.ts");
+    const cmds = (result.commands ?? []).map((c) => c.cmd);
+    // bind-mount-source default → no --build flag (sc#173 #2).
+    expect(cmds).toContain("docker compose -f docker-compose/docker-compose.dev.yml up -d");
+    expect(cmds).toContain("pnpm exec ts-node packages/seeds/dev/index.ts");
+    // The bring-up command runs remotely (ssh-wrapped if ssh_target set).
+    expect(result.commands?.[0]?.remote).toBe(true);
+  });
+
+  it("up with built-image mode includes --build", () => {
+    const builtImageCfg = normaliseConfig(
+      {
+        schema_version: 1,
+        profiles: {
+          dev: { mode: "built-image", compose_overlay: "compose.yml", apps: {} },
+        },
+      },
+      "x.yaml",
+    );
+    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, builtImageCfg, builtImageCfg.profiles.dev!);
+    expect(result.commands?.[0]?.cmd).toContain("--build");
+  });
+
+  it("up supports compose_files (multi-`-f` base + overlay)", () => {
+    const layeredCfg = normaliseConfig(
+      {
+        schema_version: 1,
+        profiles: {
+          dev: {
+            compose_files: ["docker-compose.production.yml", "docker-compose.dev.yml"],
+            apps: { patient: { mode: "next-dev", port: 3001 } },
+          },
+        },
+      },
+      "x.yaml",
+    );
+    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, layeredCfg, layeredCfg.profiles.dev!);
+    expect(result.commands?.[0]?.cmd).toBe(
+      "docker compose -f docker-compose.production.yml -f docker-compose.dev.yml up -d",
+    );
   });
 
   it("sync with dryRun + explicit --branch emits the planned push", () => {
@@ -38,10 +70,11 @@ describe("planServeDev", () => {
       profile,
     );
     expect(result.exitCode).toBe(0);
-    const joined = result.output.join("\n");
-    expect(joined).toContain("feat/x → origin/dev");
-    expect(joined).toContain("story-042");
-    expect(joined).toContain("git push --force origin feat/x:dev");
+    expect(result.output.join("\n")).toContain("feat/x → origin/dev");
+    expect(result.output.join("\n")).toContain("story-042");
+    expect(result.commands?.[0]?.cmd).toBe("git push --force origin feat/x:dev");
+    // git push runs locally — never ssh-wrapped.
+    expect(result.commands?.[0]?.remote).toBe(false);
   });
 
   it("sync rejects detached HEAD without --branch", () => {
@@ -54,13 +87,12 @@ describe("planServeDev", () => {
     expect(result.output.join("\n")).toContain("detached HEAD");
   });
 
-  it("down emits the compose down command + --prune drops volumes", () => {
+  it("down emits compose down + --prune drops volumes", () => {
     const plain = planServeDev({ verb: "down", repoRoot: "/tmp" }, baseCfg, profile);
-    expect(plain.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml down");
-    expect(plain.output.join("\n")).not.toContain(" -v");
+    expect(plain.commands?.[0]?.cmd).toBe("docker compose -f docker-compose/docker-compose.dev.yml down");
 
     const pruned = planServeDev({ verb: "down", repoRoot: "/tmp", prune: true }, baseCfg, profile);
-    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml down -v");
+    expect(pruned.commands?.[0]?.cmd).toBe("docker compose -f docker-compose/docker-compose.dev.yml down -v");
   });
 
   it("logs supports --service + --follow", () => {
@@ -69,13 +101,14 @@ describe("planServeDev", () => {
       baseCfg,
       profile,
     );
-    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.dev.yml logs -f patient");
+    expect(result.commands?.[0]?.cmd).toBe("docker compose -f docker-compose/docker-compose.dev.yml logs -f patient");
   });
 
   it("reset is a no-op for the dev profile", () => {
     const result = planServeDev({ verb: "reset", repoRoot: "/tmp" }, baseCfg, profile);
     expect(result.exitCode).toBe(0);
     expect(result.output.join("\n")).toContain("only meaningful for staging");
+    expect(result.commands).toBeUndefined();
   });
 
   it("unknown verb exits 64 with a hint", () => {
@@ -84,15 +117,15 @@ describe("planServeDev", () => {
     expect(result.output.join("\n")).toContain("Unknown verb");
   });
 
-  it("up emits a clear notice when compose_overlay is absent", () => {
-    const profileNoOverlay = { ...profile, compose_overlay: undefined };
-    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, baseCfg, profileNoOverlay);
-    expect(result.output.join("\n")).toContain("no compose_overlay set");
+  it("up errors when neither compose_files nor compose_overlay is set", () => {
+    const noFiles = { ...profile, compose_overlay: undefined, compose_files: undefined };
+    const result = planServeDev({ verb: "up", repoRoot: "/tmp" }, baseCfg, noFiles);
+    expect(result.exitCode).toBe(64);
   });
 
-  it("down errors when compose_overlay is absent", () => {
-    const profileNoOverlay = { ...profile, compose_overlay: undefined };
-    const result = planServeDev({ verb: "down", repoRoot: "/tmp" }, baseCfg, profileNoOverlay);
+  it("down errors when neither compose_files nor compose_overlay is set", () => {
+    const noFiles = { ...profile, compose_overlay: undefined, compose_files: undefined };
+    const result = planServeDev({ verb: "down", repoRoot: "/tmp" }, baseCfg, noFiles);
     expect(result.exitCode).toBe(64);
   });
 });

--- a/packages/cli/src/commands/serve/dev.ts
+++ b/packages/cli/src/commands/serve/dev.ts
@@ -3,7 +3,7 @@
  *
  * Verbs (Phase 1):
  *   - up      — bring up the dev profile (compose overlay or fallback)
- *   - sync    — rsync source to the box + restart the bind-mount targets
+ *   - sync    — push source-branch + restart bind-mount targets
  *   - down    — stop the profile's services (volumes preserved)
  *   - logs    — pass-through to docker-compose logs
  *   - reset   — no-op for dev profile (only meaningful for staging)
@@ -13,45 +13,41 @@
  *   - `slowcook dev-env up` ≡ `slowcook serve dev up`
  *   - `slowcook dev-env reset` ≡ `slowcook serve dev reset` (no-op + notice)
  *
- * `bind-mount-source` mode (the DECIDED choice for dev profile) uses
- * rsync to push source + an anonymous-volume node_modules in the
- * compose overlay. Avoids node_modules collision on macOS + chmod
- * surprises. See `docs/plans/0.20-design-discussions.md` design #5
- * "Additional decisions" for the rationale.
+ * 0.19.7 (sc#173 fixes):
+ *   - Planner populates `commands[]` (structured ShellCommand records).
+ *     The cli wrapper invokes runCommands() to actually execute (or
+ *     dry-run); previously `up`/`down`/`logs` were planners only.
+ *   - Compose-file layering: respects `profile.compose_files` (multi-`-f`)
+ *     OR `compose_overlay` (single). Real consumers need base+overlay.
+ *   - `--build` flag is suppressed for `bind-mount-source` mode (the
+ *     mode's whole point is skipping the build loop).
  */
 
 import { execSync } from "node:child_process";
 import type { ProfileConfig, ServeConfig } from "./config.js";
+import { composeFiles, shouldBuildOnUp } from "./config.js";
+import type { ShellCommand } from "./runner.js";
 
 export interface DevVerbArgs {
   verb: string;
-  /** Branch to push (sync verb). Resolved from HEAD if undefined. */
   branch?: string;
-  /** Story id, included in the push log line for audit. */
   story?: string;
-  /** Filter logs to one app (logs verb). */
   service?: string;
-  /** Follow logs (logs verb). */
   follow?: boolean;
-  /** Drop volumes too (down verb). */
   prune?: boolean;
   repoRoot: string;
-  /** Test seam: skip actual git/docker calls; emit a plan only. */
+  /** Test seam: report the plan but skip actual git rev-parse. */
   dryRun?: boolean;
 }
 
 export interface DevVerbResult {
   exitCode: number;
-  /** Lines emitted to stdout / "what would have run" under dryRun. */
+  /** Human narrative emitted by the planner. */
   output: string[];
+  /** Shell commands the cli wrapper should execute (in order). */
+  commands?: ShellCommand[];
 }
 
-/**
- * Pure dispatcher for the dev profile. Returns a DevVerbResult so the
- * caller (cli) can render output + set the exit code. Splitting the
- * pure planner from the IO wrapper lets the tests assert on the plan
- * without spawning docker.
- */
 export function planServeDev(
   args: DevVerbArgs,
   _config: ServeConfig,
@@ -77,18 +73,24 @@ export function planServeDev(
 }
 
 function planUp(_args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
+  const files = composeFiles(profile);
   const apps = Object.keys(profile.apps);
-  const lines: string[] = [`[serve dev up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
-  if (overlay) {
-    lines.push(`  cmd: docker compose -f ${overlay} up -d --build`);
-  } else {
-    lines.push("  (no compose_overlay set; consumer must wire its own up command)");
+  const output: string[] = [`[serve dev up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
+
+  if (files.length === 0) {
+    output.push("  (no compose_files / compose_overlay set; declare one in serve.yaml)");
+    return { exitCode: 64, output };
   }
+
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
+  const buildFlag = shouldBuildOnUp(profile) ? " --build" : "";
+  const commands: ShellCommand[] = [
+    { cmd: `docker compose ${fileFlags} up -d${buildFlag}`, remote: true, label: "bring up" },
+  ];
   if (profile.seed_script) {
-    lines.push(`  seed: pnpm exec ts-node ${profile.seed_script}`);
+    commands.push({ cmd: `pnpm exec ts-node ${profile.seed_script}`, remote: true, label: "seed" });
   }
-  return { exitCode: 0, output: lines };
+  return { exitCode: 0, output, commands };
 }
 
 function planSync(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
@@ -98,7 +100,7 @@ function planSync(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
     try {
       localBranch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: args.repoRoot, encoding: "utf8" }).trim();
     } catch {
-      // fall through; handled below
+      // handled below
     }
   } else if (!localBranch && args.dryRun) {
     localBranch = "<current-branch>";
@@ -109,47 +111,43 @@ function planSync(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
       output: ["[serve dev sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
     };
   }
-  const lines: string[] = [
+  const output: string[] = [
     `[serve dev sync] ${localBranch} → origin/${sourceBranch}${args.story ? ` (story-${args.story})` : ""}`,
   ];
-  if (args.dryRun) {
-    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
-    return { exitCode: 0, output: lines };
-  }
-  try {
-    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, { cwd: args.repoRoot, stdio: "inherit" });
-  } catch {
-    return {
-      exitCode: 1,
-      output: [...lines, `[serve dev sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
-    };
-  }
-  lines.push(`[serve dev sync] done. The dev-deploy workflow on origin/${sourceBranch} will fire next.`);
-  return { exitCode: 0, output: lines };
+  const commands: ShellCommand[] = [
+    { cmd: `git push --force origin ${localBranch}:${sourceBranch}`, remote: false, label: "git push" },
+  ];
+  return { exitCode: 0, output, commands };
 }
 
 function planDown(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
-  const lines: string[] = ["[serve dev down]"];
-  if (!overlay) {
-    return { exitCode: 64, output: ["[serve dev down] no compose_overlay set; nothing to stop."] };
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve dev down] no compose_files / compose_overlay set; nothing to stop."] };
   }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
   const cmd = args.prune
-    ? `docker compose -f ${overlay} down -v`
-    : `docker compose -f ${overlay} down`;
-  lines.push(`  cmd: ${cmd}`);
-  return { exitCode: 0, output: lines };
+    ? `docker compose ${fileFlags} down -v`
+    : `docker compose ${fileFlags} down`;
+  return {
+    exitCode: 0,
+    output: ["[serve dev down]"],
+    commands: [{ cmd, remote: true, label: "compose down" }],
+  };
 }
 
 function planLogs(args: DevVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
-  if (!overlay) {
-    return { exitCode: 64, output: ["[serve dev logs] no compose_overlay set; nothing to tail."] };
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve dev logs] no compose_files / compose_overlay set; nothing to tail."] };
   }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
   const follow = args.follow ? "-f" : "";
   const service = args.service ?? "";
+  const cmd = `docker compose ${fileFlags} logs ${follow} ${service}`.replace(/\s+/g, " ").trim();
   return {
     exitCode: 0,
-    output: [`  cmd: docker compose -f ${overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
+    output: ["[serve dev logs]"],
+    commands: [{ cmd, remote: true, label: "compose logs" }],
   };
 }

--- a/packages/cli/src/commands/serve/index.ts
+++ b/packages/cli/src/commands/serve/index.ts
@@ -16,6 +16,7 @@ import { planServeDev, type DevVerbArgs, type DevVerbResult } from "./dev.js";
 import { planServeMock, type MockVerbArgs } from "./mock.js";
 import { detectMockRunnable } from "./detect.js";
 import { planServeStaging, type StagingVerbArgs } from "./staging.js";
+import { runCommands } from "./runner.js";
 
 export interface ServeArgs {
   profile?: string;
@@ -122,13 +123,11 @@ export async function serve(argv: string[]): Promise<void> {
     process.exit(64);
   }
 
+  let planResult: DevVerbResult;
   switch (args.profile) {
-    case "dev": {
-      const result = runDevVerb(args, config, profile);
-      for (const line of result.output) console.log(line);
-      if (result.exitCode !== 0) process.exit(result.exitCode);
-      return;
-    }
+    case "dev":
+      planResult = runDevVerb(args, config, profile);
+      break;
     case "mock": {
       // Trade-off #4: auto-skip if mock/ isn't vite-runnable.
       const detect = detectMockRunnable(args.repoRoot);
@@ -136,20 +135,33 @@ export async function serve(argv: string[]): Promise<void> {
         console.log(`[serve mock] skipped — ${detect.reason}`);
         return;
       }
-      const result = runMockVerb(args, config, profile);
-      for (const line of result.output) console.log(line);
-      if (result.exitCode !== 0) process.exit(result.exitCode);
-      return;
+      planResult = runMockVerb(args, config, profile);
+      break;
     }
-    case "staging": {
-      const result = runStagingVerb(args, config, profile);
-      for (const line of result.output) console.log(line);
-      if (result.exitCode !== 0) process.exit(result.exitCode);
-      return;
-    }
+    case "staging":
+      planResult = runStagingVerb(args, config, profile);
+      break;
     default:
       console.error(`slowcook serve: profile "${args.profile}" has no runtime in this release.`);
       process.exit(64);
+  }
+
+  for (const line of planResult.output) console.log(line);
+  if (planResult.exitCode !== 0) process.exit(planResult.exitCode);
+
+  // sc#173 #1: actually execute the plan. Wraps `remote: true` commands
+  // in `ssh user@host 'cd <checkout_dir> && <cmd>'` when ssh_target is
+  // set; runs locally otherwise. --dry-run prints the wrapped form
+  // without executing.
+  if (planResult.commands && planResult.commands.length > 0) {
+    const runResult = runCommands({
+      commands: planResult.commands,
+      profile,
+      repoRoot: args.repoRoot,
+      dryRun: args.dryRun,
+    });
+    for (const line of runResult.output) console.log(line);
+    if (runResult.exitCode !== 0) process.exit(runResult.exitCode);
   }
 }
 

--- a/packages/cli/src/commands/serve/mock.test.ts
+++ b/packages/cli/src/commands/serve/mock.test.ts
@@ -18,45 +18,45 @@ const cfg = normaliseConfig(
 const profile = cfg.profiles.mock!;
 
 describe("planServeMock", () => {
-  it("up emits the compose command + a reachable URL hint", () => {
+  it("up emits compose-up + a reachable URL hint", () => {
     const result = planServeMock({ verb: "up", repoRoot: "/tmp" }, cfg, profile);
     expect(result.exitCode).toBe(0);
-    const joined = result.output.join("\n");
-    expect(joined).toContain("docker compose -f docker-compose/docker-compose.mock.yml up -d --build");
-    expect(joined).toContain(":5173");
+    expect(result.commands?.[0]?.cmd).toBe(
+      "docker compose -f docker-compose/docker-compose.mock.yml up -d",
+    );
+    expect(result.output.join("\n")).toContain(":5173");
   });
 
-  it("up falls back to pnpm filter when compose_overlay is unset", () => {
+  it("up falls back to pnpm filter when compose isn't configured", () => {
     const noOverlay = { ...profile, compose_overlay: undefined };
     const result = planServeMock({ verb: "up", repoRoot: "/tmp" }, cfg, noOverlay);
     expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("pnpm --filter ./mock dev");
+    expect(result.commands?.[0]?.cmd).toBe("pnpm --filter ./mock dev");
+    // Local fallback — no ssh wrap.
+    expect(result.commands?.[0]?.remote).toBe(false);
   });
 
-  it("sync with dryRun + --branch emits the planned push", () => {
+  it("sync emits git push", () => {
     const result = planServeMock(
       { verb: "sync", branch: "feat/mockup-42", repoRoot: "/tmp", dryRun: true },
       cfg,
       profile,
     );
     expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("feat/mockup-42 → origin/main");
-    expect(result.output.join("\n")).toContain("git push --force origin feat/mockup-42:main");
+    expect(result.commands?.[0]?.cmd).toBe("git push --force origin feat/mockup-42:main");
+    expect(result.commands?.[0]?.remote).toBe(false);
   });
 
   it("sync rejects detached HEAD without --branch", () => {
     const result = planServeMock({ verb: "sync", branch: "HEAD", repoRoot: "/tmp", dryRun: true }, cfg, profile);
     expect(result.exitCode).toBe(64);
-    expect(result.output.join("\n")).toContain("detached HEAD");
   });
 
   it("down + --prune drops volumes", () => {
     const plain = planServeMock({ verb: "down", repoRoot: "/tmp" }, cfg, profile);
-    expect(plain.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml down");
-    expect(plain.output.join("\n")).not.toContain(" -v");
-
+    expect(plain.commands?.[0]?.cmd).toBe("docker compose -f docker-compose/docker-compose.mock.yml down");
     const pruned = planServeMock({ verb: "down", repoRoot: "/tmp", prune: true }, cfg, profile);
-    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml down -v");
+    expect(pruned.commands?.[0]?.cmd).toBe("docker compose -f docker-compose/docker-compose.mock.yml down -v");
   });
 
   it("logs supports --service + --follow", () => {
@@ -65,7 +65,9 @@ describe("planServeMock", () => {
       cfg,
       profile,
     );
-    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.mock.yml logs -f mock-vite");
+    expect(result.commands?.[0]?.cmd).toBe(
+      "docker compose -f docker-compose/docker-compose.mock.yml logs -f mock-vite",
+    );
   });
 
   it("reset is a no-op for mock", () => {
@@ -74,13 +76,12 @@ describe("planServeMock", () => {
     expect(result.output.join("\n")).toContain("only meaningful for staging");
   });
 
-  it("unknown verb exits 64 with a hint", () => {
-    const result = planServeMock({ verb: "wibble", repoRoot: "/tmp" }, cfg, profile);
-    expect(result.exitCode).toBe(64);
+  it("unknown verb exits 64", () => {
+    expect(planServeMock({ verb: "wibble", repoRoot: "/tmp" }, cfg, profile).exitCode).toBe(64);
   });
 
-  it("down errors when compose_overlay is absent", () => {
-    const noOverlay = { ...profile, compose_overlay: undefined };
-    expect(planServeMock({ verb: "down", repoRoot: "/tmp" }, cfg, noOverlay).exitCode).toBe(64);
+  it("down errors when neither compose_files nor compose_overlay set", () => {
+    const noFiles = { ...profile, compose_overlay: undefined };
+    expect(planServeMock({ verb: "down", repoRoot: "/tmp" }, cfg, noFiles).exitCode).toBe(64);
   });
 });

--- a/packages/cli/src/commands/serve/mock.ts
+++ b/packages/cli/src/commands/serve/mock.ts
@@ -2,28 +2,19 @@
  * `slowcook serve mock <verb>` — Phase 2 implementation.
  *
  * The mock profile runs the consumer's `mock/` package as a vite-dev
- * server on a shared box, so the PM + designer + vibe-feedback loop
- * all hit the same artefact at the same URL. Mock-vite runs alongside
- * `serve dev` on the same host with distinct ports + profile-prefixed
- * container names (per design #5).
+ * server on a shared box. See `dev.ts` header for the broader pattern.
  *
- * Verbs (Phase 2):
- *   - up      — bring up the mock profile (vite-dev compose overlay)
- *   - sync    — force-push the mock-tracking branch (default `main`) so
- *               the box pulls the latest mockups
- *   - down    — stop the mock services (volumes preserved)
- *   - logs    — pass-through to docker-compose logs
- *   - reset   — no-op (mock has no scenario seed)
- *
- * Auto-skip per Trade-off #4: if the consumer's `mock/package.json`
- * has no `scripts.dev`, slowcook prints a notice + exits 0 instead of
- * trying to bring up an unrunnable vite-dev. Detection runs from
- * `index.ts`'s dispatcher before this module is called.
+ * 0.19.7 (sc#173): same refactor as dev.ts — emit ShellCommand[] so
+ * runCommands() can actually execute (including ssh-wrapping for the
+ * remote case); support `compose_files` multi-`-f`; suppress `--build`
+ * for `bind-mount-source`.
  */
 
 import { execSync } from "node:child_process";
 import type { ProfileConfig, ServeConfig } from "./config.js";
+import { composeFiles, shouldBuildOnUp } from "./config.js";
 import type { DevVerbResult } from "./dev.js";
+import type { ShellCommand } from "./runner.js";
 
 export interface MockVerbArgs {
   verb: string;
@@ -35,10 +26,6 @@ export interface MockVerbArgs {
   dryRun?: boolean;
 }
 
-/**
- * Pure planner for the mock profile. Same shape as `planServeDev` so
- * the cli wrapper can render output uniformly.
- */
 export function planServeMock(
   args: MockVerbArgs,
   _config: ServeConfig,
@@ -59,30 +46,38 @@ export function planServeMock(
         output: ["[serve mock reset] mock profile has no scenario seed; nothing to reset (only meaningful for staging)."],
       };
     default:
-      return {
-        exitCode: 64,
-        output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`],
-      };
+      return { exitCode: 64, output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`] };
   }
 }
 
 function planUp(_args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
+  const files = composeFiles(profile);
   const apps = Object.keys(profile.apps);
-  const lines: string[] = [`[serve mock up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
-  if (overlay) {
-    lines.push(`  cmd: docker compose -f ${overlay} up -d --build`);
-  } else {
-    lines.push(
-      "  (no compose_overlay set; falling back to `pnpm --filter ./mock dev` if mock/ is vite-runnable)",
-    );
+  const output: string[] = [`[serve mock up] bringing up: ${apps.join(", ") || "(no apps configured)"}`];
+
+  if (files.length === 0) {
+    // Fallback: no compose, run `pnpm --filter ./mock dev` locally. Used on
+    // a dev's laptop without a docker box.
+    output.push("  (no compose_files / compose_overlay set; falling back to local pnpm filter)");
+    return {
+      exitCode: 0,
+      output,
+      commands: [{ cmd: "pnpm --filter ./mock dev", remote: false, label: "vite dev" }],
+    };
   }
+
   // PM + designer reference URL: surface the vite port if exactly one app.
   if (apps.length === 1) {
     const vitePort = profile.apps[apps[0]!]!.port;
-    lines.push(`  vite dev URL (once up): http://<your-box>:${vitePort}`);
+    output.push(`  vite dev URL (once up): http://<your-box>:${vitePort}`);
   }
-  return { exitCode: 0, output: lines };
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
+  const buildFlag = shouldBuildOnUp(profile) ? " --build" : "";
+  return {
+    exitCode: 0,
+    output,
+    commands: [{ cmd: `docker compose ${fileFlags} up -d${buildFlag}`, remote: true, label: "bring up" }],
+  };
 }
 
 function planSync(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
@@ -106,46 +101,33 @@ function planSync(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
       output: ["[serve mock sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
     };
   }
-  const lines = [`[serve mock sync] ${localBranch} → origin/${sourceBranch}`];
-  if (args.dryRun) {
-    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
-    return { exitCode: 0, output: lines };
-  }
-  try {
-    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, {
-      cwd: args.repoRoot,
-      stdio: "inherit",
-    });
-  } catch {
-    return {
-      exitCode: 1,
-      output: [...lines, `[serve mock sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
-    };
-  }
-  lines.push(`[serve mock sync] done. The mock-deploy workflow on origin/${sourceBranch} will fire next.`);
-  return { exitCode: 0, output: lines };
+  return {
+    exitCode: 0,
+    output: [`[serve mock sync] ${localBranch} → origin/${sourceBranch}`],
+    commands: [{ cmd: `git push --force origin ${localBranch}:${sourceBranch}`, remote: false, label: "git push" }],
+  };
 }
 
 function planDown(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
-  if (!overlay) {
-    return { exitCode: 64, output: ["[serve mock down] no compose_overlay set; nothing to stop."] };
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve mock down] no compose_files / compose_overlay set; nothing to stop."] };
   }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
   const cmd = args.prune
-    ? `docker compose -f ${overlay} down -v`
-    : `docker compose -f ${overlay} down`;
-  return { exitCode: 0, output: ["[serve mock down]", `  cmd: ${cmd}`] };
+    ? `docker compose ${fileFlags} down -v`
+    : `docker compose ${fileFlags} down`;
+  return { exitCode: 0, output: ["[serve mock down]"], commands: [{ cmd, remote: true, label: "compose down" }] };
 }
 
 function planLogs(args: MockVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const overlay = profile.compose_overlay;
-  if (!overlay) {
-    return { exitCode: 64, output: ["[serve mock logs] no compose_overlay set; nothing to tail."] };
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve mock logs] no compose_files / compose_overlay set; nothing to tail."] };
   }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
   const follow = args.follow ? "-f" : "";
   const service = args.service ?? "";
-  return {
-    exitCode: 0,
-    output: [`  cmd: docker compose -f ${overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
-  };
+  const cmd = `docker compose ${fileFlags} logs ${follow} ${service}`.replace(/\s+/g, " ").trim();
+  return { exitCode: 0, output: ["[serve mock logs]"], commands: [{ cmd, remote: true, label: "compose logs" }] };
 }

--- a/packages/cli/src/commands/serve/runner.test.ts
+++ b/packages/cli/src/commands/serve/runner.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { resolveCommand, runCommands } from "./runner.js";
+import { ProfileConfigSchema } from "./config.js";
+
+const remoteProfile = ProfileConfigSchema.parse({
+  apps: {},
+  ssh_target: {
+    host: "dev.example.com",
+    user: "deploy",
+    checkout_dir: "/opt/checkout",
+  },
+});
+
+const localProfile = ProfileConfigSchema.parse({ apps: {} });
+
+describe("resolveCommand", () => {
+  it("local commands pass through unchanged regardless of profile", () => {
+    expect(resolveCommand({ cmd: "git push", remote: false }, remoteProfile)).toBe("git push");
+    expect(resolveCommand({ cmd: "git push", remote: false }, localProfile)).toBe("git push");
+  });
+
+  it("remote commands are ssh-wrapped when ssh_target is set", () => {
+    const wrapped = resolveCommand({ cmd: "docker compose up", remote: true }, remoteProfile);
+    expect(wrapped).toBe(`ssh deploy@dev.example.com 'cd /opt/checkout && docker compose up'`);
+  });
+
+  it("remote commands fall back to local when ssh_target is absent", () => {
+    expect(resolveCommand({ cmd: "docker compose up", remote: true }, localProfile)).toBe(
+      "docker compose up",
+    );
+  });
+
+  it("escapes embedded single-quotes in remote commands", () => {
+    const wrapped = resolveCommand(
+      { cmd: `bash -c 'echo hi'`, remote: true },
+      remoteProfile,
+    );
+    expect(wrapped).toBe(
+      `ssh deploy@dev.example.com 'cd /opt/checkout && bash -c '\\''echo hi'\\'''`,
+    );
+  });
+});
+
+describe("runCommands (dry-run path)", () => {
+  it("emits 'would run:' lines without executing", () => {
+    const result = runCommands({
+      commands: [
+        { cmd: "docker compose up -d", remote: true, label: "bring up" },
+        { cmd: "pnpm exec ts-node seed.ts", remote: true, label: "seed" },
+      ],
+      profile: remoteProfile,
+      repoRoot: "/tmp",
+      dryRun: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const joined = result.output.join("\n");
+    expect(joined).toContain("bring up");
+    expect(joined).toContain(
+      `would run: ssh deploy@dev.example.com 'cd /opt/checkout && docker compose up -d'`,
+    );
+    expect(joined).toContain(
+      `would run: ssh deploy@dev.example.com 'cd /opt/checkout && pnpm exec ts-node seed.ts'`,
+    );
+  });
+
+  it("handles an empty commands list as no-op", () => {
+    const result = runCommands({ commands: [], profile: localProfile, repoRoot: "/tmp", dryRun: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/serve/runner.ts
+++ b/packages/cli/src/commands/serve/runner.ts
@@ -1,0 +1,82 @@
+/**
+ * Shell-command execution layer for `slowcook serve`.
+ *
+ * Closes sc#173 finding #1: prior to this, planners emitted command
+ * strings into `output[]` and exited without executing them, even when
+ * `profile.ssh_target` was set. Operators had to copy-paste the emitted
+ * command and run it themselves — the verb was documentation, not
+ * automation.
+ *
+ * Now planners populate `result.commands[]` with structured ShellCommand
+ * records; `runCommands()` wraps `remote: true` commands in
+ * `ssh user@host 'cd checkout_dir && <cmd>'` and executes (unless
+ * --dry-run, in which case the wrapped form is just printed).
+ *
+ * Local commands run via execSync in the repoRoot. Remote commands run
+ * via execSync of an ssh invocation. Either way: stdio inherited so the
+ * operator sees docker / git output in real time.
+ */
+
+import { execSync } from "node:child_process";
+import type { ProfileConfig } from "./config.js";
+
+export interface ShellCommand {
+  /** The local-shell-shape command (e.g. `docker compose -f a.yml up -d`). */
+  cmd: string;
+  /**
+   * When true AND `profile.ssh_target` is set, wrap the command in
+   * `ssh <user>@<host> 'cd <checkout_dir> && <cmd>'`. When `ssh_target`
+   * is absent, runs locally regardless. Use for docker / box-side
+   * operations (up, down, logs). Local-only operations like `git push`
+   * should pass `remote: false`.
+   */
+  remote?: boolean;
+  /** Optional label printed before the command (e.g. "bring up", "seed"). */
+  label?: string;
+}
+
+export interface RunCommandsArgs {
+  commands: ShellCommand[];
+  profile: ProfileConfig;
+  repoRoot: string;
+  /** When true: print the resolved command but don't execute. */
+  dryRun?: boolean;
+}
+
+export interface RunCommandsResult {
+  exitCode: number;
+  /** Additional human-readable lines emitted by the runner (resolved cmds, errors). */
+  output: string[];
+}
+
+/**
+ * Resolve a single ShellCommand into the wire-form string we'd actually
+ * pass to /bin/sh. Pure; useful for tests + the dry-run print path.
+ */
+export function resolveCommand(cmd: ShellCommand, profile: ProfileConfig): string {
+  if (cmd.remote && profile.ssh_target) {
+    const { user, host, checkout_dir } = profile.ssh_target;
+    // Single-quote the remote command. Inner single quotes get escaped via
+    // the bash `'\''` trick so paths/cmds containing `'` survive.
+    const inner = cmd.cmd.replace(/'/g, `'\\''`);
+    return `ssh ${user}@${host} 'cd ${checkout_dir} && ${inner}'`;
+  }
+  return cmd.cmd;
+}
+
+export function runCommands(args: RunCommandsArgs): RunCommandsResult {
+  const out: string[] = [];
+  for (const c of args.commands) {
+    const wire = resolveCommand(c, args.profile);
+    if (c.label) out.push(`  ${c.label}:`);
+    out.push(`  ${args.dryRun ? "would run" : "run"}: ${wire}`);
+    if (args.dryRun) continue;
+    try {
+      execSync(wire, { cwd: args.repoRoot, stdio: "inherit" });
+    } catch {
+      out.push(`  ✗ command failed: ${wire}`);
+      return { exitCode: 1, output: out };
+    }
+  }
+  return { exitCode: 0, output: out };
+}

--- a/packages/cli/src/commands/serve/staging.test.ts
+++ b/packages/cli/src/commands/serve/staging.test.ts
@@ -10,7 +10,7 @@ const cfg = normaliseConfig(
         mode: "built-image",
         source_branch: "main",
         compose_overlay: "docker-compose/docker-compose.staging.yml",
-        bringup_cmd: "ssh box 'cd /opt/app && ./redeploy.sh'",
+        bringup_cmd: "./redeploy.sh",
         apps: { patient: { mode: "next-start", port: 3101 } },
         seed: {
           scenarios: {
@@ -27,39 +27,43 @@ const cfg = normaliseConfig(
 const profile = cfg.profiles.staging!;
 
 describe("planServeStaging", () => {
-  it("up uses bringup_cmd when set (Trade-off #3: consumer owns image build)", () => {
+  it("up shells out to bringup_cmd when set (Trade-off #3: consumer owns image build)", () => {
     const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, profile);
     expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("ssh box 'cd /opt/app && ./redeploy.sh'");
+    expect(result.commands?.[0]?.cmd).toBe("./redeploy.sh");
+    expect(result.commands?.[0]?.remote).toBe(true);
   });
 
   it("up falls back to compose when only compose_overlay is set", () => {
     const noBringup = { ...profile, bringup_cmd: undefined };
     const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, noBringup);
     expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.staging.yml up -d");
+    // built-image profile → --build IS included.
+    expect(result.commands?.[0]?.cmd).toBe(
+      "docker compose -f docker-compose/docker-compose.staging.yml up -d --build",
+    );
   });
 
-  it("up errors when neither bringup_cmd nor compose_overlay is set", () => {
+  it("up errors when neither bringup_cmd nor compose is set", () => {
     const bare = { ...profile, bringup_cmd: undefined, compose_overlay: undefined };
-    const result = planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, bare);
-    expect(result.exitCode).toBe(64);
+    expect(planServeStaging({ verb: "up", repoRoot: "/tmp" }, cfg, bare).exitCode).toBe(64);
   });
 
-  it("sync with dryRun emits the planned push", () => {
+  it("sync emits git push", () => {
     const result = planServeStaging(
       { verb: "sync", branch: "release/v2", repoRoot: "/tmp", dryRun: true },
       cfg,
       profile,
     );
-    expect(result.exitCode).toBe(0);
-    expect(result.output.join("\n")).toContain("release/v2 → origin/main");
-    expect(result.output.join("\n")).toContain("git push --force origin release/v2:main");
+    expect(result.commands?.[0]?.cmd).toBe("git push --force origin release/v2:main");
+    expect(result.commands?.[0]?.remote).toBe(false);
   });
 
   it("down + --prune drops volumes", () => {
     const pruned = planServeStaging({ verb: "down", repoRoot: "/tmp", prune: true }, cfg, profile);
-    expect(pruned.output.join("\n")).toContain("docker compose -f docker-compose/docker-compose.staging.yml down -v");
+    expect(pruned.commands?.[0]?.cmd).toBe(
+      "docker compose -f docker-compose/docker-compose.staging.yml down -v",
+    );
   });
 });
 
@@ -83,27 +87,26 @@ describe("planServeStaging — reset (scenarios + guard env)", () => {
     const result = planServeStaging({ verb: "reset", scenario: "bogus", repoRoot: "/tmp" }, cfg, profile);
     expect(result.exitCode).toBe(64);
     expect(result.output.join("\n")).toContain("not found");
-    expect(result.output.join("\n")).toContain("demo, enterprise");
   });
 
   it("reset blocks when guard_env is unset", () => {
     const result = planServeStaging({ verb: "reset", scenario: "demo", repoRoot: "/tmp" }, cfg, profile);
     expect(result.exitCode).toBe(1);
     expect(result.output.join("\n")).toContain("STAGING_RESET_ALLOWED");
-    expect(result.output.join("\n")).toContain("blocked");
   });
 
-  it("reset --dry-run with guard_env set + valid scenario emits the planned scripts", () => {
+  it("reset with guard_env set emits the planned seed commands", () => {
     process.env["STAGING_RESET_ALLOWED"] = "1";
     const result = planServeStaging(
-      { verb: "reset", scenario: "demo", repoRoot: "/tmp", dryRun: true },
+      { verb: "reset", scenario: "demo", repoRoot: "/tmp" },
       cfg,
       profile,
     );
     expect(result.exitCode).toBe(0);
-    const joined = result.output.join("\n");
-    expect(joined).toContain("scenario=demo");
-    expect(joined).toContain("ts-node packages/seeds/demo/index.ts");
+    expect(result.commands?.map((c) => c.cmd)).toEqual([
+      "pnpm exec ts-node packages/seeds/demo/index.ts",
+    ]);
+    expect(result.commands?.[0]?.remote).toBe(true);
   });
 
   it("reset works on a profile without guard_env (no safety net)", () => {
@@ -112,7 +115,7 @@ describe("planServeStaging — reset (scenarios + guard env)", () => {
       seed: { scenarios: profile.seed!.scenarios, guard_env: undefined },
     };
     const result = planServeStaging(
-      { verb: "reset", scenario: "demo", repoRoot: "/tmp", dryRun: true },
+      { verb: "reset", scenario: "demo", repoRoot: "/tmp" },
       cfg,
       noGuard,
     );

--- a/packages/cli/src/commands/serve/staging.ts
+++ b/packages/cli/src/commands/serve/staging.ts
@@ -1,32 +1,23 @@
 /**
  * `slowcook serve staging <verb>` — Phase 3 implementation.
  *
- * The staging profile runs a built-image deployment for PM walkthroughs +
- * manual QA. Distinct from `dev` (bind-mount source) and `mock` (vite-dev):
+ * The staging profile runs a built-image deployment for PM walkthroughs.
  *
- *   - mode: built-image (Trade-off #3 — slowcook ships zero image-build;
- *     consumer's `bringup_cmd` does the heavy lifting).
- *   - reset: named-scenario re-seed via `seed.scenarios: {demo: ..., ...}`
- *     (Trade-off #5 — map shape from day 1; no single-value form).
+ * 0.19.7 (sc#173): same refactor as dev.ts / mock.ts — emit
+ * ShellCommand[] for the cli wrapper to execute via runCommands(),
+ * supporting ssh-wrap when `ssh_target` is set; honour `compose_files`
+ * multi-`-f`; pass `--build` (staging IS built-image).
  *
- * Verbs (Phase 3):
- *   - up      — bring up the staging profile via consumer's bringup_cmd
- *   - sync    — push the staging-tracking branch (default `main`); the
- *               box's CI/deploy chain picks it up + rebuilds the image
- *   - down    — stop the profile's services (volumes preserved)
- *   - logs    — pass-through to docker-compose logs
- *   - reset --scenario <name> — re-run the named scenario's seed scripts;
- *               protected by the optional `seed.guard_env` env-var sentinel
- *               to prevent accidental wipes from interactive sessions.
- *
- * Per design #5 "Additional decisions" — the staging seed is idempotent;
- * each scenario's scripts MUST be re-runnable. Slowcook just invokes them
- * via `ts-node` (Trade-off #2) inside the container.
+ * `reset --scenario <name>` re-runs the named scenario's seed scripts.
+ * Idempotency is the seed-script author's contract; slowcook bails on
+ * any non-zero exit. Optional `seed.guard_env` blocks accidental wipes.
  */
 
 import { execSync } from "node:child_process";
 import type { ProfileConfig, ServeConfig } from "./config.js";
+import { composeFiles, shouldBuildOnUp } from "./config.js";
 import type { DevVerbResult } from "./dev.js";
+import type { ShellCommand } from "./runner.js";
 
 export interface StagingVerbArgs {
   verb: string;
@@ -56,27 +47,35 @@ export function planServeStaging(
     case "reset":
       return planReset(args, profile);
     default:
-      return {
-        exitCode: 64,
-        output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`],
-      };
+      return { exitCode: 64, output: [`Unknown verb: ${args.verb}. See \`slowcook serve --help\`.`] };
   }
 }
 
 function planUp(_args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
-  const lines: string[] = [`[serve staging up] mode: ${profile.mode}`];
+  const output: string[] = [`[serve staging up] mode: ${profile.mode}`];
+
+  // Trade-off #3: when consumer's bringup_cmd is set, slowcook just shells it out.
   if (profile.bringup_cmd) {
-    // Trade-off #3 — consumer's bring-up runs the show. Slowcook just shells out.
-    lines.push(`  cmd: ${profile.bringup_cmd}`);
-    return { exitCode: 0, output: lines };
+    return {
+      exitCode: 0,
+      output,
+      commands: [{ cmd: profile.bringup_cmd, remote: true, label: "bring up" }],
+    };
   }
-  if (profile.compose_overlay) {
-    lines.push(`  cmd: docker compose -f ${profile.compose_overlay} up -d`);
-    return { exitCode: 0, output: lines };
+
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return {
+      exitCode: 64,
+      output: ["[serve staging up] neither bringup_cmd nor compose_files / compose_overlay set; nothing to bring up."],
+    };
   }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
+  const buildFlag = shouldBuildOnUp(profile) ? " --build" : "";
   return {
-    exitCode: 64,
-    output: ["[serve staging up] neither bringup_cmd nor compose_overlay set; nothing to bring up."],
+    exitCode: 0,
+    output,
+    commands: [{ cmd: `docker compose ${fileFlags} up -d${buildFlag}`, remote: true, label: "bring up" }],
   };
 }
 
@@ -101,57 +100,37 @@ function planSync(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult 
       output: ["[serve staging sync] couldn't resolve a local branch (detached HEAD?). Pass --branch <name>."],
     };
   }
-  const lines = [`[serve staging sync] ${localBranch} → origin/${sourceBranch} (staging-deploy CI rebuilds)`];
-  if (args.dryRun) {
-    lines.push(`  would run: git push --force origin ${localBranch}:${sourceBranch}`);
-    return { exitCode: 0, output: lines };
-  }
-  try {
-    execSync(`git push --force origin ${localBranch}:${sourceBranch}`, {
-      cwd: args.repoRoot,
-      stdio: "inherit",
-    });
-  } catch {
-    return {
-      exitCode: 1,
-      output: [...lines, `[serve staging sync] git push failed. Check push permissions on origin/${sourceBranch}.`],
-    };
-  }
-  lines.push(`[serve staging sync] done.`);
-  return { exitCode: 0, output: lines };
-}
-
-function planDown(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
-  if (!profile.compose_overlay) {
-    return { exitCode: 64, output: ["[serve staging down] no compose_overlay set; nothing to stop."] };
-  }
-  const cmd = args.prune
-    ? `docker compose -f ${profile.compose_overlay} down -v`
-    : `docker compose -f ${profile.compose_overlay} down`;
-  return { exitCode: 0, output: ["[serve staging down]", `  cmd: ${cmd}`] };
-}
-
-function planLogs(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
-  if (!profile.compose_overlay) {
-    return { exitCode: 64, output: ["[serve staging logs] no compose_overlay set; nothing to tail."] };
-  }
-  const follow = args.follow ? "-f" : "";
-  const service = args.service ?? "";
   return {
     exitCode: 0,
-    output: [`  cmd: docker compose -f ${profile.compose_overlay} logs ${follow} ${service}`.replace(/\s+/g, " ").trim()],
+    output: [`[serve staging sync] ${localBranch} → origin/${sourceBranch} (staging-deploy CI rebuilds)`],
+    commands: [{ cmd: `git push --force origin ${localBranch}:${sourceBranch}`, remote: false, label: "git push" }],
   };
 }
 
-/**
- * `serve staging reset --scenario <name>` — re-run the named scenario's
- * seed scripts. Idempotency is the seed-script author's job; slowcook
- * just invokes them via ts-node (Trade-off #2 — runtime model locked).
- *
- * Guard: if `seed.guard_env` is set in the profile, the named env var
- * must be non-empty in the caller's environment. Prevents accidental
- * wipes from an interactive `serve staging reset`.
- */
+function planDown(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve staging down] no compose_files / compose_overlay set; nothing to stop."] };
+  }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
+  const cmd = args.prune
+    ? `docker compose ${fileFlags} down -v`
+    : `docker compose ${fileFlags} down`;
+  return { exitCode: 0, output: ["[serve staging down]"], commands: [{ cmd, remote: true, label: "compose down" }] };
+}
+
+function planLogs(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
+  const files = composeFiles(profile);
+  if (files.length === 0) {
+    return { exitCode: 64, output: ["[serve staging logs] no compose_files / compose_overlay set; nothing to tail."] };
+  }
+  const fileFlags = files.map((f) => `-f ${f}`).join(" ");
+  const follow = args.follow ? "-f" : "";
+  const service = args.service ?? "";
+  const cmd = `docker compose ${fileFlags} logs ${follow} ${service}`.replace(/\s+/g, " ").trim();
+  return { exitCode: 0, output: ["[serve staging logs]"], commands: [{ cmd, remote: true, label: "compose logs" }] };
+}
+
 function planReset(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult {
   if (!args.scenario) {
     const available = profile.seed?.scenarios ? Object.keys(profile.seed.scenarios) : [];
@@ -187,23 +166,11 @@ function planReset(args: StagingVerbArgs, profile: ProfileConfig): DevVerbResult
       };
     }
   }
-  const lines: string[] = [`[serve staging reset] scenario=${args.scenario}`];
-  for (const script of scenario.scripts) {
-    lines.push(`  ts-node ${script}`);
-  }
-  if (args.dryRun || scenario.scripts.length === 0) {
-    return { exitCode: 0, output: lines };
-  }
-  // Real reset: shell out to ts-node for each script. Idempotency is the
-  // seed-script author's contract; slowcook bails on any non-zero exit.
-  for (const script of scenario.scripts) {
-    try {
-      execSync(`pnpm exec ts-node ${script}`, { cwd: args.repoRoot, stdio: "inherit" });
-    } catch {
-      lines.push(`[serve staging reset] script ${script} failed; aborting.`);
-      return { exitCode: 1, output: lines };
-    }
-  }
-  lines.push(`[serve staging reset] scenario=${args.scenario} complete.`);
-  return { exitCode: 0, output: lines };
+  const output: string[] = [`[serve staging reset] scenario=${args.scenario}`];
+  const commands: ShellCommand[] = scenario.scripts.map((script) => ({
+    cmd: `pnpm exec ts-node ${script}`,
+    remote: true,
+    label: `seed ${script}`,
+  }));
+  return { exitCode: 0, output, commands };
 }


### PR DESCRIPTION
Two correctness fixes from delgoosh dogfood feedback on 0.19.6 (sc#173). Closes findings **#1** + **#2** of that issue.

## #1 — \`serve <profile> up\` actually executes

Before: planners emitted \`cmd: docker compose ...\` into \`output[]\` and exited. \`profile.ssh_target\` was parsed but ignored. The verb was documentation, not automation.

After:
- Planners populate \`result.commands[]\` with structured \`ShellCommand\` records.
- The cli wrapper invokes \`runCommands()\`, which wraps \`remote: true\` commands in \`ssh user@host 'cd <checkout_dir> && <cmd>'\` and execs via \`execSync\` (stdio inherited).
- \`--dry-run\` prints the wrapped form without executing.
- Local-only commands like \`git push\` declare \`remote: false\` so they're never ssh-wrapped.

New module: \`packages/cli/src/commands/serve/runner.ts\` (\`ShellCommand\` interface + pure \`resolveCommand\` + executing \`runCommands\`).

## #2 — Multi-file compose + \`--build\` suppression

Real consumers split long-lived services (postgres, networks, depends_on chain) into \`docker-compose.production.yml\` and overlay bind-mount-source services in \`docker-compose.dev.yml\`. Emitting just \`-f overlay.yml\` skipped the base + broke \`depends_on\`.

- New \`compose_files: [string]\` field on \`ProfileConfigSchema\`. Takes precedence over \`compose_overlay\` when both are set.
- New \`shouldBuildOnUp(profile)\` helper — \`false\` for \`bind-mount-source\` (the whole point of bind-mount is skipping the build loop), \`true\` for \`built-image\`.
- New \`composeFiles(profile)\` helper — returns ordered file list, prefers \`compose_files\`, falls back to \`compose_overlay\`, empty when neither.

## Tests

+15 tests:
- 6 runner (local pass-through, ssh wrap, single-quote escape, dry-run, empty-list)
- 7 config-helpers (\`compose_files\` precedence, \`shouldBuildOnUp\` mode-gated, legacy-wrap round-trip)
- 2 net additions across dev/mock/staging covering \`compose_files\` + \`--build\` suppression

cli total: 1154 → 1169.

## Release

cli 0.19.6 → 0.19.7. No other package bumps.

## Backward compat

Every existing \`slowcook serve\` invocation continues to work. The legacy \`compose_overlay\` field still resolves through \`composeFiles()\`. Consumers can adopt \`compose_files\` incrementally.

## Out of scope (sc#173 follow-ups)

- #3 (autosync workflow scaffold)
- #4 (dynamic source-branch resolver, e.g. \`@latest-vibe\`)
- #5 (doc: alpine→debian for native modules)
- #6 (doc: dev-mode side-effects audit pattern)
- #7 (mock-detect verbosity)

Some are net-new design discussions and worth their own design entries; others are docs.

## Test plan

- [ ] CI green
- [ ] Smoke: \`node dist/cli.js serve dev up --dry-run\` against a consumer config with \`ssh_target\` shows the ssh-wrapped docker command
- [ ] Smoke: \`compose_files: [base.yml, overlay.yml]\` produces \`docker compose -f base.yml -f overlay.yml up -d\`
- [ ] Smoke: \`mode: bind-mount-source\` (default) emits no \`--build\` flag