### PR TITLE
feat(gates): fidelity eye + HITL gates — design #8/#9 + diff core (sc#173 #12, #13)

### DIFF
--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -627,6 +627,25 @@ Closes the gap the dogfood exposed at its mechanical source. Cheap + determinist
 
 ---
 
+## Implementation status — #8 / #9 / #10 (2026-06-07)
+
+Built autonomously on `feat/fidelity-eye-hitl-gates` (PR #185). Full workspace green: all packages build, 1223 cli + 22 gates tests pass.
+
+**Shipped + tested:**
+- **#8** — `gates/fidelity/`: `diffSnapshots` (pure), `captureSnapshot` (Playwright), `gradeFidelity`/`runFidelityGate` (matrix grading + thresholds). `cli/brew/fidelity-loop.ts`: bounded eye-driven convergence controller (stall/exhaust escalation). `slowcook eye` command (renders mock+brewed across viewport×scheme, grades, screenshots, exits 1 on drift). Validated end-to-end on the real delgoosh login dark-mode drift (21 dark-mode color violations, 0 false-positives in light).
+- **#9** — `cli/gate/`: `reviewers.yaml` loader + `isGateSatisfied` (the unforgeable-halt integrity core — only a human in the role's handle-list satisfies; bot/agent reviews never do). `slowcook gate check` command (fetches PR reviews via gh, identity-classifies, exits 1 + names the blocking role). `slowcook-gate.yml` workflow + the local-pipeline managed-docs halt section.
+- **#8 file-mgmt** — `slowcook-eye-cleanup.yml` (deletes a PR's eye artifacts on close).
+- **#10** — dense `extractElementClasses` + per-testid + no-testid containment in recon; brew plate-mode prompt scopes edit license to data-wiring + names the dense tests as the contract.
+
+**Remaining (wiring, not core):**
+- Wire the eye + brew-loop into the brew dispatch (autonomous correction in the bot pipeline; the controller + command exist, the brew-agent call-site that supplies `applyFix` is not yet connected).
+- `stories status` `blocked-on-<role>` surfacing.
+- Acceptance workflow: upload eye artifacts as `eye-pr-<N>-*` + push the review thumbnail to the `eye-review` branch (the cleanup + gate halves exist; the producer side is stubbed).
+- Retire `TOKENS_OF_INTEREST` (kept as harmless back-compat; dense path is primary).
+- Release: version bump + publish (eye/gate commands + cli→gates dep) — pending OTP.
+
+---
+
 ## Cross-doc references
 
 - Strategy + ideation: [`0.20-and-beyond.md`](./0.20-and-beyond.md)

--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -465,6 +465,111 @@ Per-invariant remains a fallback path; not building it now.
 
 ---
 
+## #8 — Fidelity eye: visual + behavioural mock-vs-prod diff that drives front-end brew (DECIDED 2026-06-06)
+
+### Problem
+
+Surfaced in the delgoosh design-react migration dogfood (epic #759, [issue #173 finding #12](https://github.com/aminazar/slowcook/issues/173)). The PM had a **full React/Vite design repo** as the visual source-of-truth (`references.visual`, per #7), yet brew shipped a front-end that was *not* pixel-faithful to it. Structural recon tests (containment, DOM order, token presence) pass while the rendered result still looks wrong: spacing off, wrong design-token values, a broken dark-mode variant, a responsive break that only appears at a mobile width.
+
+The gap class is exactly the one called out in the 0.9 tier-2 plan: *"Prompt-only steering failed to produce styled components; screenshots + vision review close the last residual slack in 'does it LOOK right.'"* That plan captured screenshots `(viewport × scheme)` as PR artifacts for **manual** PM review but explicitly deferred the mock-vs-prod **comparison** ("No visual diffing — visual regression diff is a 0.11+ consideration") and the grading gates. So slowcook has a Playwright eye (the `gates` package already drives real Chromium) but never points it at the mock to close the loop.
+
+Two further realities sharpen the requirement:
+
+1. **The diff is multi-modal, not just pixels.** It must cover pixel delta, **color**, **computed-style** (the load-bearing axis — it yields an actionable fix instruction, not just "something's off"), and **behaviour**. Behaviour cannot be captured by one screenshot: it needs a *sequence* of captures before+after user-generated events (click, type, navigate), compared step-by-step.
+2. **The eye should DRIVE brew, not merely gate it** — specifically on hot-reload stacks (React/Vite HMR) where a fix-render cycle costs no build wait. The eye emits hard, per-element fix-signals that brew applies and re-renders against in a tight loop, converging the last mile of fidelity.
+
+### Options considered
+
+- **A — Screenshot-first generation.** Treat rendered screenshots as the only ground truth; have a vision model reconstruct/adjust CSS from pixel diffs. *Rejected as primary:* when the mock IS code (`references.visual`), this discards the exact CSS we already possess and replaces it with a lossy, high-variance, high-token guessing loop. Pixel diff is a **soft** signal; brew ignores soft signals under optimization pressure (established rule). Worse for behaviour, which pixels can't express.
+- **B — Code-port only.** Transplant the mock's presentational components verbatim (path-alias share / parallel-port patterns), swap the data layer, declare done. *Rejected as sufficient:* gets ~90% for free and deterministically, but cannot catch token/theme divergence (prod Tailwind config, global CSS, font loading differ from the mock so the *same* JSX renders differently), responsive breaks, or behavioural drift. And when the mock is NOT code (Figma/HTML/other framework) there is nothing to port.
+- **C — Port-seed + eye-driven convergence (hybrid).** Seed brew with a code-port from `references.visual` so it starts at ~90%; then the **fidelity eye** renders reference vs candidate across the `(viewport × scheme)` matrix AND drives both through the tier-2 acceptance event sequences, diffs multi-modally, and emits per-element fix-signals that drive brew via HMR for a bounded number of iterations; residual diff escalates to the designer/QA HITL gate (#9).
+
+### Chosen: **C**
+
+Architecture:
+
+- **Source-of-truth from #7.** `references.visual` → the reference render target; `references.behaviour` + tier-2 acceptance scenarios → the event scripts. The eye consumes the references map; it does not re-derive source-of-truth.
+- **Pure core + thin Playwright shell** (mirrors the serve `resolveCommand`/`runCommands` split):
+  - `StyleSnapshot` — per matched element: stable selector + key computed-style props (box model, color/background, font, flex/grid, position) + bounding box + (optional) pixel hash of the element crop.
+  - `captureSnapshot(page)` — impure Playwright wrapper that walks the DOM and builds a `StyleSnapshot` (one per viewport×scheme, and one per step of an event sequence).
+  - `diffSnapshots(reference, candidate, opts)` — **pure**, unit-testable. Returns `FidelityViolation[]`: each names a selector + axis (`pixel|color|computed-style|behaviour`) + `expected→actual` evidence. This is the hard fix-signal.
+- **Behaviour = stepped snapshots.** Drive reference and candidate through the same scripted events; snapshot before+after each step; diff per step. A divergence at step N is reported as a behavioural violation with the event that triggered it.
+- **Two consumers of the same core:**
+  1. **Brew driver** — on HMR-capable stacks, feed `FidelityViolation[]` back into the brew loop as concrete instructions ("`.hero-cta`: padding 12→16px; background #1a1a1a→#222"), re-render, re-diff, ≤N bounded iterations. No build wait → cheap iterations.
+  2. **Gate 2 (visual+behavioural fidelity)** — extends the existing `gates` package (`runGate1` → add `runFidelityGate`). Residual violations over threshold produce the side-by-side `(viewport × scheme)` + stepped-behaviour artifact that the designer/QA HITL gate (#9) halts on.
+
+### Rationale
+
+Code is a lossless design spec; a screenshot is a lossy derivative of it. So port-seed first (free, exact, deterministic for the 90%), then spend the expensive eye only on the residual — and make the eye's output a **hard structural signal** (computed-style + stepped-behaviour deltas), not a soft pixel blob, so brew acts on it. Reusing one pure `diffSnapshots` core for both the brew-driver and the gate means the autonomous loop and the human gate grade fidelity identically. Extends infra already shipped (`gates`+Playwright, `recorder` for deterministic prod renders, the 0.9 capture matrix, #7 references) rather than greenfielding an "eye."
+
+Bounded iterations + escalation (not unbounded pixel-chase) respects the documented brew analysis-paralysis failure mode.
+
+### Scope estimate
+
+- 1d — `StyleSnapshot` + pure `diffSnapshots` (pixel/color/computed-style axes) + unit tests **(first slice — lands with this doc)**
+- 1d — `captureSnapshot` Playwright wrapper + `(viewport × scheme)` matrix capture
+- 1.5d — behavioural stepped-snapshot driver (consume tier-2 acceptance scenarios as event scripts)
+- 1.5d — brew HMR-driver loop: feed violations → re-render → re-diff, bounded + escalate
+- 1d — `runFidelityGate` in `gates` + artifact emission for #9
+- 0.5d — docs
+
+**~6.5d total.** Phased; the pure-diff slice is independently useful (manual fidelity report) before the loop + gate land.
+
+### Dependencies
+
+- #7 `references` (visual/behaviour source split) — **required**, already DECIDED.
+- #9 HITL gates — the residual-fidelity halt; co-designed here.
+- `recorder` for deterministic prod data during render; `gates` Playwright harness; 0.9 capture matrix.
+
+---
+
+## #9 — HITL role gates: hard halts for PM / designer / QA review (DECIDED 2026-06-06)
+
+### Problem
+
+Surfaced alongside #8 in the delgoosh dogfood ([issue #173 finding #13](https://github.com/aminazar/slowcook/issues/173)). slowcook advances a story through refine → vibe/plate → brew with only **soft** human checkpoints: PM review of plate amendments is a convention, not an enforced stop. The pipeline (bot or local-claude-pipeline) can run past a point where a **named human role** — PM, designer, or QA — genuinely needs to sign off, and nothing structurally prevents it. The agent can effectively self-advance.
+
+This is the same integrity problem as the `override-freeze` discipline in `local-pipeline-role.md` ("don't apply override-freeze to your own PRs"): a guard the actor can bypass is theatre. The fix is a **first-class, role-typed, agent-unforgeable halt**.
+
+### Options considered
+
+- **A — Role gates as first-class pipeline objects.** A gate = `{ stage, required_role(s), approval_signal, on_reject_target }`. The downstream stage refuses to dispatch until a valid approval signal from a *human* identity exists. Roles resolve via a repo-level `.brewing/reviewers.yaml` (role → GH handles). State surfaces through `slowcook stories status` (#161, shipped) as `blocked-on-<role>`.
+- **B — Lean on GitHub branch protection / required reviewers only.** *Rejected as sufficient:* couples to one forge, doesn't model role semantics (designer vs QA vs PM), and is invisible to the local-claude-pipeline pattern, which is the active dogfood path.
+- **C — Prompt-only "please wait for review" instruction.** *Rejected:* soft signal; the actor can ignore it. Same failure mode as the problem.
+
+### Chosen: **A**
+
+- **Gate points (default map, spec-overridable):**
+  - refine spec → **PM** approves (refine answers are already treated as contractual)
+  - vibe/plate mock → **designer** approves fidelity
+  - brew output → **QA + designer** sign off ← consumes #8's fidelity artifact (side-by-side `(viewport × scheme)` + stepped-behaviour diff)
+- **Three integrity properties:**
+  1. **Enforced at dispatch, not advisory.** Bot pipeline: the downstream workflow is a no-op without the approval signal. Local-claude-pipeline: a hard instruction the agent honours and **cannot forge** — it does not get to emit its own approval.
+  2. **Approval authenticity.** The signal must come from a *human* identity allow-listed in `reviewers.yaml` (a PR review approval, or a comment from a configured reviewer) — **never** the `slowcook-*[bot]` or the driving agent's identity. This is the load-bearing property; without it the gate is theatre.
+  3. **Reject loops back.** A designer reject of the mock targets `on_reject_target: plate` (not brew); a QA reject of brew targets `brew`. Encoded per-gate.
+- **Surfacing.** Halted stories carry a `blocked-on-<role>` label + a PR comment naming exactly what is needed; `slowcook stories status` shows the blocked state.
+
+### Rationale
+
+Role-typed because PM / designer / QA gate different stages with different artifacts. Forge-agnostic + visible to the local pipeline because that is the active dogfood channel and "agent can't self-advance" matters most there. Authenticity-by-human-identity is the one property that makes the halt real, and it reuses the existing bot-identity discipline.
+
+### Scope estimate
+
+- 0.5d — `reviewers.yaml` schema + role resolver + tests
+- 1d — gate object model (`{stage, required_role(s), approval_signal, on_reject_target}`) + dispatch precondition check
+- 1d — bot workflow integration (downstream no-op without approval) + label/comment surfacing
+- 1d — local-claude-pipeline managed-agent-docs block: the unforgeable-halt instruction + how to recognise a valid human approval
+- 0.5d — `stories status` `blocked-on-<role>` integration + docs
+
+**~4d total.** #8 and #9 are one feature seam: the eye produces the review artifact; the gate halts for the human to grade it.
+
+### Dependencies
+
+- #8 fidelity eye — produces the brew-stage review artifact.
+- `slowcook stories status` (#161) — blocked-state surface, shipped.
+
+---
+
 ## Cross-doc references
 
 - Strategy + ideation: [`0.20-and-beyond.md`](./0.20-and-beyond.md)

--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -511,15 +511,27 @@ Bounded iterations + escalation (not unbounded pixel-chase) respects the documen
 - 1.5d — behavioural stepped-snapshot driver (consume tier-2 acceptance scenarios as event scripts)
 - 1.5d — brew HMR-driver loop: feed violations → re-render → re-diff, bounded + escalate
 - 1d — `runFidelityGate` in `gates` + artifact emission for #9
+- 0.5d — eye artifact file-management: `upload-artifact` + `pull_request: closed` cleanup workflow + review-thumbnail push to the `eye-review` branch
 - 0.5d — docs
 
-**~6.5d total.** Phased; the pure-diff slice is independently useful (manual fidelity report) before the loop + gate land.
+**~7d total.** Phased; the pure-diff slice is independently useful (manual fidelity report) before the loop + gate land.
 
 ### Dependencies
 
 - #7 `references` (visual/behaviour source split) — **required**, already DECIDED.
 - #9 HITL gates — the residual-fidelity halt; co-designed here.
 - `recorder` for deterministic prod data during render; `gates` Playwright harness; 0.9 capture matrix.
+
+### Artifact file management (DECIDED 2026-06-07)
+
+Minimal, trigger-based. Two tiers:
+
+- **Working set** — per-iteration renders, both snapshots, the full `(viewport × scheme)` matrix. One GitHub Actions artifact per acceptance run, keyed to PR + commit, `retention-days: 14` as a passive backstop. **Actively deleted on `pull_request: closed`**: a cleanup workflow calls `DELETE /repos/{owner}/{repo}/actions/artifacts/{id}` for that PR's runs. Trigger-based, not just expiry. Nothing is lost — the reference render is regenerable from the mock (`references.visual`) at the merged SHA.
+- **Review set** — the single side-by-side the #9 designer/QA gate grades, plus a thumbnail. **Persisted + inlined in the review-overlay PR comment**, survives close (it is the audit trail).
+
+**Mechanism note (resolves the "attach files to a PR?" question):** GitHub has **no public API to inline-upload an attachment to a PR or comment** — the web drag-drop user-attachments flow is not an endpoint. So the review image is hosted by pushing the thumbnail to a dedicated `eye-review/<pr>/<sha>.png` orphan branch and referencing its `raw.githubusercontent.com` URL in the comment markdown (renders inline, persists, deletable, doesn't bloat `main`). Full-res lives only in the expiring artifact; the comment keeps the small thumbnail indefinitely.
+
+**No MinIO / long-term full-res warehouse** (revises the 0.9.2 tier-2 plan): the eye diffs against a regenerable mock, not a stored golden image, so baseline warehousing solves a problem this architecture does not have. Keep the pixels disposable; the contract is the mock + the #10 dense shape tests + the computed-style assertions, all permanent in git.
 
 ---
 

--- a/docs/plans/0.20-design-discussions.md
+++ b/docs/plans/0.20-design-discussions.md
@@ -570,6 +570,51 @@ Role-typed because PM / designer / QA gate different stages with different artif
 
 ---
 
+## #10 — Drift minimization: dense, paradigm-aware mock-style extraction (DECIDED 2026-06-06)
+
+### Problem
+
+Surfaced in the delgoosh design-react dogfood ([issue #173 finding #14](https://github.com/aminazar/slowcook/issues/173)): brew ships a front-end that is *not* faithful to the React/Vite mock even though the mock is the visual source-of-truth (`references.visual`, #7). The brew agent itself characterised it as "natural drift."
+
+Root cause is mechanical, in `recon/shape-preserve.ts`. The shape-test generator pins only a **sparse, hand-picked subset** of the mock's styling: testids, `<header>` presence, "no inline hex", and className tokens **filtered through a 17-item hardcoded allowlist** (`TOKENS_OF_INTEREST` = `rounded-*`, `min-h-[44px]`, `flex/grid`). `extractTokens` records a class *only if it is already in that allowlist*. So a mock button with `bg-primary px-4 py-3 text-sm font-medium shadow-md gap-2 hover:bg-primary/90 focus-visible:ring-2` is pinned as, at most, `flex` + `rounded-lg`. Everything else — real spacing, color tokens, typography, the full utility stack, state/responsive variants — is **unpinned**. brew's plate-mode "preserve the UI shape" is a *soft* prompt instruction; under optimization pressure brew satisfies the sparse pins and drifts the unpinned remainder. (Behaviour is pinned to zero from the mock entirely — shape-preserve defers behaviour to testgen, which derives it from the spec, not the mock; mock interaction behaviour is pure drift surface, owned by the #8 eye.)
+
+### The over-extraction framing (locked)
+
+The failure mode is **over/under-extraction, not over-assertion.** Test synthesis is a faithful mechanical function of the extract — an assertion is only ever as strict as what `extractShape` fed it. So brittleness ("brew makes a legit change, a test goes red") roots at *what we chose to extract* (pinning a property that was never design-contract: mock-only chrome, demo styling, or a hashed CSS-module class name), not at the assertion step. The quality lever is therefore **extraction discrimination**, with **containment** (`brewed ⊇ mock`) as cheap insurance for the one genuinely assertion-side risk (brew legitimately *adds* a real-data class).
+
+This decision is consistent with `feedback_shape_in_tests_not_in_guard`: a *dense* shape test is lock-equivalent protection **without** reintroducing the retired JSX-diff guard. It stays in the test vehicle; it just stops being sparse.
+
+### Options considered
+
+- **A — Densify extraction + containment assertions.** Drop the `TOKENS_OF_INTEREST` allowlist; extract the mock element's *actual* utility-class set (string-literal classNames on non-mock-chrome elements), paradigm-aware; emit per-element `brewed ⊇ mock` containment assertions anchored by testid.
+- **B — Softer prompt steering** ("reuse the mock's classes"). Rejected: the remainder is *already* soft and that is exactly what drifts (`feedback_soft_steering_vs_hard_signals`).
+- **C — Reintroduce a JSX-shape-diff guard / file-edit lock.** Rejected: re-litigates `feedback_shape_in_tests_not_in_guard`. Option A gets lock-equivalent protection in the settled vehicle.
+
+### Chosen: **A**
+
+- **Extraction is paradigm-aware.** Pull utility tokens from **string-literal** classNames only; skip `className={...}` dynamic/module/`cx(...)` values. For CSS-modules / styled-component mocks there is no utility-token set to extract — extracting hashed identifiers would be over-extraction (noise, not intent), so static extraction yields nothing there and **styling fidelity defers to the #8 eye** (resolved computed-style). Clean partition: dense static containment for utility-class mocks; the eye for the rest and for resolved-value / responsive / theme / behaviour fidelity.
+- **Per-element, testid-anchored, containment.** v2 render-and-assert: `queryByTestId(tid)` then assert the element's class list contains each extracted token. Elements without a testid fall back to file-level token containment.
+- **`elementClasses` is an additive optional field** on `ExtractedShape` (existing fixtures/consumers unaffected); `visualTokens` (the allowlist) stays for back-compat and is subsumed — retire in a follow-up.
+
+### Rationale
+
+Closes the gap the dogfood exposed at its mechanical source. Cheap + deterministic (no LLM, no browser). Partitions cleanly with #8 so neither static nor runtime is asked to do what it can't: static catches *dropped utility classes* (the bulk); the eye catches *resolved-render* divergence. Containment keeps it from breaking on additive real-data edits.
+
+### Scope estimate
+
+- 1d — `extractElementClasses` (paradigm-aware) + containment synth (v1 + v2) + unit tests **(first slice — lands with this doc)**
+- 0.5d — retire `TOKENS_OF_INTEREST` / fold `visualTokens` into the dense path
+- 0.5d — brew plate-mode prompt: name the dense shape tests as the shape contract; scope edit license to data-wiring seams
+- 0.5d — docs
+
+**~2.5d total.** Phased; the extraction slice is independently useful (denser shape tests) before the prompt + retirement land.
+
+### Dependencies
+
+- #7 `references.visual` (which source to extract from). #8 eye (owns resolved-value + behaviour fidelity — the static/runtime partition). `recon/shape-preserve.ts` (the file changed).
+
+---
+
 ## Cross-doc references
 
 - Strategy + ideation: [`0.20-and-beyond.md`](./0.20-and-beyond.md)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -92,6 +92,14 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook recon [--story <id>] [--cwd <path>] [--reuse-scan] [--stub-scan] [--exclude <glob>]
   ```
+- **`eye`** — Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.
+  ```
+  slowcook eye --reference <url> --candidate <url> [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>]
+  ```
+- **`gate`** — HITL review halt (design #9). Refuses to advance a stage until a human in the required role has approved on the PR; bot/agent reviews never satisfy it.
+  ```
+  slowcook gate check --stage <refine|plate|brew> --pr <n> [--repo <owner/name>]
+  ```
 - **`map`** — Generate / check the repo-wide code map (APIs, pages, components, helpers, types).
   ```
   slowcook map (generate|check) [--cwd <path>] [--out <path>] [--md <path>]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,8 +47,10 @@
     "@slowcook-ai/llm-anthropic": "workspace:^",
     "@slowcook-ai/recorder": "workspace:^",
     "@slowcook-ai/review-overlay": "workspace:^",
+    "@slowcook-ai/gates": "workspace:^",
     "@anthropic-ai/sdk": "^0.100.1",
     "@octokit/rest": "^22.0.1",
+    "@playwright/test": "^1.40.0",
     "ts-morph": "^28.0.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,6 +38,8 @@ import { devEnv } from "./commands/dev-env/index.js";
 import { serve } from "./commands/serve/index.js";
 import { budget } from "./commands/budget/index.js";
 import { brand } from "./commands/brand/index.js";
+import { eye } from "./commands/eye/index.js";
+import { gate } from "./commands/gate/index.js";
 import { renderHelp, renderCommandHelp, renderReadmeBlock } from "./help.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
@@ -280,6 +282,16 @@ async function main(): Promise<void> {
       // both mockup PR + tests PR are merged; catches residual
       // vibe ⇄ testgen divergence before brew burns tokens.
       await recon(args.slice(1), VERSION);
+      return;
+    case "eye":
+      // design #8 — render reference (mock) + candidate (brewed) URLs across
+      // the viewport×scheme matrix, grade fidelity, screenshot, exit 1 on drift.
+      await eye(args.slice(1), VERSION);
+      return;
+    case "gate":
+      // design #9 — HITL halt: refuse to advance a stage until a human in the
+      // required role has approved on the PR (agent-unforgeable).
+      await gate(args.slice(1), VERSION);
       return;
     case "run-mock":
       // 0.16.0-α.17 — one-command mock launch + auto-pull on plate

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -158,6 +158,18 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
     group: "checks",
   },
   {
+    name: "eye",
+    usage: "slowcook eye --reference <url> --candidate <url> [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>]",
+    description: "Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.",
+    group: "checks",
+  },
+  {
+    name: "gate",
+    usage: "slowcook gate check --stage <refine|plate|brew> --pr <n> [--repo <owner/name>]",
+    description: "HITL review halt (design #9). Refuses to advance a stage until a human in the required role has approved on the PR; bot/agent reviews never satisfy it.",
+    group: "checks",
+  },
+  {
     name: "map",
     usage: "slowcook map (generate|check) [--cwd <path>] [--out <path>] [--md <path>]",
     description: "Generate / check the repo-wide code map (APIs, pages, components, helpers, types).",

--- a/packages/cli/src/commands/brew/fidelity-loop.test.ts
+++ b/packages/cli/src/commands/brew/fidelity-loop.test.ts
@@ -1,0 +1,214 @@
+/**
+ * design #8 — tests for the bounded fidelity-correction loop controller.
+ *
+ * Uses fake measure()/applyFix() driven by scripted violation-count
+ * sequences. Violations are modelled as `{ key: string }` so `keyOf` has
+ * something real to return.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { runFidelityLoop, type FidelityLoopDeps } from "./fidelity-loop.js";
+
+interface V {
+  key: string;
+}
+
+/** Build `n` distinct fake violations for a given iteration. */
+function violations(n: number, salt = ""): V[] {
+  return Array.from({ length: n }, (_, i) => ({ key: `${salt}sel-${i}:color` }));
+}
+
+/**
+ * Make a `measure` that returns scripted counts, one per call. Each entry can
+ * be a number (count → distinct violations) or an explicit V[] for key tests.
+ */
+function scriptedMeasure(script: Array<number | V[]>) {
+  let call = 0;
+  return vi.fn(async () => {
+    const step = script[call];
+    call += 1;
+    if (step === undefined) {
+      throw new Error(`measure() called more times than scripted (${call})`);
+    }
+    return typeof step === "number" ? violations(step) : step;
+  });
+}
+
+const keyOf = (v: V) => v.key;
+
+function deps(over: Partial<FidelityLoopDeps<V>>): FidelityLoopDeps<V> {
+  return {
+    measure: scriptedMeasure([0]),
+    applyFix: vi.fn(async () => {}),
+    keyOf,
+    ...over,
+  };
+}
+
+describe("runFidelityLoop", () => {
+  it("converges immediately when the first measure is clean", async () => {
+    const applyFix = vi.fn(async () => {});
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([0]), applyFix }),
+    );
+
+    expect(res.converged).toBe(true);
+    expect(res.escalated).toBe(false);
+    expect(res.reason).toBe("converged");
+    expect(res.iterations).toBe(1);
+    expect(res.history).toEqual([0]);
+    expect(res.remaining).toEqual([]);
+    expect(applyFix).not.toHaveBeenCalled();
+  });
+
+  it("converges over three iterations and calls applyFix twice", async () => {
+    const applyFix = vi.fn(async () => {});
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([3, 1, 0]), applyFix }),
+    );
+
+    expect(res.converged).toBe(true);
+    expect(res.escalated).toBe(false);
+    expect(res.reason).toBe("converged");
+    expect(res.iterations).toBe(3);
+    expect(res.history).toEqual([3, 1, 0]);
+    expect(res.remaining).toEqual([]);
+    // applyFix called after measure #1 (3) and #2 (1), not after the clean #3.
+    expect(applyFix).toHaveBeenCalledTimes(2);
+    expect(applyFix.mock.calls[0][1]).toBe(1); // iteration arg
+    expect(applyFix.mock.calls[1][1]).toBe(2);
+  });
+
+  it("escalates as 'stalled' when the count never decreases", async () => {
+    const applyFix = vi.fn(async () => {});
+    // [2,2,2]: iter1 applies (no prev), iter2 count>=prev → stall=1 applies,
+    // iter3 count>=prev → stall=2 == stallLimit → bail, no applyFix.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([2, 2, 2]), applyFix }),
+    );
+
+    expect(res.converged).toBe(false);
+    expect(res.escalated).toBe(true);
+    expect(res.reason).toBe("stalled");
+    expect(res.iterations).toBe(3);
+    expect(res.history).toEqual([2, 2, 2]);
+    expect(res.remaining).toHaveLength(2);
+    // applyFix runs after iter1 and iter2 only — NOT after the stall is detected.
+    expect(applyFix).toHaveBeenCalledTimes(2);
+  });
+
+  it("escalates as 'stalled' on a plateau that follows progress", async () => {
+    const applyFix = vi.fn(async () => {});
+    // [4,3,3,3]: iter2 decreases (stall reset), iter3 plateau stall=1,
+    // iter4 plateau stall=2 → stalled. applyFix after 1,2,3 = 3 times.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([4, 3, 3, 3]), applyFix }),
+    );
+
+    expect(res.reason).toBe("stalled");
+    expect(res.escalated).toBe(true);
+    expect(res.iterations).toBe(4);
+    expect(res.history).toEqual([4, 3, 3, 3]);
+    expect(applyFix).toHaveBeenCalledTimes(3);
+  });
+
+  it("escalates as 'exhausted' when it keeps improving but hits maxIters", async () => {
+    const applyFix = vi.fn(async () => {});
+    // Strictly decreasing, never empty within 5 measures → never stalls,
+    // but iteration 5 still has violations → exhausted.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([5, 4, 3, 2, 1]), applyFix }),
+    );
+
+    expect(res.converged).toBe(false);
+    expect(res.escalated).toBe(true);
+    expect(res.reason).toBe("exhausted");
+    expect(res.iterations).toBe(5);
+    expect(res.history).toEqual([5, 4, 3, 2, 1]);
+    expect(res.remaining).toHaveLength(1);
+    // applyFix after iters 1..4; iter5 bails on budget before fixing.
+    expect(applyFix).toHaveBeenCalledTimes(4);
+  });
+
+  it("honors a custom maxIters", async () => {
+    const applyFix = vi.fn(async () => {});
+    // maxIters=3, strictly decreasing → exhausted at iteration 3.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([3, 2, 1]), applyFix, maxIters: 3 }),
+    );
+
+    expect(res.reason).toBe("exhausted");
+    expect(res.iterations).toBe(3);
+    expect(res.history).toEqual([3, 2, 1]);
+    expect(applyFix).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors a custom stallLimit (1 = bail on first non-improvement)", async () => {
+    const applyFix = vi.fn(async () => {});
+    // stallLimit=1: iter1 applies, iter2 count>=prev → stall=1 == limit → bail.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([2, 2]), applyFix, stallLimit: 1 }),
+    );
+
+    expect(res.reason).toBe("stalled");
+    expect(res.iterations).toBe(2);
+    expect(res.history).toEqual([2, 2]);
+    expect(applyFix).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a count INCREASE as non-progress (stall)", async () => {
+    const applyFix = vi.fn(async () => {});
+    // [2,3,4]: iter2 count>prev stall=1, iter3 count>prev stall=2 → stalled.
+    const res = await runFidelityLoop(
+      deps({ measure: scriptedMeasure([2, 3, 4]), applyFix }),
+    );
+
+    expect(res.reason).toBe("stalled");
+    expect(res.history).toEqual([2, 3, 4]);
+    expect(applyFix).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses keyOf-bearing violations in `remaining` (different keys, same count still stalls)", async () => {
+    const applyFix = vi.fn(async () => {});
+    // Same count (2) every step but DIFFERENT key sets each time. Progress is
+    // count-based, so this still stalls — and `remaining` carries the last
+    // measured violations whose keys keyOf can read.
+    const measure = scriptedMeasure([
+      violations(2, "a-"),
+      violations(2, "b-"),
+      violations(2, "c-"),
+    ]);
+    const res = await runFidelityLoop(deps({ measure, applyFix }));
+
+    expect(res.reason).toBe("stalled");
+    expect(res.remaining.map(keyOf)).toEqual(["c-sel-0:color", "c-sel-1:color"]);
+  });
+
+  it("invokes onIteration once per measure with correct flags", async () => {
+    const onIteration = vi.fn();
+    await runFidelityLoop(
+      deps({ measure: scriptedMeasure([2, 1, 0]), onIteration }),
+    );
+
+    expect(onIteration).toHaveBeenCalledTimes(3);
+    expect(onIteration.mock.calls[0][0]).toEqual({
+      iteration: 1,
+      count: 2,
+      converged: false,
+    });
+    expect(onIteration.mock.calls[2][0]).toEqual({
+      iteration: 3,
+      count: 0,
+      converged: true,
+    });
+  });
+
+  it("escalated is always the negation of converged", async () => {
+    const conv = await runFidelityLoop(deps({ measure: scriptedMeasure([1, 0]) }));
+    const esc = await runFidelityLoop(deps({ measure: scriptedMeasure([1, 1, 1]) }));
+
+    expect(conv.escalated).toBe(!conv.converged);
+    expect(esc.escalated).toBe(!esc.converged);
+  });
+});

--- a/packages/cli/src/commands/brew/fidelity-loop.ts
+++ b/packages/cli/src/commands/brew/fidelity-loop.ts
@@ -1,0 +1,142 @@
+/**
+ * design #8 — eye-driven brew convergence loop.
+ *
+ * Bounded fidelity-correction controller: the "brain" that drives a front-end
+ * brew toward a mock by repeatedly measuring fidelity violations (the eye) and
+ * applying fixes (the brew agent), relying on a hot-reload stack to re-render
+ * between iterations so each pass is cheap.
+ *
+ * Generic + dependency-free. Parameterised over a violation type `V` so it
+ * never couples to the eye's concrete types (no import from
+ * @slowcook-ai/gates or any sibling package).
+ *
+ * MUST be bounded and detect non-progress. slowcook's brew agent has a
+ * documented "analysis-paralysis" failure mode (see
+ * `project_brew_agent_improvements`) where it loops without converging — so
+ * the controller escalates rather than spinning:
+ *   - converged: zero violations measured.
+ *   - stalled:   violation COUNT failed to strictly decrease for `stallLimit`
+ *                consecutive iterations (default 2). The stalling applyFix is
+ *                NOT re-run — we bail before burning another fix.
+ *   - exhausted: `maxIters` (default 5) measure() calls made while violations
+ *                remain.
+ *
+ * Progress is measured by strictly-decreasing violation COUNT. `keyOf` is
+ * required in deps (and is the stable per-violation identity used by callers
+ * for logging/diffing `remaining`) but the convergence decision itself is
+ * count-based and documented as such for simplicity.
+ */
+
+export interface FidelityLoopDeps<V> {
+  /** Render + measure current fidelity violations (the eye). */
+  measure: () => Promise<V[]>;
+  /** Apply fixes for the given violations (the brew agent), then the caller's HMR re-renders. */
+  applyFix: (violations: V[], iteration: number) => Promise<void>;
+  /** Stable key per violation, used to detect progress/stall (e.g. `${selector}:${property}`). */
+  keyOf: (v: V) => string;
+  /** Max iterations before escalating (default 5). */
+  maxIters?: number;
+  /** Consecutive non-improving iterations before escalating early (default 2). */
+  stallLimit?: number;
+  /** Optional progress callback for logging. */
+  onIteration?: (info: { iteration: number; count: number; converged: boolean }) => void;
+}
+
+export interface FidelityLoopResult<V> {
+  converged: boolean;     // reached zero violations
+  escalated: boolean;     // gave up (stall or exhausted) — true iff !converged
+  iterations: number;     // how many measure() calls were made
+  remaining: V[];         // violations left at exit
+  history: number[];      // violation count per iteration (in order)
+  reason: 'converged' | 'stalled' | 'exhausted';
+}
+
+/**
+ * Drive a bounded measure → fix → re-measure loop until the front-end matches
+ * the mock (zero violations) or the controller escalates.
+ *
+ * Escalation semantics (return without calling applyFix again on bail):
+ *   - First iteration always proceeds to applyFix if violations exist (there is
+ *     no "previous" count to stall against).
+ *   - After each measure: if `iterations >= maxIters` and violations remain →
+ *     `exhausted`.
+ *   - Stall: if this iteration's count did NOT strictly decrease vs the prior
+ *     count (>= previous), increment the stall counter; otherwise reset it to
+ *     0. When the stall counter reaches `stallLimit` → `stalled` (applyFix is
+ *     NOT invoked for this iteration).
+ *   - `escalated === !converged`.
+ */
+export async function runFidelityLoop<V>(
+  deps: FidelityLoopDeps<V>,
+): Promise<FidelityLoopResult<V>> {
+  const maxIters = deps.maxIters ?? 5;
+  const stallLimit = deps.stallLimit ?? 2;
+
+  const history: number[] = [];
+  let iterations = 0;
+  let stallCount = 0;
+  let prevCount: number | null = null;
+  let remaining: V[] = [];
+
+  // Loop guard: maxIters caps measure() calls, so this can never run forever.
+  for (;;) {
+    remaining = await deps.measure();
+    iterations += 1;
+    const count = remaining.length;
+    history.push(count);
+
+    const converged = count === 0;
+    deps.onIteration?.({ iteration: iterations, count, converged });
+
+    if (converged) {
+      return {
+        converged: true,
+        escalated: false,
+        iterations,
+        remaining,
+        history,
+        reason: 'converged',
+      };
+    }
+
+    // Out of budget: violations remain and we've used our measure() quota.
+    if (iterations >= maxIters) {
+      return {
+        converged: false,
+        escalated: true,
+        iterations,
+        remaining,
+        history,
+        reason: 'exhausted',
+      };
+    }
+
+    // Progress check (count-based). Skipped on the first iteration since there
+    // is no previous count to compare against.
+    if (prevCount !== null) {
+      if (count >= prevCount) {
+        stallCount += 1;
+      } else {
+        stallCount = 0;
+      }
+
+      if (stallCount >= stallLimit) {
+        // Bail BEFORE applying another fix — the agent is spinning.
+        return {
+          converged: false,
+          escalated: true,
+          iterations,
+          remaining,
+          history,
+          reason: 'stalled',
+        };
+      }
+    }
+
+    prevCount = count;
+
+    // Hand the current violations to the brew agent; the caller's HMR stack
+    // re-renders before the next measure().
+    await deps.applyFix(remaining, iterations);
+  }
+}

--- a/packages/cli/src/commands/eye/index.ts
+++ b/packages/cli/src/commands/eye/index.ts
@@ -1,0 +1,77 @@
+/**
+ * design #8 — `slowcook eye`. Renders a reference (mock) URL and a candidate
+ * (brewed) URL across the (viewport × scheme) matrix in headless Chromium,
+ * captures a fidelity snapshot of each, grades candidate-vs-reference with the
+ * gates fidelity engine, writes screenshots + a JSON report, and exits 1 when
+ * the gate fails. This is the runnable eye behind the brew-loop + the #9
+ * designer/QA gate; it consumes `references.visual` as the reference URL.
+ *
+ *   slowcook eye --reference http://localhost:33010 --candidate http://localhost:3001 \
+ *     [--out .brewing/eye] [--viewport mobile|desktop] [--scheme light|dark] \
+ *     [--max-violations N] [--fail-on color,box,computed-style,missing]
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { chromium } from "@playwright/test";
+import { captureSnapshot, gradeFidelity, type StyleSnapshot } from "@slowcook-ai/gates";
+import { parseEyeArgs, type EyeContext } from "./plan.js";
+
+export async function eye(args: string[], _version: string): Promise<void> {
+  if (args[0] === "--help" || args[0] === "-h") {
+    console.log("usage: slowcook eye --reference <url> --candidate <url> [--out dir] [--viewport m] [--scheme s] [--max-violations N] [--fail-on a,b]");
+    return;
+  }
+
+  let opts;
+  try {
+    opts = parseEyeArgs(args);
+  } catch (e) {
+    console.error(String(e instanceof Error ? e.message : e));
+    process.exit(64);
+  }
+
+  mkdirSync(opts.outDir, { recursive: true });
+  const browser = await chromium.launch();
+  const screenshots: string[] = [];
+
+  const captureUrl = async (url: string, label: string, ctx: EyeContext): Promise<StyleSnapshot> => {
+    const c = await browser.newContext({
+      colorScheme: ctx.scheme,
+      viewport: { width: ctx.width, height: ctx.height },
+      deviceScaleFactor: 2,
+    });
+    const page = await c.newPage();
+    await page.goto(url, { waitUntil: "networkidle" });
+    await page.waitForTimeout(400); // let lazy / client styles settle
+    const shot = join(opts.outDir, `${label}-${ctx.viewport}-${ctx.scheme}.png`);
+    await page.screenshot({ path: shot, fullPage: true });
+    screenshots.push(shot);
+    const snap = await captureSnapshot(page, { viewport: ctx.viewport, scheme: ctx.scheme });
+    await c.close();
+    return snap;
+  };
+
+  const pairs: { reference: StyleSnapshot; candidate: StyleSnapshot }[] = [];
+  try {
+    for (const ctx of opts.matrix) {
+      const reference = await captureUrl(opts.referenceUrl, "reference", ctx);
+      const candidate = await captureUrl(opts.candidateUrl, "candidate", ctx);
+      pairs.push({ reference, candidate });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const result = gradeFidelity(pairs, opts.gate);
+  writeFileSync(join(opts.outDir, "eye-report.json"), JSON.stringify({ ...result, screenshots }, null, 2));
+
+  console.log(`\nslowcook eye — ${result.passed ? "PASS ✓" : "FAIL ✗"} (${result.violations.length} violation(s) across ${pairs.length} render(s))`);
+  for (const ctx of result.byContext) {
+    if (ctx.violations.length === 0) continue;
+    console.log(`  [${ctx.context.viewport}/${ctx.context.scheme}] ${ctx.violations.length}: ${JSON.stringify(ctx.summary.byAxis)}`);
+    for (const v of ctx.violations.slice(0, 5)) console.log(`     ${v.axis}: ${v.evidence}`);
+  }
+  console.log(`  screenshots + report → ${opts.outDir}/`);
+
+  if (!result.passed) process.exit(1);
+}

--- a/packages/cli/src/commands/eye/plan.test.ts
+++ b/packages/cli/src/commands/eye/plan.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parseEyeArgs, DEFAULT_MATRIX, VIEWPORTS } from "./plan.js";
+
+const base = ["--reference", "http://ref", "--candidate", "http://cand"];
+
+describe("parseEyeArgs", () => {
+  it("requires --reference and --candidate", () => {
+    expect(() => parseEyeArgs([])).toThrow(/reference/);
+    expect(() => parseEyeArgs(["--reference", "x"])).toThrow(/candidate/);
+  });
+
+  it("defaults to the full mobile/desktop × light/dark matrix + .brewing/eye", () => {
+    const o = parseEyeArgs(base);
+    expect(o.referenceUrl).toBe("http://ref");
+    expect(o.candidateUrl).toBe("http://cand");
+    expect(o.outDir).toBe(".brewing/eye");
+    expect(o.matrix).toHaveLength(4);
+    expect(o.matrix.map((c) => `${c.viewport}-${c.scheme}`).sort()).toEqual([
+      "desktop-dark", "desktop-light", "mobile-dark", "mobile-light",
+    ]);
+  });
+
+  it("attaches real pixel dimensions per viewport", () => {
+    const o = parseEyeArgs([...base, "--viewport", "mobile"]);
+    expect(o.matrix.every((c) => c.width === VIEWPORTS.mobile.width)).toBe(true);
+  });
+
+  it("narrows the matrix by --viewport and --scheme", () => {
+    expect(parseEyeArgs([...base, "--viewport", "desktop"]).matrix).toHaveLength(2);
+    expect(parseEyeArgs([...base, "--scheme", "dark"]).matrix).toHaveLength(2);
+    const one = parseEyeArgs([...base, "--viewport", "mobile", "--scheme", "dark"]).matrix;
+    expect(one).toHaveLength(1);
+    expect(one[0]).toMatchObject({ viewport: "mobile", scheme: "dark" });
+  });
+
+  it("rejects unknown viewport / scheme", () => {
+    expect(() => parseEyeArgs([...base, "--viewport", "watch"])).toThrow(/unknown --viewport/);
+    expect(() => parseEyeArgs([...base, "--scheme", "sepia"])).toThrow(/light\|dark/);
+  });
+
+  it("maps --max-violations and --fail-on into gate options", () => {
+    const o = parseEyeArgs([...base, "--max-violations", "3", "--fail-on", "color,box"]);
+    expect(o.gate.maxViolations).toBe(3);
+    expect(o.gate.failOnAxes).toEqual(["color", "box"]);
+  });
+
+  it("DEFAULT_MATRIX is the 4-cell product", () => {
+    expect(DEFAULT_MATRIX).toHaveLength(4);
+  });
+});

--- a/packages/cli/src/commands/eye/plan.ts
+++ b/packages/cli/src/commands/eye/plan.ts
@@ -1,0 +1,79 @@
+/**
+ * design #8 — `slowcook eye` planning (pure). Expands the CLI flags into the
+ * (viewport × scheme) capture matrix + gate thresholds the runner executes.
+ * Kept pure + unit-tested; the Playwright execution lives in ./index.ts.
+ */
+import type { FidelityAxis, FidelityGateOptions } from "@slowcook-ai/gates";
+
+/** A capture context plus the pixel viewport to emulate. */
+export interface EyeContext {
+  viewport: string;
+  scheme: "light" | "dark";
+  width: number;
+  height: number;
+}
+
+export interface EyeOptions {
+  referenceUrl: string;
+  candidateUrl: string;
+  outDir: string;
+  matrix: EyeContext[];
+  gate: FidelityGateOptions;
+}
+
+export const VIEWPORTS: Record<string, { width: number; height: number }> = {
+  mobile: { width: 390, height: 844 },
+  desktop: { width: 1280, height: 800 },
+};
+
+const SCHEMES: ReadonlyArray<"light" | "dark"> = ["light", "dark"];
+
+/** Full default matrix: {mobile,desktop} × {light,dark}. */
+export const DEFAULT_MATRIX: EyeContext[] = Object.entries(VIEWPORTS).flatMap(([viewport, dim]) =>
+  SCHEMES.map((scheme) => ({ viewport, scheme, ...dim })),
+);
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+/**
+ * Parse `slowcook eye` flags. Required: --reference <url>, --candidate <url>.
+ * Optional: --out <dir> (default ./.brewing/eye), --viewport <name> + --scheme
+ * <light|dark> to narrow the matrix, --max-violations <n>, --fail-on <a,b>.
+ * Throws on a missing required flag (caller maps to a non-zero exit).
+ */
+export function parseEyeArgs(args: string[]): EyeOptions {
+  const referenceUrl = val(args, "--reference");
+  const candidateUrl = val(args, "--candidate");
+  if (!referenceUrl || !candidateUrl) {
+    throw new Error("eye: --reference <url> and --candidate <url> are both required");
+  }
+
+  let matrix = DEFAULT_MATRIX;
+  const onlyViewport = val(args, "--viewport");
+  const onlyScheme = val(args, "--scheme");
+  if (onlyViewport) {
+    if (!VIEWPORTS[onlyViewport]) throw new Error(`eye: unknown --viewport '${onlyViewport}' (have: ${Object.keys(VIEWPORTS).join(", ")})`);
+    matrix = matrix.filter((c) => c.viewport === onlyViewport);
+  }
+  if (onlyScheme) {
+    if (onlyScheme !== "light" && onlyScheme !== "dark") throw new Error(`eye: --scheme must be light|dark`);
+    matrix = matrix.filter((c) => c.scheme === onlyScheme);
+  }
+
+  const maxV = val(args, "--max-violations");
+  const failOn = val(args, "--fail-on");
+  const gate: FidelityGateOptions = {};
+  if (maxV !== undefined) gate.maxViolations = Number.parseInt(maxV, 10);
+  if (failOn) gate.failOnAxes = failOn.split(",").map((s) => s.trim()) as FidelityAxis[];
+
+  return {
+    referenceUrl,
+    candidateUrl,
+    outDir: val(args, "--out") ?? ".brewing/eye",
+    matrix,
+    gate,
+  };
+}

--- a/packages/cli/src/commands/gate/github.test.ts
+++ b/packages/cli/src/commands/gate/github.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mapReviewsToApprovals } from "./github.js";
+
+describe("mapReviewsToApprovals", () => {
+  it("maps states + lowercases handles", () => {
+    const out = mapReviewsToApprovals([
+      { user: { login: "Designer1", type: "User" }, state: "APPROVED" },
+      { user: { login: "qaPerson", type: "User" }, state: "CHANGES_REQUESTED" },
+    ]);
+    expect(out).toEqual([
+      { byHandle: "designer1", state: "approved", identityType: "human" },
+      { byHandle: "qaperson", state: "rejected", identityType: "human" },
+    ]);
+  });
+
+  it("classifies bots by type, [bot] suffix, and known-login list", () => {
+    const out = mapReviewsToApprovals([
+      { user: { login: "slowcook-brew[bot]", type: "Bot" }, state: "APPROVED" },
+      { user: { login: "dependabot[bot]", type: "User" }, state: "APPROVED" },
+      { user: { login: "github-actions", type: "User" }, state: "APPROVED" },
+    ]);
+    expect(out.every((a) => a.identityType === "bot")).toBe(true);
+  });
+
+  it("drops dismissed/pending and keeps only the latest review per author", () => {
+    const out = mapReviewsToApprovals([
+      { user: { login: "pm", type: "User" }, state: "CHANGES_REQUESTED" },
+      { user: { login: "pm", type: "User" }, state: "APPROVED" }, // supersedes
+      { user: { login: "x", type: "User" }, state: "DISMISSED" },
+      { user: { login: "y", type: "User" }, state: "PENDING" },
+    ]);
+    expect(out).toEqual([{ byHandle: "pm", state: "approved", identityType: "human" }]);
+  });
+
+  it("ignores reviews with no author", () => {
+    expect(mapReviewsToApprovals([{ state: "APPROVED" }])).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/gate/github.ts
+++ b/packages/cli/src/commands/gate/github.ts
@@ -1,0 +1,60 @@
+/**
+ * design #9 — map GitHub PR reviews to the Approval shape `isGateSatisfied`
+ * grades. Pure + unit-tested; the live `gh api` fetch lives in ./index.ts.
+ *
+ * The identity classification is the load-bearing bit: a review authored by a
+ * Bot account (GitHub `user.type === "Bot"`, or a login ending in `[bot]`, or a
+ * known slowcook bot handle) is marked `identityType: "bot"` so it can never
+ * satisfy a human-review gate — the automation cannot self-approve.
+ */
+import type { Approval } from "./model.js";
+
+/** Subset of the GitHub PR-review payload we consume. */
+export interface GhReview {
+  user?: { login?: string; type?: string } | null;
+  state?: string; // APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING
+}
+
+/** Logins always treated as bots regardless of the GitHub `type` field. */
+export const BOT_LOGINS: ReadonlyArray<string> = ["github-actions"];
+
+function isBot(login: string, type: string | undefined): boolean {
+  if (type === "Bot") return true;
+  if (login.endsWith("[bot]")) return true;
+  if (BOT_LOGINS.includes(login)) return true;
+  return false;
+}
+
+function mapState(state: string | undefined): Approval["state"] | null {
+  switch (state) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "rejected";
+    case "COMMENTED":
+      return "commented";
+    default:
+      return null; // DISMISSED / PENDING / unknown → not a signal
+  }
+}
+
+/**
+ * Convert raw PR reviews into Approvals. Dismissed/pending reviews are dropped.
+ * Only the latest review per author is kept (GitHub returns reviews
+ * chronologically; a later review supersedes an earlier one from the same user).
+ */
+export function mapReviewsToApprovals(reviews: GhReview[]): Approval[] {
+  const latestByAuthor = new Map<string, Approval>();
+  for (const r of reviews) {
+    const login = (r.user?.login ?? "").toLowerCase();
+    if (!login) continue;
+    const state = mapState(r.state);
+    if (!state) continue;
+    latestByAuthor.set(login, {
+      byHandle: login,
+      state,
+      identityType: isBot(login, r.user?.type ?? undefined) ? "bot" : "human",
+    });
+  }
+  return [...latestByAuthor.values()];
+}

--- a/packages/cli/src/commands/gate/index.ts
+++ b/packages/cli/src/commands/gate/index.ts
@@ -1,0 +1,74 @@
+/**
+ * design #9 — `slowcook gate check`. The dispatch-time HITL halt: refuse to let
+ * a stage proceed until a human in the required role has approved on the PR.
+ *
+ *   slowcook gate check --stage <refine|plate|brew> --pr <n> [--repo owner/name]
+ *
+ * Exit 0 = gate satisfied (advance). Exit 1 = blocked (a human in the required
+ * role(s) must approve, or a rejection must be resolved). Because approvals are
+ * classified by identity (./github.ts) and only human reviewers in the role's
+ * handle-list count (./model.ts), the automation cannot satisfy its own gate.
+ */
+import { execFileSync } from "node:child_process";
+import { loadReviewers } from "./reviewers.js";
+import { DEFAULT_GATES, isGateSatisfied, type Gate } from "./model.js";
+import { mapReviewsToApprovals, type GhReview } from "./github.js";
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function fetchReviews(repo: string, pr: string): GhReview[] {
+  const out = execFileSync("gh", ["api", `repos/${repo}/pulls/${pr}/reviews`, "--paginate"], {
+    encoding: "utf8",
+  });
+  return JSON.parse(out) as GhReview[];
+}
+
+function detectRepo(): string {
+  const out = execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+    encoding: "utf8",
+  });
+  return out.trim();
+}
+
+export async function gate(args: string[], _version: string): Promise<void> {
+  const sub = args[0];
+  if (sub !== "check") {
+    console.error("usage: slowcook gate check --stage <stage> --pr <n> [--repo owner/name]");
+    process.exit(64);
+  }
+  const rest = args.slice(1);
+  const stage = val(rest, "--stage");
+  const pr = val(rest, "--pr");
+  if (!stage || !pr) {
+    console.error("gate check: --stage and --pr are required");
+    process.exit(64);
+  }
+
+  const gateDef: Gate | undefined = DEFAULT_GATES.find((g) => g.stage === stage);
+  if (!gateDef) {
+    console.error(`gate check: no gate defined for stage '${stage}' (have: ${DEFAULT_GATES.map((g) => g.stage).join(", ")})`);
+    process.exit(64);
+  }
+
+  const repo = val(rest, "--repo") ?? detectRepo();
+  const reviewers = loadReviewers(process.cwd());
+  const approvals = mapReviewsToApprovals(fetchReviews(repo, pr));
+  const verdict = isGateSatisfied(gateDef!, reviewers, approvals);
+
+  if (verdict.satisfied) {
+    console.log(`gate '${stage}' ✓ satisfied — ${verdict.reason}`);
+    return;
+  }
+  // Blocked. Name exactly who must act.
+  const need = verdict.rejected
+    ? verdict.reason
+    : verdict.missingRoles
+        .map((r) => `${r} (${reviewers.roles[r]?.join(", ") || "no reviewers configured in .brewing/reviewers.yaml"})`)
+        .join("; ");
+  console.error(`gate '${stage}' ✗ blocked-on-review — ${verdict.reason}`);
+  console.error(`  needs approval from: ${need}`);
+  process.exit(1);
+}

--- a/packages/cli/src/commands/gate/model.test.ts
+++ b/packages/cli/src/commands/gate/model.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_GATES,
+  isGateSatisfied,
+  type Gate,
+  type Approval,
+} from "./model.js";
+import type { ReviewersConfig } from "./reviewers.js";
+
+const REFINE_GATE: Gate = DEFAULT_GATES.find((g) => g.stage === "refine")!;
+const PLATE_GATE: Gate = DEFAULT_GATES.find((g) => g.stage === "plate")!;
+const BREW_GATE: Gate = DEFAULT_GATES.find((g) => g.stage === "brew")!;
+
+const reviewers: ReviewersConfig = {
+  schema_version: 1,
+  roles: {
+    pm: ["aminazar"],
+    designer: ["some-designer"],
+    qa: ["qa-person", "another-qa"],
+  },
+};
+
+function approval(
+  byHandle: string,
+  state: Approval["state"],
+  identityType: Approval["identityType"] = "human",
+): Approval {
+  return { byHandle, state, identityType };
+}
+
+describe("DEFAULT_GATES", () => {
+  it("wires refine→[pm], plate→[designer], brew→[qa,designer]", () => {
+    expect(REFINE_GATE.requiredRoles).toEqual(["pm"]);
+    expect(PLATE_GATE.requiredRoles).toEqual(["designer"]);
+    expect(BREW_GATE.requiredRoles).toEqual(["qa", "designer"]);
+    expect(REFINE_GATE.onRejectTarget).toBe("refine");
+    expect(BREW_GATE.approvalSignal).toBe("review");
+  });
+});
+
+describe("isGateSatisfied — integrity property", () => {
+  it("a valid human approval from a configured pm satisfies the refine gate", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [approval("aminazar", "approved")]);
+    expect(v.satisfied).toBe(true);
+    expect(v.missingRoles).toEqual([]);
+    expect(v.rejected).toBe(false);
+    expect(v.reason).toBe("satisfied");
+  });
+
+  it("a BOT approval from a configured handle does NOT satisfy — bot identity is unforgeable", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [approval("aminazar", "approved", "bot")]);
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["pm"]);
+    expect(v.rejected).toBe(false);
+    expect(v.reason).toContain("missing pm");
+  });
+
+  it("a human approval from someone NOT in the role list does NOT satisfy", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [approval("random-person", "approved")]);
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["pm"]);
+  });
+
+  it("matches handles case-insensitively (AminAzar vs aminazar)", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [approval("AminAzar", "approved")]);
+    expect(v.satisfied).toBe(true);
+    expect(v.missingRoles).toEqual([]);
+  });
+
+  it("brew gate needs BOTH qa AND designer — only-qa is missing ['designer']", () => {
+    const v = isGateSatisfied(BREW_GATE, reviewers, [approval("qa-person", "approved")]);
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["designer"]);
+    expect(v.reason).toContain("missing designer");
+  });
+
+  it("brew gate satisfied when both qa and designer approve", () => {
+    const v = isGateSatisfied(BREW_GATE, reviewers, [
+      approval("another-qa", "approved"),
+      approval("some-designer", "approved"),
+    ]);
+    expect(v.satisfied).toBe(true);
+    expect(v.missingRoles).toEqual([]);
+    expect(v.rejected).toBe(false);
+  });
+
+  it("a valid human rejection → rejected:true, satisfied:false even if another role approved", () => {
+    const v = isGateSatisfied(BREW_GATE, reviewers, [
+      approval("qa-person", "rejected"),
+      approval("some-designer", "approved"),
+    ]);
+    expect(v.rejected).toBe(true);
+    expect(v.satisfied).toBe(false);
+    expect(v.reason).toContain("rejected by qa");
+  });
+
+  it("a BOT rejection does not count as a valid rejection", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [
+      approval("aminazar", "rejected", "bot"),
+    ]);
+    expect(v.rejected).toBe(false);
+    // still unsatisfied — no valid approval either
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["pm"]);
+  });
+
+  it("an empty reviewers config for a required role can never be satisfied", () => {
+    const empty: ReviewersConfig = { schema_version: 1, roles: {} };
+    const v = isGateSatisfied(REFINE_GATE, empty, [approval("aminazar", "approved")]);
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["pm"]);
+  });
+
+  it("a 'commented' signal (not approved) does not satisfy", () => {
+    const v = isGateSatisfied(REFINE_GATE, reviewers, [approval("aminazar", "commented")]);
+    expect(v.satisfied).toBe(false);
+    expect(v.missingRoles).toEqual(["pm"]);
+  });
+});

--- a/packages/cli/src/commands/gate/model.ts
+++ b/packages/cli/src/commands/gate/model.ts
@@ -1,0 +1,110 @@
+/**
+ * design #9 — HITL role gates: the gate-integrity core.
+ *
+ * Decides whether a pipeline stage may proceed past a human-review gate.
+ * The load-bearing security property: an approval only counts if it
+ * comes from a HUMAN identity that is in the configured handle-list for
+ * the required role. A bot/agent approval, or an approval from someone
+ * not assigned that role, NEVER satisfies a gate. This is what makes the
+ * halt unforgeable by the automation driving the pipeline.
+ */
+import { resolveRole, type ReviewersConfig } from "./reviewers.js";
+
+export type Role = "pm" | "designer" | "qa";
+export type Stage = "refine" | "plate" | "brew" | string;
+
+export interface Gate {
+  stage: Stage;
+  requiredRoles: Role[];
+  approvalSignal: "review" | "comment";
+  onRejectTarget: Stage;
+}
+
+export interface Approval {
+  /** GitHub handle of the approver. */
+  byHandle: string;
+  state: "approved" | "rejected" | "commented";
+  /** bot = slowcook-*[bot] / the driving agent; human = a real reviewer. */
+  identityType: "human" | "bot";
+}
+
+export interface GateVerdict {
+  satisfied: boolean;
+  /** required roles lacking a valid human approval. */
+  missingRoles: Role[];
+  /** a valid human reviewer for a required role rejected. */
+  rejected: boolean;
+  /** human-readable summary. */
+  reason: string;
+}
+
+/**
+ * The standard pipeline gates. refine is signed off by a PM, plate by a
+ * designer, and brew needs BOTH qa and designer before code ships.
+ */
+export const DEFAULT_GATES: Gate[] = [
+  { stage: "refine", requiredRoles: ["pm"], approvalSignal: "review", onRejectTarget: "refine" },
+  { stage: "plate", requiredRoles: ["designer"], approvalSignal: "review", onRejectTarget: "plate" },
+  { stage: "brew", requiredRoles: ["qa", "designer"], approvalSignal: "review", onRejectTarget: "brew" },
+];
+
+/**
+ * True when `approvals` contains an approval in `state` for role `role`
+ * that is BOTH human-authored AND from a handle configured for that role
+ * in `reviewers`. Handle matching is case-insensitive (both sides
+ * lowercased). This is the single chokepoint enforcing the integrity
+ * property — a bot identity or an unconfigured handle can never pass.
+ */
+function hasValidSignal(
+  reviewers: ReviewersConfig,
+  approvals: Approval[],
+  role: Role,
+  state: "approved" | "rejected",
+): boolean {
+  const allowed = new Set(resolveRole(reviewers, role)); // already lowercased on load
+  return approvals.some(
+    (a) =>
+      a.identityType === "human" &&
+      a.state === state &&
+      allowed.has(a.byHandle.toLowerCase()),
+  );
+}
+
+/**
+ * Evaluate a gate against the reviewer roster and the observed approvals.
+ *
+ * - A valid approval for role R = human + state 'approved' + handle in
+ *   the role's configured list.
+ * - A valid rejection for role R = same, but state 'rejected'.
+ * - `rejected` is true if ANY required role has a valid rejection; a
+ *   rejected gate is never satisfied (and routes back to onRejectTarget,
+ *   handled by the caller).
+ * - `missingRoles` lists required roles with no valid approval.
+ * - `satisfied` requires every required role to have a valid approval
+ *   AND no valid rejection.
+ */
+export function isGateSatisfied(
+  gate: Gate,
+  reviewers: ReviewersConfig,
+  approvals: Approval[],
+): GateVerdict {
+  const rejectingRoles = gate.requiredRoles.filter((role) =>
+    hasValidSignal(reviewers, approvals, role, "rejected"),
+  );
+  const missingRoles = gate.requiredRoles.filter(
+    (role) => !hasValidSignal(reviewers, approvals, role, "approved"),
+  );
+  const rejected = rejectingRoles.length > 0;
+  const satisfied = !rejected && missingRoles.length === 0;
+
+  let reason: string;
+  if (rejected) {
+    reason = `rejected by ${rejectingRoles.join(", ")}`;
+  } else if (missingRoles.length > 0) {
+    reason = `blocked: missing ${missingRoles.join(", ")} approval`;
+  } else {
+    reason = "satisfied";
+  }
+
+  return { satisfied, missingRoles, rejected, reason };
+}

--- a/packages/cli/src/commands/gate/reviewers.test.ts
+++ b/packages/cli/src/commands/gate/reviewers.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadReviewers, resolveRole } from "./reviewers.js";
+
+function makeRepo(): string {
+  return mkdtempSync(join(tmpdir(), "reviewers-test-"));
+}
+
+function writeReviewers(repo: string, body: string): void {
+  mkdirSync(join(repo, ".brewing"), { recursive: true });
+  writeFileSync(join(repo, ".brewing", "reviewers.yaml"), body, "utf8");
+}
+
+describe("loadReviewers", () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  it("returns empty roster default when the file is absent", () => {
+    const out = loadReviewers(repo);
+    expect(out.schema_version).toBe(1);
+    expect(out.roles).toEqual({});
+  });
+
+  it("parses a valid roster and lowercases handles", () => {
+    writeReviewers(
+      repo,
+      `schema_version: 1
+roles:
+  pm: [AminAzar]
+  designer: [Some-Designer]
+  qa: [QA-Person, Another-QA]
+`,
+    );
+    const out = loadReviewers(repo);
+    expect(out.roles.pm).toEqual(["aminazar"]);
+    expect(out.roles.designer).toEqual(["some-designer"]);
+    expect(out.roles.qa).toEqual(["qa-person", "another-qa"]);
+  });
+
+  it("accepts a roster with no roles block (defaults to {})", () => {
+    writeReviewers(repo, `schema_version: 1\n`);
+    const out = loadReviewers(repo);
+    expect(out.roles).toEqual({});
+  });
+
+  it("throws on schema violation (wrong schema_version)", () => {
+    writeReviewers(repo, `schema_version: 2\nroles: {}\n`);
+    expect(() => loadReviewers(repo)).toThrow(/reviewers\.yaml/);
+  });
+
+  it("throws on malformed yaml", () => {
+    writeReviewers(repo, `schema_version: 1\nroles: [: : :\n`);
+    expect(() => loadReviewers(repo)).toThrow();
+  });
+});
+
+describe("resolveRole", () => {
+  it("returns the configured (lowercased) handles for a role", () => {
+    const cfg = { schema_version: 1 as const, roles: { qa: ["qa-person", "another-qa"] } };
+    expect(resolveRole(cfg, "qa")).toEqual(["qa-person", "another-qa"]);
+  });
+
+  it("returns [] for an unknown / unset role", () => {
+    const cfg = { schema_version: 1 as const, roles: { pm: ["aminazar"] } };
+    expect(resolveRole(cfg, "designer")).toEqual([]);
+  });
+
+  it("returns [] for an empty roster", () => {
+    expect(resolveRole({ schema_version: 1, roles: {} }, "pm")).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/gate/reviewers.ts
+++ b/packages/cli/src/commands/gate/reviewers.ts
@@ -1,0 +1,77 @@
+/**
+ * design #9 — HITL role gates: reviewer roster.
+ *
+ * Reads `.brewing/reviewers.yaml` to map review roles (pm, designer, qa,
+ * …) to the GitHub handles authorised to satisfy that role's gate. This
+ * roster is the trust anchor for the gate-integrity core: an approval
+ * only counts if its author is a configured handle for the required
+ * role (see `./model.js`).
+ *
+ * Handles are lowercased on load so downstream matching against the
+ * (also lowercased) approver handle is case-insensitive — GitHub login
+ * comparison is case-insensitive and a gate must not be bypassable by a
+ * casing mismatch.
+ *
+ * Single source of truth: nothing else should hard-code the roster
+ * location or shape.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+import { z } from "zod";
+
+const ReviewersConfigSchema = z.object({
+  schema_version: z.literal(1),
+  // role -> list of GitHub handles. Lowercased on load (see transform).
+  roles: z
+    .record(z.string(), z.array(z.string()))
+    .default({})
+    .transform((roles) => {
+      const out: Record<string, string[]> = {};
+      for (const [role, handles] of Object.entries(roles)) {
+        out[role] = handles.map((h) => h.toLowerCase());
+      }
+      return out;
+    }),
+});
+
+export type ReviewersConfig = z.infer<typeof ReviewersConfigSchema>;
+
+const EMPTY_DEFAULT: ReviewersConfig = {
+  schema_version: 1,
+  roles: {},
+};
+
+/**
+ * Load `.brewing/reviewers.yaml`. Returns an empty roster
+ * (`{ schema_version: 1, roles: {} }`) when the file is absent — a repo
+ * with no roster has no configured reviewers, so every role gate is
+ * unsatisfiable until one is authored (fail-closed). Throws on parse
+ * error / schema violation so a mis-authored roster surfaces loudly
+ * rather than silently granting or denying approvals.
+ */
+export function loadReviewers(repoRoot: string): ReviewersConfig {
+  const p = join(repoRoot, ".brewing", "reviewers.yaml");
+  if (!existsSync(p)) {
+    return { schema_version: 1, roles: {} };
+  }
+  const raw = YAML.parse(readFileSync(p, "utf8"));
+  const parsed = ReviewersConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid .brewing/reviewers.yaml: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * Returns the configured handles for a role (already lowercased), or an
+ * empty array when the role is unset. An empty array means the role can
+ * never be satisfied — fail-closed by design.
+ */
+export function resolveRole(cfg: ReviewersConfig, role: string): string[] {
+  return cfg.roles[role] ?? [];
+}
+
+export { EMPTY_DEFAULT };

--- a/packages/cli/src/commands/recon/shape-preserve.test.ts
+++ b/packages/cli/src/commands/recon/shape-preserve.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractElementClasses,
+  isUtilityShaped,
+  synthesiseShapeTestFile,
+  type ExtractedShape,
+} from "./shape-preserve.js";
+
+describe("isUtilityShaped (design #10)", () => {
+  it("keeps lowercase bare utilities", () => {
+    for (const t of ["flex", "grid", "block", "hidden", "relative"]) {
+      expect(isUtilityShaped(t)).toBe(true);
+    }
+  });
+  it("keeps dashed / colon / bracket utilities", () => {
+    for (const t of ["bg-primary", "px-4", "hover:bg-primary/90", "min-h-[44px]", "focus-visible:ring-2"]) {
+      expect(isUtilityShaped(t)).toBe(true);
+    }
+  });
+  it("drops capitalised identifiers + empties", () => {
+    for (const t of ["Button", "Root", ""]) {
+      expect(isUtilityShaped(t)).toBe(false);
+    }
+  });
+});
+
+describe("extractElementClasses (design #10)", () => {
+  it("extracts the FULL utility set, not just an allowlist subset", () => {
+    const src = `<button data-testid="cta" className="bg-primary px-4 py-3 text-sm font-medium shadow-md gap-2 rounded-lg">Go</button>`;
+    const facts = extractElementClasses(src);
+    expect(facts).toHaveLength(1);
+    expect(facts[0].testid).toBe("cta");
+    // every token is captured — the pre-#10 allowlist would only keep rounded-lg
+    expect(facts[0].tokens).toEqual([
+      "bg-primary", "px-4", "py-3", "text-sm", "font-medium", "shadow-md", "gap-2", "rounded-lg",
+    ]);
+  });
+
+  it("keeps state + responsive variant tokens", () => {
+    const src = `<a data-testid="link" className="text-blue-600 hover:underline md:text-lg focus-visible:ring-2">x</a>`;
+    expect(extractElementClasses(src)[0].tokens).toEqual([
+      "text-blue-600", "hover:underline", "md:text-lg", "focus-visible:ring-2",
+    ]);
+  });
+
+  it("records null testid for unanchored elements (with tokens)", () => {
+    const facts = extractElementClasses(`<div className="flex gap-2">x</div>`);
+    expect(facts).toEqual([{ testid: null, tokens: ["flex", "gap-2"] }]);
+  });
+
+  it("skips dynamic / CSS-module classNames (paradigm-aware — avoids over-extraction)", () => {
+    expect(extractElementClasses(`<div className={styles.root}>x</div>`)).toEqual([]);
+    expect(extractElementClasses(`<div className={cx("a", cond && "b")}>x</div>`)).toEqual([]);
+    expect(extractElementClasses("<div className={`p-2 ${active ? 'on' : 'off'}`}>x</div>")).toEqual([]);
+  });
+
+  it("reads a plain backtick literal (no interpolation)", () => {
+    expect(extractElementClasses("<div className=`flex p-4`>x</div>")[0].tokens).toEqual(["flex", "p-4"]);
+  });
+
+  it("dedupes repeated tokens on one element", () => {
+    expect(extractElementClasses(`<div className="flex flex gap-2">x</div>`)[0].tokens).toEqual(["flex", "gap-2"]);
+  });
+
+  it("ignores elements with no utility tokens", () => {
+    expect(extractElementClasses(`<span>plain</span>`)).toEqual([]);
+  });
+});
+
+describe("synthesiseShapeTestFile — #10 containment emission", () => {
+  const shape: ExtractedShape = {
+    file: "mock/src/components/Cta.tsx",
+    componentName: "Cta",
+    testids: ["cta"],
+    visualTokens: ["rounded-lg"],
+    hasHeader: false,
+    elementClasses: [{ testid: "cta", tokens: ["bg-primary", "px-4", "rounded-lg"] }],
+  };
+
+  it("v2 emits per-testid containment that keeps the mock token set", () => {
+    const out = synthesiseShapeTestFile({ story: "020", emitMode: "v2", shapes: [shape] });
+    expect(out).toContain("[data-testid=cta] keeps mock class tokens");
+    expect(out).toContain(`queryByTestId("cta")`);
+    expect(out).toContain(`["bg-primary","px-4","rounded-lg"].filter((t) => !have.includes(t))`);
+    expect(out).toContain(`expect(missing, "dropped mock class tokens").toEqual([]);`);
+  });
+
+  it("v1 emits dense file-level token containment for non-allowlist tokens", () => {
+    const out = synthesiseShapeTestFile({ story: "020", emitMode: "v1", shapes: [shape] });
+    // dense tokens NOT already in visualTokens get a containment assertion
+    expect(out).toContain(`preserves mock class token 'bg-primary'`);
+    expect(out).toContain(`expect(src).toContain("bg-primary");`);
+    expect(out).toContain(`preserves mock class token 'px-4'`);
+    // rounded-lg is already a visualToken → not duplicated as a dense token
+    expect(out).not.toContain(`preserves mock class token 'rounded-lg'`);
+  });
+
+  it("does not emit #10 containment when elementClasses is absent (back-compat)", () => {
+    const legacy: ExtractedShape = {
+      file: "mock/src/components/Old.tsx",
+      componentName: "Old",
+      testids: ["old"],
+      visualTokens: ["rounded-full"],
+      hasHeader: false,
+    };
+    const out = synthesiseShapeTestFile({ story: "001", emitMode: "v2", shapes: [legacy] });
+    expect(out).not.toContain("keeps mock class tokens");
+  });
+});

--- a/packages/cli/src/commands/recon/shape-preserve.ts
+++ b/packages/cli/src/commands/recon/shape-preserve.ts
@@ -33,6 +33,23 @@ export interface ExtractedShape {
   hasHeader: boolean;
   /** Component name (best-effort). */
   componentName: string | null;
+  /**
+   * design #10 — dense, paradigm-aware per-element class facts. Unlike
+   * `visualTokens` (filtered through the 17-item TOKENS_OF_INTEREST
+   * allowlist), this captures the element's *actual* utility-class set so
+   * the shape test can assert `brewed ⊇ mock` containment per element and
+   * drift can't hide in unpinned classes. Optional + additive: absent on
+   * hand-built fixtures and pre-#10 callers.
+   */
+  elementClasses?: ElementClassFacts[];
+}
+
+/** design #10 — one element's testid anchor + its utility-class tokens. */
+export interface ElementClassFacts {
+  /** data-testid on the element, or null (anchor for per-element assertions). */
+  testid: string | null;
+  /** Utility-shaped class tokens on the element (string-literal classNames only). */
+  tokens: string[];
 }
 
 const TOKENS_OF_INTEREST = [
@@ -63,8 +80,73 @@ export function extractShape(absFile: string, repoRoot: string): ExtractedShape 
   const testids = [...new Set(extractTestids(cleaned))];
   const visualTokens = [...new Set(extractTokens(cleaned, TOKENS_OF_INTEREST))];
   const hasHeader = /<header\b/.test(cleaned);
+  const elementClasses = extractElementClasses(cleaned);
 
-  return { file: fileRel, testids, visualTokens, hasHeader, componentName };
+  return { file: fileRel, testids, visualTokens, hasHeader, componentName, elementClasses };
+}
+
+/**
+ * design #10 — extract per-element utility-class facts from a (mock-chrome-
+ * stripped) source. Paradigm-aware: only reads STRING-LITERAL classNames
+ * (`className="..."` / `'...'` / plain backtick). `className={...}` brace
+ * expressions — CSS-modules (`{styles.x}`), `cx(...)`, conditional template
+ * literals with `${}` — are SKIPPED, because their tokens are either hashed
+ * identifiers (noise, not design intent) or computed; extracting them would
+ * be over-extraction. Styling fidelity for those mocks defers to the #8 eye.
+ *
+ * Pairs each element's tokens with its `data-testid` (the stable anchor for
+ * per-element containment assertions). Only elements carrying ≥1 utility
+ * token are returned.
+ */
+export function extractElementClasses(source: string): ElementClassFacts[] {
+  const facts: ElementClassFacts[] = [];
+  // Iterate JSX opening tags (and self-closing). Attr blob is captured
+  // non-greedily up to the tag close.
+  for (const m of source.matchAll(/<[A-Za-z][\w.]*\b([^>]*?)\/?>/g)) {
+    const attrs = m[1] ?? "";
+    const className = literalClassName(attrs);
+    if (className === null) continue; // dynamic/module/no className → skip
+    const tokens = className
+      .split(/\s+/)
+      .map((t) => t.trim())
+      .filter((t) => isUtilityShaped(t));
+    if (tokens.length === 0) continue;
+    const tidMatch = attrs.match(/data-testid\s*=\s*["']([^"']+)["']/);
+    facts.push({
+      testid: tidMatch?.[1] ?? null,
+      tokens: [...new Set(tokens)],
+    });
+  }
+  return facts;
+}
+
+/**
+ * Return the string-literal value of a `className` attribute from a tag's
+ * attr blob, or null when the className is absent or a brace expression
+ * (`className={...}` — dynamic/module/computed; intentionally not read).
+ * Plain backtick literals are read only when they contain no `${}`.
+ */
+function literalClassName(attrs: string): string | null {
+  const dq = attrs.match(/className\s*=\s*"([^"]*)"/);
+  if (dq) return dq[1] ?? "";
+  const sq = attrs.match(/className\s*=\s*'([^']*)'/);
+  if (sq) return sq[1] ?? "";
+  const bt = attrs.match(/className\s*=\s*`([^`]*)`/);
+  if (bt && !bt[1]?.includes("${")) return bt[1] ?? "";
+  return null;
+}
+
+/**
+ * Heuristic: is `t` a utility-class token (Tailwind-shaped) rather than a
+ * component/module identifier? Keeps lowercase-led tokens + any token with
+ * a utility marker (`-`, `:`, `[`); drops capitalised identifiers and the
+ * empty string. Errs permissive — string-literal classNames in a utility
+ * mock are virtually all utilities.
+ */
+export function isUtilityShaped(t: string): boolean {
+  if (!t) return false;
+  if (/[-:[]/.test(t)) return true; // bg-primary, hover:..., min-h-[44px]
+  return /^[a-z][a-z0-9]*$/.test(t); // flex, grid, block, hidden, relative
 }
 
 /**
@@ -315,6 +397,23 @@ export function synthesiseShapeTestFileV2(opts: SynthOpts): string {
         lines.push(`      expect(container.querySelector("header")).toBeTruthy();`);
         lines.push(`    });`);
       }
+      // design #10 — per-element class containment (brewed ⊇ mock), anchored
+      // by testid. Asserts the rendered element keeps the mock's utility-class
+      // set; brew may ADD real-data classes (containment, not equality) but
+      // not DROP the mock's styling.
+      for (const ec of shape.elementClasses ?? []) {
+        if (!ec.testid || ec.tokens.length === 0) continue;
+        lines.push(`    it("[data-testid=${ec.testid}] keeps mock class tokens", () => {`);
+        lines.push(`      const { queryByTestId } = render(<${cn} />);`);
+        lines.push(`      const el = queryByTestId(${JSON.stringify(ec.testid)});`);
+        lines.push(
+          `      expect(el, ${JSON.stringify(`expected [data-testid=${ec.testid}] in rendered <${cn} />`)}).toBeTruthy();`,
+        );
+        lines.push(`      const have = (el?.getAttribute("class") ?? "").split(/\\s+/);`);
+        lines.push(`      const missing = ${JSON.stringify(ec.tokens)}.filter((t) => !have.includes(t));`);
+        lines.push(`      expect(missing, "dropped mock class tokens").toEqual([]);`);
+        lines.push(`    });`);
+      }
       lines.push(`  });`);
       lines.push(``);
     }
@@ -377,6 +476,17 @@ function synthesiseShapeTestFileV1(opts: SynthOpts): string {
       for (const token of shape.visualTokens) {
         lines.push(`    it("preserves visual token '${token}'", () => {`);
         lines.push(`      expect(src).toMatch(/className=[^>]*\\b${escapeRegexForTest(token)}\\b/);`);
+        lines.push(`    });`);
+      }
+      // design #10 — dense token containment (file-level, source-grep).
+      // Coarse vs v2's per-element render assertion, but robust to bracket/
+      // colon/slash tokens; ensures the mock's full utility set survives brew.
+      const denseTokens = [...new Set((shape.elementClasses ?? []).flatMap((e) => e.tokens))].filter(
+        (t) => !shape.visualTokens.includes(t),
+      );
+      for (const token of denseTokens) {
+        lines.push(`    it("preserves mock class token '${token}'", () => {`);
+        lines.push(`      expect(src).toContain(${JSON.stringify(token)});`);
         lines.push(`    });`);
       }
       if (shape.hasHeader) {

--- a/packages/cli/src/commands/recon/shape-preserve.ts
+++ b/packages/cli/src/commands/recon/shape-preserve.ts
@@ -414,6 +414,25 @@ export function synthesiseShapeTestFileV2(opts: SynthOpts): string {
         lines.push(`      expect(missing, "dropped mock class tokens").toEqual([]);`);
         lines.push(`    });`);
       }
+      // design #10 — no-testid dense coverage: tokens on unanchored elements
+      // can't be matched per-element, so assert each survives SOMEWHERE in the
+      // rendered tree (file-level containment via [class*=]). Excludes tokens
+      // already covered by a testid-anchored or visualToken assertion.
+      const anchoredV2 = new Set((shape.elementClasses ?? []).filter((e) => e.testid).flatMap((e) => e.tokens));
+      const noTestidTokens = [
+        ...new Set(
+          (shape.elementClasses ?? [])
+            .filter((e) => !e.testid)
+            .flatMap((e) => e.tokens)
+            .filter((t) => !anchoredV2.has(t) && !shape.visualTokens.includes(t)),
+        ),
+      ];
+      for (const token of noTestidTokens) {
+        lines.push(`    it("rendered DOM keeps mock class token '${token}'", () => {`);
+        lines.push(`      const { container } = render(<${cn} />);`);
+        lines.push(`      expect(container.querySelector('[class*="${token}"]')).toBeTruthy();`);
+        lines.push(`    });`);
+      }
       lines.push(`  });`);
       lines.push(``);
     }

--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -141,6 +141,18 @@ Full doc: [\`docs/local-pipeline-role.md\`](https://github.com/aminazar/slowcook
 
 Recorded sc#145 finding 6 — pattern emerged from the delgoosh dogfood (2026-05) and shipped 5 batches of slowcook feedback as a side effect.
 
+### HITL review gates — you cannot self-advance past one (design #9)
+
+Some stage transitions are gated on a HUMAN review by a named role (PM / designer / QA), configured in \`.brewing/reviewers.yaml\`. Default gates: refine spec → PM; vibe/plate mock → designer; brew output → QA + designer.
+
+This is a HARD halt, and the integrity of it depends on you NOT bypassing it:
+- **Do not advance a story past a gated stage until \`slowcook gate check --stage <stage> --pr <n>\` exits 0.** Run it; don't assume.
+- **Your own approval does NOT count, and you must not manufacture one.** A valid approval is a GitHub PR review (state \`APPROVED\`) from a *human* handle listed for the required role. Reviews from \`slowcook-*[bot]\`, \`github-actions\`, or the agent identity are classified as bot and never satisfy a gate — do not try to approve your own PR, ask a teammate to "rubber-stamp", or label your way around the gate.
+- **A \`CHANGES_REQUESTED\` from a required-role human is a hard stop.** Address it and re-request review; loop back to the gate's \`on_reject_target\` stage (designer reject of a mock → back to plate, not forward to brew).
+- **If a gate blocks you, surface it to the PM** ("blocked-on-\<role\>: needs designer approval on PR #N") rather than working around it. The gate exists because the human's eyes are the contract at that point.
+
+The bot pipeline enforces the same gate via \`.github/workflows/slowcook-gate.yml\`; the local pipeline enforces it by your honouring this section.
+
 ### Working alongside other agents (multi-agent choreography)
 
 When your work depends on another agent's still-open PR — common when one agent owns the app shell + another owns a feature inside it — follow this:

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../stack-ts" },
     { "path": "../forge-github" },
     { "path": "../llm-anthropic" },
-    { "path": "../recorder" }
+    { "path": "../recorder" },
+    { "path": "../gates" }
   ]
 }

--- a/packages/forge-github/src/templates.ts
+++ b/packages/forge-github/src/templates.ts
@@ -875,6 +875,105 @@ jobs:
 `;
 }
 
+function slowcookEyeCleanupWorkflow(): string {
+  return `name: slowcook eye cleanup
+
+# design #8 — trigger-based eye-artifact cleanup. When a PR closes (merged or
+# not), delete its full-res eye render/snapshot artifacts. The review thumbnail
+# lives in the PR comment + the eye-review branch, so nothing reviewable is
+# lost; full renders regenerate from the mock at the merged SHA. Artifacts are
+# uploaded by slowcook-acceptance as \`eye-pr-<N>-<viewport>-<scheme>\`.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to clean up"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete eye artifacts for this PR
+        env:
+          GH_TOKEN: \${{ github.token }}
+          PR: \${{ github.event.pull_request.number || github.event.inputs.pr }}
+          REPO: \${{ github.repository }}
+        run: |
+          prefix="eye-pr-\${PR}-"
+          echo "Deleting eye artifacts with prefix \${prefix}"
+          gh api --paginate "repos/\${REPO}/actions/artifacts" \\
+            --jq ".artifacts[] | select(.name | startswith(\\"\${prefix}\\")) | .id" \\
+          | while read -r id; do
+              echo "  rm artifact \${id}"
+              gh api -X DELETE "repos/\${REPO}/actions/artifacts/\${id}" || true
+            done
+`;
+}
+
+function slowcookGateWorkflow(cliVersion: string): string {
+  return `name: slowcook HITL gate
+
+# design #9 — the human-review halt. On every PR review submission (and on
+# demand) re-evaluate the stage gate: a stage may only advance once a HUMAN in
+# the required role (.brewing/reviewers.yaml) has approved. A bot/agent review
+# never satisfies the gate. Stage is derived from the slowcook branch prefix.
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Resolve stage from branch
+        id: stage
+        env:
+          HEAD: \${{ github.event.pull_request.head.ref || github.head_ref }}
+        run: |
+          case "\${HEAD}" in
+            slowcook/brew/*)   echo "stage=brew"   >> "\$GITHUB_OUTPUT" ;;
+            slowcook/plate/*)  echo "stage=plate"  >> "\$GITHUB_OUTPUT" ;;
+            slowcook/vibe/*)   echo "stage=plate"  >> "\$GITHUB_OUTPUT" ;;
+            slowcook/refine/*) echo "stage=refine" >> "\$GITHUB_OUTPUT" ;;
+            *)                 echo "stage=" >> "\$GITHUB_OUTPUT" ;;
+          esac
+      - name: Evaluate gate
+        if: steps.stage.outputs.stage != ''
+        env:
+          GH_TOKEN: \${{ github.token }}
+          PR: \${{ github.event.pull_request.number || github.event.inputs.pr }}
+          REPO: \${{ github.repository }}
+        run: |
+          npx --yes @slowcook-ai/cli@${cliVersion} gate check \\
+            --stage "\${{ steps.stage.outputs.stage }}" --pr "\${PR}" --repo "\${REPO}"
+`;
+}
+
 export function getGitHubCiArtifacts(params: {
   cliVersion: string;
   /** Consumer package manager (slowcook#25). Defaults to npm. */
@@ -909,6 +1008,10 @@ export function getGitHubCiArtifacts(params: {
     // PRs. refine's in-process lint never re-fires on commits that bypass
     // refine, so a workflow check catches drift after merge.
     { path: ".github/workflows/slowcook-spec-validate.yml", contents: slowcookSpecValidateWorkflow() },
+    // design #8 — trigger-based eye-artifact cleanup on PR close.
+    { path: ".github/workflows/slowcook-eye-cleanup.yml", contents: slowcookEyeCleanupWorkflow() },
+    // design #9 — HITL role gate: re-evaluated on every PR review submission.
+    { path: ".github/workflows/slowcook-gate.yml", contents: slowcookGateWorkflow(params.cliVersion) },
   ];
 }
 

--- a/packages/gates/src/fidelity/diff.test.ts
+++ b/packages/gates/src/fidelity/diff.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { diffSnapshots, summariseFidelity } from "./diff.js";
+import type { ElementSnapshot, SnapshotContext, StyleSnapshot } from "./snapshot.js";
+
+const CTX: SnapshotContext = { viewport: "desktop", scheme: "light" };
+
+function el(
+  selector: string,
+  styles: Record<string, string> = {},
+  box: ElementSnapshot["box"] = { x: 0, y: 0, width: 100, height: 40 }
+): ElementSnapshot {
+  return { selector, styles, box };
+}
+
+function snap(elements: ElementSnapshot[], context: SnapshotContext = CTX): StyleSnapshot {
+  return { context, elements };
+}
+
+describe("diffSnapshots", () => {
+  it("returns no violations for identical snapshots", () => {
+    const a = snap([el(".hero", { "padding-top": "16px", color: "rgb(0, 0, 0)" })]);
+    const b = snap([el(".hero", { "padding-top": "16px", color: "rgb(0, 0, 0)" })]);
+    expect(diffSnapshots(a, b)).toEqual([]);
+  });
+
+  it("flags a computed-style divergence with a hard fix-signal", () => {
+    const ref = snap([el(".cta", { "padding-top": "16px" })]);
+    const cand = snap([el(".cta", { "padding-top": "12px" })]);
+    const v = diffSnapshots(ref, cand);
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatchObject({
+      selector: ".cta",
+      axis: "computed-style",
+      property: "padding-top",
+      expected: "16px",
+      actual: "12px",
+    });
+    expect(v[0].evidence).toBe(".cta: padding-top 16px → 12px");
+  });
+
+  it("tags color properties with the color axis", () => {
+    const ref = snap([el(".cta", { "background-color": "rgb(26, 26, 26)" })]);
+    const cand = snap([el(".cta", { "background-color": "rgb(34, 34, 34)" })]);
+    const v = diffSnapshots(ref, cand);
+    expect(v).toHaveLength(1);
+    expect(v[0].axis).toBe("color");
+    expect(v[0].property).toBe("background-color");
+  });
+
+  it("reports a reference element missing from the candidate", () => {
+    const ref = snap([el(".hero"), el(".footer")]);
+    const cand = snap([el(".hero")]);
+    const v = diffSnapshots(ref, cand);
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatchObject({ selector: ".footer", axis: "missing" });
+  });
+
+  it("ignores candidate-only elements (extra prod chrome is allowed)", () => {
+    const ref = snap([el(".hero")]);
+    const cand = snap([el(".hero"), el(".analytics-pixel")]);
+    expect(diffSnapshots(ref, cand)).toEqual([]);
+  });
+
+  it("flags box-dimension divergence beyond tolerance", () => {
+    const ref = snap([el(".card", {}, { x: 0, y: 0, width: 320, height: 200 })]);
+    const cand = snap([el(".card", {}, { x: 0, y: 0, width: 300, height: 200 })]);
+    const v = diffSnapshots(ref, cand);
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatchObject({ axis: "box", property: "width" });
+    expect(v[0].evidence).toBe(".card: width 320px → 300px (Δ-20px)");
+  });
+
+  it("respects box tolerance (sub-pixel jitter ignored)", () => {
+    const ref = snap([el(".card", {}, { x: 0, y: 0, width: 320, height: 200 })]);
+    const cand = snap([el(".card", {}, { x: 0, y: 0, width: 321, height: 200 })]);
+    expect(diffSnapshots(ref, cand, { boxTolerancePx: 1 })).toEqual([]);
+  });
+
+  it("does not flag a candidate style key absent from the reference", () => {
+    // reference is the contract; only graded reference props are compared
+    const ref = snap([el(".hero", { color: "rgb(0, 0, 0)" })]);
+    const cand = snap([el(".hero", { color: "rgb(0, 0, 0)", opacity: "0.5" })]);
+    expect(diffSnapshots(ref, cand)).toEqual([]);
+  });
+
+  it("matches the first candidate occurrence for a duplicated selector", () => {
+    const ref = snap([el(".item", { color: "rgb(0, 0, 0)" })]);
+    const cand = snap([
+      el(".item", { color: "rgb(0, 0, 0)" }),
+      el(".item", { color: "rgb(255, 0, 0)" }),
+    ]);
+    expect(diffSnapshots(ref, cand)).toEqual([]);
+  });
+
+  it("carries the reference capture context onto every violation", () => {
+    const ctx: SnapshotContext = { viewport: "mobile", scheme: "dark", step: "after:click submit" };
+    const ref = snap([el(".cta", { "padding-top": "16px" })], ctx);
+    const cand = snap([el(".cta", { "padding-top": "12px" })], ctx);
+    expect(diffSnapshots(ref, cand)[0].context).toEqual(ctx);
+  });
+
+  it("accumulates multiple violations on one element", () => {
+    const ref = snap([el(".cta", { "padding-top": "16px", color: "rgb(0, 0, 0)" })]);
+    const cand = snap([el(".cta", { "padding-top": "12px", color: "rgb(255, 255, 255)" })]);
+    expect(diffSnapshots(ref, cand)).toHaveLength(2);
+  });
+});
+
+describe("summariseFidelity", () => {
+  it("counts total + per-axis", () => {
+    const ref = snap([
+      el(".cta", { "padding-top": "16px", color: "rgb(0, 0, 0)" }, { x: 0, y: 0, width: 320, height: 40 }),
+      el(".gone"),
+    ]);
+    const cand = snap([
+      el(".cta", { "padding-top": "12px", color: "rgb(255, 255, 255)" }, { x: 0, y: 0, width: 300, height: 40 }),
+    ]);
+    const summary = summariseFidelity(diffSnapshots(ref, cand));
+    expect(summary).toEqual({
+      total: 4,
+      byAxis: { "computed-style": 1, color: 1, box: 1, missing: 1 },
+    });
+  });
+
+  it("zeroes cleanly for no violations", () => {
+    expect(summariseFidelity([])).toEqual({
+      total: 0,
+      byAxis: { "computed-style": 0, color: 0, box: 0, missing: 0 },
+    });
+  });
+});

--- a/packages/gates/src/fidelity/diff.ts
+++ b/packages/gates/src/fidelity/diff.ts
@@ -1,0 +1,142 @@
+import {
+  COLOR_PROPS,
+  type ElementSnapshot,
+  type SnapshotContext,
+  type StyleSnapshot,
+} from "./snapshot.js";
+
+/**
+ * Pure fidelity diff (design #8). Compares a reference snapshot (the
+ * `references.visual` render — the target) against a candidate snapshot
+ * (brew output) and emits a flat list of `FidelityViolation`s: hard,
+ * per-element, per-property fix-signals brew can act on directly
+ * ("`.hero-cta`: padding-top 12px → 16px"), rather than a soft "looks off".
+ *
+ * Pure + browser-free → fully unit-tested here. The Playwright capture
+ * that produces the snapshots lives in ./snapshot.ts.
+ */
+
+export type FidelityAxis = "computed-style" | "color" | "box" | "missing";
+
+export interface FidelityViolation {
+  /** Reference selector of the offending element. */
+  selector: string;
+  axis: FidelityAxis;
+  /** CSS property or box dimension that diverged (e.g. "padding-top", "width"). */
+  property: string;
+  /** Reference (target) value. */
+  expected: string;
+  /** Candidate (brew output) value. */
+  actual: string;
+  /** Agent/human-facing one-line fix instruction. */
+  evidence: string;
+  /** Capture context the violation was found in. */
+  context: SnapshotContext;
+}
+
+export interface DiffOptions {
+  /**
+   * Box-dimension tolerance in CSS px; deltas ≤ this are ignored
+   * (sub-pixel rounding, scrollbar jitter). Default 1.
+   */
+  boxTolerancePx?: number;
+  /**
+   * Box dimensions to compare. Default ["width", "height"] — position
+   * (x/y) is noisy and usually a downstream effect of a size/spacing diff.
+   */
+  boxDims?: ReadonlyArray<"x" | "y" | "width" | "height">;
+}
+
+/**
+ * Diff two snapshots. Elements are matched by selector; a reference
+ * element with no candidate match yields a `missing` violation (brew did
+ * not render it). Selectors present only in the candidate are ignored —
+ * the reference is the contract, and extra prod chrome is allowed.
+ */
+export function diffSnapshots(
+  reference: StyleSnapshot,
+  candidate: StyleSnapshot,
+  options: DiffOptions = {}
+): FidelityViolation[] {
+  const tolerance = options.boxTolerancePx ?? 1;
+  const boxDims = options.boxDims ?? (["width", "height"] as const);
+  const context = reference.context;
+
+  const candidateBySelector = new Map<string, ElementSnapshot>();
+  for (const el of candidate.elements) {
+    // first occurrence wins — document order, matches reference walk
+    if (!candidateBySelector.has(el.selector)) {
+      candidateBySelector.set(el.selector, el);
+    }
+  }
+
+  const violations: FidelityViolation[] = [];
+
+  for (const ref of reference.elements) {
+    const cand = candidateBySelector.get(ref.selector);
+
+    if (!cand) {
+      violations.push({
+        selector: ref.selector,
+        axis: "missing",
+        property: "element",
+        expected: "present",
+        actual: "absent",
+        evidence: `${ref.selector}: present in reference, absent in candidate render`,
+        context,
+      });
+      continue;
+    }
+
+    // computed-style + color axes
+    for (const [prop, expected] of Object.entries(ref.styles)) {
+      const actual = cand.styles[prop];
+      if (actual === undefined || actual === expected) continue;
+      const axis: FidelityAxis = COLOR_PROPS.has(prop) ? "color" : "computed-style";
+      violations.push({
+        selector: ref.selector,
+        axis,
+        property: prop,
+        expected,
+        actual,
+        evidence: `${ref.selector}: ${prop} ${expected} → ${actual}`,
+        context,
+      });
+    }
+
+    // box axis
+    for (const dim of boxDims) {
+      const e = ref.box[dim];
+      const a = cand.box[dim];
+      if (Math.abs(e - a) <= tolerance) continue;
+      violations.push({
+        selector: ref.selector,
+        axis: "box",
+        property: dim,
+        expected: `${e}px`,
+        actual: `${a}px`,
+        evidence: `${ref.selector}: ${dim} ${e}px → ${a}px (Δ${a - e}px)`,
+        context,
+      });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Convenience: total + per-axis counts for gate thresholds + reporting.
+ */
+export function summariseFidelity(violations: FidelityViolation[]): {
+  total: number;
+  byAxis: Record<FidelityAxis, number>;
+} {
+  const byAxis: Record<FidelityAxis, number> = {
+    "computed-style": 0,
+    color: 0,
+    box: 0,
+    missing: 0,
+  };
+  for (const v of violations) byAxis[v.axis]++;
+  return { total: violations.length, byAxis };
+}

--- a/packages/gates/src/fidelity/gate.test.ts
+++ b/packages/gates/src/fidelity/gate.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { gradeFidelity } from "./gate.js";
+import type { ElementSnapshot, SnapshotContext, StyleSnapshot } from "./snapshot.js";
+
+const CTX: SnapshotContext = { viewport: "desktop", scheme: "light" };
+
+function el(
+  selector: string,
+  styles: Record<string, string> = {},
+  box: ElementSnapshot["box"] = { x: 0, y: 0, width: 100, height: 40 }
+): ElementSnapshot {
+  return { selector, styles, box };
+}
+
+function snap(elements: ElementSnapshot[], context: SnapshotContext = CTX): StyleSnapshot {
+  return { context, elements };
+}
+
+describe("gradeFidelity", () => {
+  it("passes a clean pair with no violations", () => {
+    const reference = snap([el(".hero", { "padding-top": "16px", color: "rgb(0, 0, 0)" })]);
+    const candidate = snap([el(".hero", { "padding-top": "16px", color: "rgb(0, 0, 0)" })]);
+    const result = gradeFidelity([{ reference, candidate }]);
+    expect(result.passed).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.summary.total).toBe(0);
+    expect(result.byContext).toHaveLength(1);
+    expect(result.byContext[0].context).toEqual(CTX);
+    expect(result.byContext[0].violations).toEqual([]);
+    expect(result.byContext[0].summary.total).toBe(0);
+  });
+
+  it("fails a pair with a color divergence", () => {
+    const reference = snap([el(".cta", { "background-color": "rgb(26, 26, 26)" })]);
+    const candidate = snap([el(".cta", { "background-color": "rgb(34, 34, 34)" })]);
+    const result = gradeFidelity([{ reference, candidate }]);
+    expect(result.passed).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({ axis: "color", property: "background-color" });
+    expect(result.summary.byAxis.color).toBe(1);
+  });
+
+  it("tolerates up to maxViolations", () => {
+    const reference = snap([
+      el(".cta", { "padding-top": "16px", color: "rgb(0, 0, 0)" }),
+    ]);
+    const candidate = snap([
+      el(".cta", { "padding-top": "12px", color: "rgb(255, 255, 255)" }),
+    ]);
+    const result = gradeFidelity([{ reference, candidate }], { maxViolations: 2 });
+    expect(result.violations).toHaveLength(2);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when violations exceed maxViolations", () => {
+    const reference = snap([
+      el(".cta", { "padding-top": "16px", color: "rgb(0, 0, 0)" }),
+    ]);
+    const candidate = snap([
+      el(".cta", { "padding-top": "12px", color: "rgb(255, 255, 255)" }),
+    ]);
+    const result = gradeFidelity([{ reference, candidate }], { maxViolations: 1 });
+    expect(result.violations).toHaveLength(2);
+    expect(result.passed).toBe(false);
+  });
+
+  it("failOnAxes only counts the listed axes for pass/fail and returned violations", () => {
+    // one color violation + one box violation + one computed-style violation
+    const reference = snap([
+      el(
+        ".card",
+        { "background-color": "rgb(0, 0, 0)", "padding-top": "16px" },
+        { x: 0, y: 0, width: 320, height: 200 }
+      ),
+    ]);
+    const candidate = snap([
+      el(
+        ".card",
+        { "background-color": "rgb(255, 255, 255)", "padding-top": "12px" },
+        { x: 0, y: 0, width: 300, height: 200 }
+      ),
+    ]);
+    const result = gradeFidelity([{ reference, candidate }], { failOnAxes: ["color"] });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].axis).toBe("color");
+    expect(result.passed).toBe(false);
+    expect(result.summary.byAxis).toEqual({
+      "computed-style": 0,
+      color: 1,
+      box: 0,
+      missing: 0,
+    });
+  });
+
+  it("passes when the only violations are on non-failing axes", () => {
+    const reference = snap([
+      el(".card", { "padding-top": "16px" }, { x: 0, y: 0, width: 320, height: 200 }),
+    ]);
+    const candidate = snap([
+      el(".card", { "padding-top": "12px" }, { x: 0, y: 0, width: 300, height: 200 }),
+    ]);
+    // box + computed-style diffs exist, but we only fail on color
+    const result = gradeFidelity([{ reference, candidate }], { failOnAxes: ["color"] });
+    expect(result.violations).toEqual([]);
+    expect(result.passed).toBe(true);
+  });
+
+  it("aggregates a multi-pair matrix with one byContext entry per pair", () => {
+    const mobileCtx: SnapshotContext = { viewport: "mobile", scheme: "light" };
+    const darkCtx: SnapshotContext = { viewport: "desktop", scheme: "dark" };
+
+    const pairs = [
+      {
+        // clean
+        reference: snap([el(".hero", { "padding-top": "16px" })], mobileCtx),
+        candidate: snap([el(".hero", { "padding-top": "16px" })], mobileCtx),
+      },
+      {
+        // one color diff
+        reference: snap([el(".cta", { color: "rgb(0, 0, 0)" })], darkCtx),
+        candidate: snap([el(".cta", { color: "rgb(255, 255, 255)" })], darkCtx),
+      },
+    ];
+
+    const result = gradeFidelity(pairs);
+    expect(result.passed).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.summary.total).toBe(1);
+
+    expect(result.byContext).toHaveLength(2);
+    expect(result.byContext[0].context).toEqual(mobileCtx);
+    expect(result.byContext[0].violations).toEqual([]);
+    expect(result.byContext[0].summary.total).toBe(0);
+    expect(result.byContext[1].context).toEqual(darkCtx);
+    expect(result.byContext[1].violations).toHaveLength(1);
+    expect(result.byContext[1].violations[0].context).toEqual(darkCtx);
+    expect(result.byContext[1].summary.byAxis.color).toBe(1);
+  });
+
+  it("forwards diff options (box tolerance) to diffSnapshots", () => {
+    const reference = snap([el(".card", {}, { x: 0, y: 0, width: 320, height: 200 })]);
+    const candidate = snap([el(".card", {}, { x: 0, y: 0, width: 325, height: 200 })]);
+    const strict = gradeFidelity([{ reference, candidate }]);
+    expect(strict.passed).toBe(false);
+    const lenient = gradeFidelity([{ reference, candidate }], { diff: { boxTolerancePx: 10 } });
+    expect(lenient.passed).toBe(true);
+    expect(lenient.violations).toEqual([]);
+  });
+
+  it("passes with empty pairs", () => {
+    const result = gradeFidelity([]);
+    expect(result.passed).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.summary.total).toBe(0);
+    expect(result.byContext).toEqual([]);
+  });
+});

--- a/packages/gates/src/fidelity/gate.ts
+++ b/packages/gates/src/fidelity/gate.ts
@@ -1,0 +1,110 @@
+import type { Page } from "@playwright/test";
+import {
+  diffSnapshots,
+  summariseFidelity,
+  type DiffOptions,
+  type FidelityAxis,
+  type FidelityViolation,
+} from "./diff.js";
+import {
+  captureSnapshot,
+  type SnapshotContext,
+  type StyleSnapshot,
+} from "./snapshot.js";
+
+/**
+ * Fidelity gate (design #8) — the "fidelity eye". Grades one or more
+ * (reference, candidate) snapshot pairs (e.g. the viewport×scheme matrix)
+ * into a single pass/fail verdict, carrying the flat `FidelityViolation`
+ * fix-signals through so a failing gate hands brew exactly what to fix.
+ *
+ * The grading (`gradeFidelity`) is pure + browser-free → fully unit-tested
+ * here. The Playwright capture that produces the snapshots is a thin
+ * wrapper (`runFidelityGate`) that defers to `captureSnapshot` + this pure
+ * core. Same split as the diff/snapshot pair it sits on top of.
+ */
+
+export interface FidelityGateOptions {
+  /** Max kept violations that still passes. Default 0 — any violation fails. */
+  maxViolations?: number;
+  /**
+   * If set, only violations on these axes count toward the returned
+   * violations + the pass/fail decision. Unset → all axes count.
+   */
+  failOnAxes?: FidelityAxis[];
+  /** Forwarded to `diffSnapshots` (boxTolerancePx, boxDims). */
+  diff?: DiffOptions;
+}
+
+export interface FidelityGateResult {
+  passed: boolean;
+  /** All kept violations across all pairs (after axis filtering). */
+  violations: FidelityViolation[];
+  summary: ReturnType<typeof summariseFidelity>;
+  /** Per-pair breakdown, one entry per input pair. */
+  byContext: {
+    context: SnapshotContext;
+    violations: FidelityViolation[];
+    summary: ReturnType<typeof summariseFidelity>;
+  }[];
+}
+
+/**
+ * Grade `(reference, candidate)` snapshot pairs into a single verdict.
+ *
+ * Each pair is diffed independently; if `failOnAxes` is set, only
+ * violations on those axes are kept (for both the returned lists and the
+ * pass/fail decision). The gate passes when the total kept violation count
+ * across all pairs is within `maxViolations` (default 0). `byContext`
+ * groups the kept violations by each pair's `reference.context`.
+ *
+ * Pure + browser-free → the load-bearing, fully unit-tested function.
+ */
+export function gradeFidelity(
+  pairs: { reference: StyleSnapshot; candidate: StyleSnapshot }[],
+  opts: FidelityGateOptions = {}
+): FidelityGateResult {
+  const maxViolations = opts.maxViolations ?? 0;
+  const axisFilter = opts.failOnAxes ? new Set(opts.failOnAxes) : undefined;
+
+  const violations: FidelityViolation[] = [];
+  const byContext: FidelityGateResult["byContext"] = [];
+
+  for (const pair of pairs) {
+    const raw = diffSnapshots(pair.reference, pair.candidate, opts.diff);
+    const kept = axisFilter ? raw.filter((v) => axisFilter.has(v.axis)) : raw;
+    violations.push(...kept);
+    byContext.push({
+      context: pair.reference.context,
+      violations: kept,
+      summary: summariseFidelity(kept),
+    });
+  }
+
+  return {
+    passed: violations.length <= maxViolations,
+    violations,
+    summary: summariseFidelity(violations),
+    byContext,
+  };
+}
+
+/**
+ * Thin Playwright wrapper: capture both pages at their current state under
+ * one `context`, then grade the resulting pair. Caller sets the viewport +
+ * scheme (and any event step) on both pages before calling and passes the
+ * matching `context`.
+ *
+ * Not unit-tested (needs a real browser); the load-bearing logic lives in
+ * the pure `gradeFidelity`.
+ */
+export async function runFidelityGate(
+  referencePage: Page,
+  candidatePage: Page,
+  context: SnapshotContext,
+  opts: FidelityGateOptions = {}
+): Promise<FidelityGateResult> {
+  const reference = await captureSnapshot(referencePage, context);
+  const candidate = await captureSnapshot(candidatePage, context);
+  return gradeFidelity([{ reference, candidate }], opts);
+}

--- a/packages/gates/src/fidelity/snapshot.ts
+++ b/packages/gates/src/fidelity/snapshot.ts
@@ -1,0 +1,149 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Fidelity snapshots — the input to the visual/behavioural mock-vs-prod
+ * diff (design #8). A snapshot is a structural record of a single render:
+ * one entry per matched element, capturing the computed-style properties
+ * and box we grade. Two snapshots (reference = `references.visual` render,
+ * candidate = brew output) are compared by `diffSnapshots` (./diff.ts).
+ *
+ * The capture (`captureSnapshot`) is an impure Playwright wrapper; the
+ * diff is pure + unit-tested. Same split as serve's
+ * resolveCommand/runCommands.
+ */
+
+/** Which render a snapshot is — viewport, scheme, and optional event step. */
+export interface SnapshotContext {
+  /** "mobile" | "desktop", or any named viewport the matrix defines. */
+  viewport: string;
+  /** Color scheme the page was rendered under. */
+  scheme: "light" | "dark";
+  /**
+   * Behavioural step label for stepped (event-sequence) captures, e.g.
+   * "after:click [data-testid=submit]". Absent for static captures.
+   */
+  step?: string;
+}
+
+/** One matched element's graded properties within a render. */
+export interface ElementSnapshot {
+  /**
+   * Stable selector pointer — prefers `#id` / `[data-testid]`, else
+   * `tag.class:nth`. Used to match the same element across the reference
+   * and candidate renders. A selector present in reference but absent in
+   * candidate becomes a `missing` violation.
+   */
+  selector: string;
+  /** Graded computed-style props, keyed by CSS property name → value. */
+  styles: Record<string, string>;
+  /** Bounding box in CSS px at the capture viewport. */
+  box: { x: number; y: number; width: number; height: number };
+}
+
+export interface StyleSnapshot {
+  context: SnapshotContext;
+  /** One entry per matched element, in document order. */
+  elements: ElementSnapshot[];
+}
+
+/**
+ * Computed-style properties graded by default. Chosen for design-fidelity
+ * signal: box model, color, typography, layout, and key visual props.
+ * `getComputedStyle` normalises all of these (colors → `rgb(...)`, lengths
+ * → `px`), so reference and candidate values compare as plain strings.
+ */
+export const FIDELITY_STYLE_PROPS: readonly string[] = [
+  // box model
+  "padding-top", "padding-right", "padding-bottom", "padding-left",
+  "margin-top", "margin-right", "margin-bottom", "margin-left",
+  "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
+  "gap",
+  // color
+  "color", "background-color",
+  "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
+  // typography
+  "font-size", "font-weight", "font-family", "line-height", "letter-spacing", "text-align",
+  // layout
+  "display", "flex-direction", "justify-content", "align-items", "position",
+  // visual
+  "border-radius", "opacity", "box-shadow",
+];
+
+/** Props whose violations are tagged with the `color` axis (vs `computed-style`). */
+export const COLOR_PROPS: ReadonlySet<string> = new Set([
+  "color", "background-color",
+  "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
+]);
+
+/**
+ * Capture a `StyleSnapshot` from a live Playwright page. Walks the visible
+ * DOM, builds a stable selector per element, and reads the graded computed
+ * styles + box. Caller sets the viewport + scheme before calling and passes
+ * the matching `context`.
+ *
+ * Not unit-tested (needs a real browser); the load-bearing logic lives in
+ * the pure `diffSnapshots`. Integration coverage comes from the gate runner.
+ */
+export async function captureSnapshot(
+  page: Page,
+  context: SnapshotContext,
+  options: { styleProps?: readonly string[] } = {}
+): Promise<StyleSnapshot> {
+  const styleProps = options.styleProps ?? FIDELITY_STYLE_PROPS;
+  const elements = await page.evaluate((props: readonly string[]) => {
+    const selectorFor = (el: Element): string => {
+      const he = el as HTMLElement;
+      if (he.id) return `#${he.id}`;
+      const testid = he.getAttribute("data-testid");
+      if (testid) return `[data-testid="${testid}"]`;
+      const tag = el.tagName.toLowerCase();
+      const cls =
+        typeof he.className === "string" && he.className
+          ? "." +
+            he.className.split(/\s+/).filter(Boolean).slice(0, 2).join(".")
+          : "";
+      const base = `${tag}${cls}`;
+      // disambiguate among siblings matching the same base
+      const parent = el.parentElement;
+      if (!parent) return base;
+      const sameBase = Array.from(parent.children).filter((sib) => {
+        const se = sib as HTMLElement;
+        const sc =
+          typeof se.className === "string" && se.className
+            ? "." +
+              se.className.split(/\s+/).filter(Boolean).slice(0, 2).join(".")
+            : "";
+        return `${sib.tagName.toLowerCase()}${sc}` === base;
+      });
+      if (sameBase.length <= 1) return base;
+      return `${base}:nth-of-type(${sameBase.indexOf(el) + 1})`;
+    };
+
+    const out: {
+      selector: string;
+      styles: Record<string, string>;
+      box: { x: number; y: number; width: number; height: number };
+    }[] = [];
+    for (const el of Array.from(document.querySelectorAll("body *"))) {
+      const cs = getComputedStyle(el);
+      if (cs.display === "none" || cs.visibility === "hidden") continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+      const styles: Record<string, string> = {};
+      for (const p of props) styles[p] = cs.getPropertyValue(p).trim();
+      out.push({
+        selector: selectorFor(el),
+        styles,
+        box: {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        },
+      });
+    }
+    return out;
+  }, styleProps as string[]);
+
+  return { context, elements };
+}

--- a/packages/gates/src/index.ts
+++ b/packages/gates/src/index.ts
@@ -3,6 +3,12 @@ export { checkTapTargets } from "./tap-targets.js";
 export { checkNoOverflow } from "./overflow.js";
 export type { GateViolation } from "./types.js";
 
+// Fidelity eye (design #8) — visual + behavioural mock-vs-prod diff.
+export { captureSnapshot, FIDELITY_STYLE_PROPS, COLOR_PROPS } from "./fidelity/snapshot.js";
+export type { StyleSnapshot, ElementSnapshot, SnapshotContext } from "./fidelity/snapshot.js";
+export { diffSnapshots, summariseFidelity } from "./fidelity/diff.js";
+export type { FidelityViolation, FidelityAxis, DiffOptions } from "./fidelity/diff.js";
+
 import type { Page } from "@playwright/test";
 import { checkContrast } from "./contrast.js";
 import { checkTapTargets } from "./tap-targets.js";

--- a/packages/gates/src/index.ts
+++ b/packages/gates/src/index.ts
@@ -8,6 +8,8 @@ export { captureSnapshot, FIDELITY_STYLE_PROPS, COLOR_PROPS } from "./fidelity/s
 export type { StyleSnapshot, ElementSnapshot, SnapshotContext } from "./fidelity/snapshot.js";
 export { diffSnapshots, summariseFidelity } from "./fidelity/diff.js";
 export type { FidelityViolation, FidelityAxis, DiffOptions } from "./fidelity/diff.js";
+export { gradeFidelity, runFidelityGate } from "./fidelity/gate.js";
+export type { FidelityGateOptions, FidelityGateResult } from "./fidelity/gate.js";
 
 import type { Page } from "@playwright/test";
 import { checkContrast } from "./contrast.js";

--- a/packages/llm-anthropic/src/prompts/brew.ts
+++ b/packages/llm-anthropic/src/prompts/brew.ts
@@ -241,8 +241,8 @@ The mockup app at \`mock/\` was approved by the PM. The deterministic \`slowcook
 
 **Two-part rule:**
 
-1. **Preserve the UI shape.** JSX structure, props signature, \`className\`, layout, and visual hierarchy of every \`@slowcook-port-from\` file are the design contract. Tier-2 acceptance + visual regression will catch shape drift later.
-2. **Swap mock data for real data.** Inside those port-marked files, you CAN edit handlers, hooks, fetch calls, and effects to wire real data instead of in-memory mocks. The mock might do \`setPins([newPin, ...prev])\` for a click; the port-marked component should \`fetch('/api/pins', { method: 'POST', ... })\` instead. That's exactly the change brew is here to make.
+1. **Preserve the UI presentation VERBATIM.** The JSX structure, props signature, and **every \`className\` token** of each \`@slowcook-port-from\` file are the design contract — copied from the PM-approved mock. Your edit license inside a port-marked file is scoped to the **data-wiring seams only** (handlers, hooks, fetch/effect bodies). You may NOT add, remove, reorder, or rewrite presentational markup or className tokens to "tidy up", restyle, or shortcut — that is exactly the drift this contract exists to prevent. If a className looks redundant, it is still the contract; leave it. The recon shape tests (below) now pin the mock's **full per-element className set** by containment, so dropped or altered tokens fail hard.
+2. **Swap mock data for real data.** Inside those port-marked files, you CAN edit handlers, hooks, fetch calls, and effects to wire real data instead of in-memory mocks. The mock might do \`setPins([newPin, ...prev])\` for a click; the port-marked component should \`fetch('/api/pins', { method: 'POST', ... })\` instead. That's exactly the change brew is here to make. Adding a className that real data legitimately requires (e.g. a loading/error state the mock didn't show) is fine — containment only forbids *dropping* the mock's tokens, never *adding*.
 
 ### What you can write
 
@@ -256,7 +256,7 @@ You can edit any file in the repo to satisfy the failing test. The common destin
 
 Two protections catch shape drift if you go too far:
 
-1. **Recon-emitted shape tests** at \`tests/integration/story-N-shape.test.tsx\` assert testid presence, visual className tokens (\`rounded-full\`, \`min-h-[44px]\`), semantic landmarks. Read these before editing — your edits must keep them green.
+1. **Recon-emitted shape tests** at \`tests/integration/story-N-shape.test.tsx\` assert testid presence, semantic landmarks, and — per element — that the brewed component **retains the mock's full className token set** (containment: brewed ⊇ mock). These are the design contract in test form; read them before editing and keep them green. A failing one names the exact element + dropped token.
 2. **Full-suite test gate** at brew completion reverts any iteration that broke a previously-green test (catches cross-story regression).
 
 ### What you still must NOT touch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,18 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@playwright/test':
+        specifier: ^1.40.0
+        version: 1.59.1
       '@slowcook-ai/core':
         specifier: workspace:^
         version: link:../core
       '@slowcook-ai/forge-github':
         specifier: workspace:^
         version: link:../forge-github
+      '@slowcook-ai/gates':
+        specifier: workspace:^
+        version: link:../gates
       '@slowcook-ai/llm-anthropic':
         specifier: workspace:^
         version: link:../llm-anthropic


### PR DESCRIPTION
Two parked design items from the delgoosh dogfood (sc#173 findings #12 + #13), decided 2026-06-06, plus the first implementation slice.

## Why
On the delgoosh design-react migration, slowcook had a **full React/Vite visual source-of-truth** (`references.visual`, #7) yet brew shipped a front-end that wasn't pixel-faithful — structural recon tests pass while spacing/tokens/dark-mode/responsive still look wrong. And the pipeline can advance past points where a **named human role** (PM / designer / QA) needs to sign off, with nothing structurally stopping it.

## Design (`docs/plans/0.20-design-discussions.md`)
- **#8 — Fidelity eye.** A visual + behavioural mock-vs-prod diff that **drives** front-end brew on hot-reload stacks (HMR → no build wait), not just gates it. Chosen **C** (port-seed + eye-driven convergence): seed brew with a code-port from `references.visual`, then diff multi-modally (pixel / color / computed-style / **behaviour**) and feed hard, per-element fix-signals back into the loop; residual escalates to the designer/QA gate. Behaviour = stepped snapshots before+after scripted events (a single screenshot can't express it). Rejected screenshot-first (lossy, soft signal) and code-port-only (misses token/theme/responsive/behaviour drift).
- **#9 — HITL role gates.** Hard, role-typed, **agent-unforgeable** halts. Gate = `{stage, required_role(s), approval_signal, on_reject_target}`; approval must come from a *human* identity in `reviewers.yaml`, never the bot/agent. Enforced in both the bot pipeline and the local-claude-pipeline.

The two are **one feature seam**: the eye produces the review artifact; the gate halts for the human to grade it.

## First slice — `packages/gates/src/fidelity/`
- `snapshot.ts` — `StyleSnapshot` / `ElementSnapshot` / `SnapshotContext` types, `FIDELITY_STYLE_PROPS` / `COLOR_PROPS`, and `captureSnapshot(page)` Playwright shell (impure; not unit-tested, matching the existing gate convention).
- `diff.ts` — **pure** `diffSnapshots(reference, candidate)` emitting per-element `FidelityViolation` fix-signals across `computed-style` / `color` / `box` / `missing` axes, plus `summariseFidelity()` for thresholds. Browser-free.
- **13 unit tests** — gates' first tests (the Page-based checks couldn't be unit-tested; the pure diff can).

Both the future brew HMR-driver and `runFidelityGate` consume this same pure core. The slice is independently useful today as a manual fidelity report.

## Verification
- `pnpm --filter @slowcook-ai/gates build` — clean
- `pnpm --filter @slowcook-ai/gates test` — 13/13 pass

## Scope / follow-ups (phased per the design)
This PR lands the design decisions + the pure-diff slice (~1d of the ~6.5d #8 + ~4d #9). Next slices: `captureSnapshot` matrix capture → behavioural stepped driver → brew HMR loop → `runFidelityGate` → the #9 gate object model + `reviewers.yaml`.

Refs design #7 (references field), #8, #9 · sc#173 #12, #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)