### PR TITLE
feat(eye): spec-declared fidelity modes — refine declares, eye enforces (#8)

### DIFF
--- a/packages/cli/src/commands/eye/index.ts
+++ b/packages/cli/src/commands/eye/index.ts
@@ -14,7 +14,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { chromium } from "@playwright/test";
 import { captureSnapshot, gradeFidelity, type StyleSnapshot } from "@slowcook-ai/gates";
-import { parseEyeArgs, type EyeContext } from "./plan.js";
+import { parseEyeArgs, matrixFromModes, narrowMatrix, type EyeContext } from "./plan.js";
+import { loadFidelityModes } from "./spec-modes.js";
 
 export async function eye(args: string[], _version: string): Promise<void> {
   if (args[0] === "--help" || args[0] === "-h") {
@@ -28,6 +29,18 @@ export async function eye(args: string[], _version: string): Promise<void> {
   } catch (e) {
     console.error(String(e instanceof Error ? e.message : e));
     process.exit(64);
+  }
+
+  // Spec-declared modes (the contract) override the default matrix; explicit
+  // --viewport/--scheme flags still narrow on top.
+  if (opts.story) {
+    const modes = loadFidelityModes(opts.cwd, opts.story);
+    if (modes && modes.length) {
+      opts.matrix = narrowMatrix(matrixFromModes(modes), { viewport: opts.viewport, scheme: opts.scheme });
+      console.log(`eye: matrix from story-${opts.story} fidelity.modes [${modes.join(", ")}] → ${opts.matrix.length} cell(s)`);
+    } else {
+      console.log(`eye: story-${opts.story} declares no fidelity.modes; using ${opts.matrix.length}-cell default matrix`);
+    }
   }
 
   mkdirSync(opts.outDir, { recursive: true });

--- a/packages/cli/src/commands/eye/plan.test.ts
+++ b/packages/cli/src/commands/eye/plan.test.ts
@@ -1,7 +1,51 @@
 import { describe, it, expect } from "vitest";
-import { parseEyeArgs, DEFAULT_MATRIX, VIEWPORTS } from "./plan.js";
+import { parseEyeArgs, DEFAULT_MATRIX, VIEWPORTS, matrixFromModes, narrowMatrix } from "./plan.js";
 
 const base = ["--reference", "http://ref", "--candidate", "http://cand"];
+
+const cell = (c: { viewport: string; scheme: string }) => `${c.viewport}-${c.scheme}`;
+
+describe("matrixFromModes", () => {
+  it("expands a full mode list to the 4-cell product", () => {
+    expect(matrixFromModes(["light", "dark", "mobile", "desktop"]).map(cell).sort()).toEqual([
+      "desktop-dark", "desktop-light", "mobile-dark", "mobile-light",
+    ]);
+  });
+
+  it("a scheme-only mode defaults the viewport dimension to its full set", () => {
+    expect(matrixFromModes(["dark"]).map(cell).sort()).toEqual(["desktop-dark", "mobile-dark"]);
+  });
+
+  it("a viewport-only mode defaults the scheme dimension to its full set", () => {
+    expect(matrixFromModes(["mobile"]).map(cell).sort()).toEqual(["mobile-dark", "mobile-light"]);
+  });
+
+  it("an explicit single cell yields one cell", () => {
+    expect(matrixFromModes(["mobile", "dark"]).map(cell)).toEqual(["mobile-dark"]);
+  });
+
+  it("is case-insensitive and trims", () => {
+    expect(matrixFromModes([" Dark ", "MOBILE"]).map(cell)).toEqual(["mobile-dark"]);
+  });
+
+  it("ignores unrecognised tokens; all-garbage fails open to the full matrix", () => {
+    expect(matrixFromModes(["dark", "tablet"]).map(cell).sort()).toEqual(["desktop-dark", "mobile-dark"]);
+    expect(matrixFromModes(["watch", "sepia"]).length).toBe(DEFAULT_MATRIX.length);
+  });
+
+  it("carries real pixel dimensions", () => {
+    expect(matrixFromModes(["mobile", "dark"])[0]!.width).toBe(VIEWPORTS.mobile!.width);
+  });
+});
+
+describe("narrowMatrix", () => {
+  it("filters by viewport + scheme and validates", () => {
+    expect(narrowMatrix(DEFAULT_MATRIX, { scheme: "dark" }).map(cell).sort()).toEqual(["desktop-dark", "mobile-dark"]);
+    expect(narrowMatrix(DEFAULT_MATRIX, { viewport: "mobile", scheme: "light" }).map(cell)).toEqual(["mobile-light"]);
+    expect(() => narrowMatrix(DEFAULT_MATRIX, { viewport: "watch" })).toThrow(/unknown --viewport/);
+    expect(() => narrowMatrix(DEFAULT_MATRIX, { scheme: "sepia" })).toThrow(/light\|dark/);
+  });
+});
 
 describe("parseEyeArgs", () => {
   it("requires --reference and --candidate", () => {
@@ -42,6 +86,14 @@ describe("parseEyeArgs", () => {
     const o = parseEyeArgs([...base, "--max-violations", "3", "--fail-on", "color,box"]);
     expect(o.gate.maxViolations).toBe(3);
     expect(o.gate.failOnAxes).toEqual(["color", "box"]);
+  });
+
+  it("records --story and --cwd for spec-driven matrix resolution", () => {
+    const o = parseEyeArgs([...base, "--story", "020", "--cwd", "/repo"]);
+    expect(o.story).toBe("020");
+    expect(o.cwd).toBe("/repo");
+    // matrix is still the flag default until the runner reads the spec
+    expect(o.matrix).toHaveLength(4);
   });
 
   it("DEFAULT_MATRIX is the 4-cell product", () => {

--- a/packages/cli/src/commands/eye/plan.ts
+++ b/packages/cli/src/commands/eye/plan.ts
@@ -1,7 +1,12 @@
 /**
- * design #8 — `slowcook eye` planning (pure). Expands the CLI flags into the
- * (viewport × scheme) capture matrix + gate thresholds the runner executes.
- * Kept pure + unit-tested; the Playwright execution lives in ./index.ts.
+ * design #8 — `slowcook eye` planning (pure). Expands the CLI flags + the
+ * spec's declared fidelity modes into the (viewport × scheme) capture matrix +
+ * gate thresholds the runner executes. Kept pure + unit-tested; the Playwright
+ * execution + spec IO live in ./index.ts (matrix source) and ./spec-modes.ts.
+ *
+ * Which modes are in fidelity scope is a CONTRACT declared by refine in the
+ * spec (`fidelity.modes`), not chosen by brew. The eye reads + enforces it;
+ * brew is measured against it. CLI flags can only NARROW (never widen).
  */
 import type { FidelityAxis, FidelityGateOptions } from "@slowcook-ai/gates";
 
@@ -19,6 +24,13 @@ export interface EyeOptions {
   outDir: string;
   matrix: EyeContext[];
   gate: FidelityGateOptions;
+  /** When set, the runner derives the matrix from this story's `fidelity.modes`. */
+  story?: string;
+  /** Repo root for spec lookup (default "."). */
+  cwd: string;
+  /** Raw narrowing flags, re-applied after a spec-derived matrix is built. */
+  viewport?: string;
+  scheme?: string;
 }
 
 export const VIEWPORTS: Record<string, { width: number; height: number }> = {
@@ -33,6 +45,40 @@ export const DEFAULT_MATRIX: EyeContext[] = Object.entries(VIEWPORTS).flatMap(([
   SCHEMES.map((scheme) => ({ viewport, scheme, ...dim })),
 );
 
+/**
+ * Build the capture matrix from a spec's declared `fidelity.modes` (pure).
+ * Tokens are dimension VALUES (`light`/`dark`/`mobile`/`desktop`), expanded to
+ * the product: a dimension with no declared value defaults to its full set
+ * (so `[dark]` → dark × {mobile,desktop}; `[mobile]` → {light,dark} × mobile).
+ * Unrecognised tokens are ignored; if NONE are recognised, the full default
+ * matrix is returned (fail-open — a typo never silently checks nothing).
+ */
+export function matrixFromModes(modes: string[]): EyeContext[] {
+  const wanted = new Set(modes.map((m) => String(m).toLowerCase().trim()));
+  const viewports = Object.keys(VIEWPORTS).filter((v) => wanted.has(v));
+  const schemes = SCHEMES.filter((s) => wanted.has(s));
+  if (!viewports.length && !schemes.length) return DEFAULT_MATRIX;
+  const vps = viewports.length ? viewports : Object.keys(VIEWPORTS);
+  const schs = schemes.length ? schemes : SCHEMES;
+  return vps.flatMap((viewport) => schs.map((scheme) => ({ viewport, scheme, ...VIEWPORTS[viewport]! })));
+}
+
+/** Narrow a matrix by explicit --viewport / --scheme flags (pure). Validates. */
+export function narrowMatrix(base: EyeContext[], opts: { viewport?: string; scheme?: string }): EyeContext[] {
+  let m = base;
+  if (opts.viewport) {
+    if (!VIEWPORTS[opts.viewport]) {
+      throw new Error(`eye: unknown --viewport '${opts.viewport}' (have: ${Object.keys(VIEWPORTS).join(", ")})`);
+    }
+    m = m.filter((c) => c.viewport === opts.viewport);
+  }
+  if (opts.scheme) {
+    if (opts.scheme !== "light" && opts.scheme !== "dark") throw new Error("eye: --scheme must be light|dark");
+    m = m.filter((c) => c.scheme === opts.scheme);
+  }
+  return m;
+}
+
 function val(args: string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
   return i >= 0 ? args[i + 1] : undefined;
@@ -40,9 +86,10 @@ function val(args: string[], flag: string): string | undefined {
 
 /**
  * Parse `slowcook eye` flags. Required: --reference <url>, --candidate <url>.
- * Optional: --out <dir> (default ./.brewing/eye), --viewport <name> + --scheme
- * <light|dark> to narrow the matrix, --max-violations <n>, --fail-on <a,b>.
- * Throws on a missing required flag (caller maps to a non-zero exit).
+ * Optional: --story <id> (derive the matrix from the spec's fidelity.modes),
+ * --cwd <dir>, --out <dir>, --viewport <name> + --scheme <light|dark> (narrow),
+ * --max-violations <n>, --fail-on <a,b>. The returned `matrix` is the flag-only
+ * default; when `story` is set the runner rebuilds it from the spec.
  */
 export function parseEyeArgs(args: string[]): EyeOptions {
   const referenceUrl = val(args, "--reference");
@@ -51,17 +98,9 @@ export function parseEyeArgs(args: string[]): EyeOptions {
     throw new Error("eye: --reference <url> and --candidate <url> are both required");
   }
 
-  let matrix = DEFAULT_MATRIX;
-  const onlyViewport = val(args, "--viewport");
-  const onlyScheme = val(args, "--scheme");
-  if (onlyViewport) {
-    if (!VIEWPORTS[onlyViewport]) throw new Error(`eye: unknown --viewport '${onlyViewport}' (have: ${Object.keys(VIEWPORTS).join(", ")})`);
-    matrix = matrix.filter((c) => c.viewport === onlyViewport);
-  }
-  if (onlyScheme) {
-    if (onlyScheme !== "light" && onlyScheme !== "dark") throw new Error(`eye: --scheme must be light|dark`);
-    matrix = matrix.filter((c) => c.scheme === onlyScheme);
-  }
+  const viewport = val(args, "--viewport");
+  const scheme = val(args, "--scheme");
+  const matrix = narrowMatrix(DEFAULT_MATRIX, { viewport, scheme });
 
   const maxV = val(args, "--max-violations");
   const failOn = val(args, "--fail-on");
@@ -75,5 +114,9 @@ export function parseEyeArgs(args: string[]): EyeOptions {
     outDir: val(args, "--out") ?? ".brewing/eye",
     matrix,
     gate,
+    story: val(args, "--story"),
+    cwd: val(args, "--cwd") ?? ".",
+    viewport,
+    scheme,
   };
 }

--- a/packages/cli/src/commands/eye/spec-modes.test.ts
+++ b/packages/cli/src/commands/eye/spec-modes.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { extractFidelityModes } from "./spec-modes.js";
+
+describe("extractFidelityModes", () => {
+  it("reads fidelity.modes from a spec", () => {
+    const yaml = `story_id: "020"\nfidelity:\n  modes: [light, dark, mobile]\n`;
+    expect(extractFidelityModes(yaml)).toEqual(["light", "dark", "mobile"]);
+  });
+
+  it("returns null when fidelity is absent", () => {
+    expect(extractFidelityModes(`story_id: "020"\ntitle: x\n`)).toBeNull();
+  });
+
+  it("returns null when fidelity has no modes array", () => {
+    expect(extractFidelityModes(`fidelity:\n  notes: dark matters\n`)).toBeNull();
+  });
+
+  it("coerces non-string mode entries to strings", () => {
+    expect(extractFidelityModes(`fidelity:\n  modes:\n    - dark\n    - 2\n`)).toEqual(["dark", "2"]);
+  });
+
+  it("returns null on malformed yaml rather than throwing", () => {
+    expect(extractFidelityModes(`fidelity:\n  modes: [unterminated\n`)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/eye/spec-modes.ts
+++ b/packages/cli/src/commands/eye/spec-modes.ts
@@ -1,0 +1,34 @@
+/**
+ * design #8 — read a story spec's declared fidelity modes. refine writes
+ * `fidelity.modes` on the spec (the contract for which viewport/scheme cells
+ * matter); the eye reads it here to build its matrix. Decoupled from the
+ * (not-yet-built) #7 `references` field — when that lands, `references.visual[].modes`
+ * becomes the per-source override and `fidelity.modes` the spec-level default.
+ *
+ *   # specs/story-020.yaml
+ *   fidelity:
+ *     modes: [light, dark, mobile, desktop]
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+
+/** Pure: extract `fidelity.modes` from a spec YAML string, or null if absent. */
+export function extractFidelityModes(specYaml: string): string[] | null {
+  let doc: unknown;
+  try {
+    doc = YAML.parse(specYaml);
+  } catch {
+    return null;
+  }
+  const modes = (doc as { fidelity?: { modes?: unknown } } | null)?.fidelity?.modes;
+  if (Array.isArray(modes)) return modes.map((m) => String(m));
+  return null;
+}
+
+/** Load `fidelity.modes` for a story from `<repoRoot>/specs/story-<id>.yaml`. */
+export function loadFidelityModes(repoRoot: string, story: string): string[] | null {
+  const p = join(repoRoot, "specs", `story-${story}.yaml`);
+  if (!existsSync(p)) return null;
+  return extractFidelityModes(readFileSync(p, "utf8"));
+}

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -149,6 +149,10 @@ const SpecSchema = z.object({
   invariants: z.array(z.string()),
   api_contract: z.array(z.unknown()).optional(),
   ui_behavior: z.record(z.string(), z.string()).optional(),
+  // design #8 — which viewport/scheme cells are in fidelity scope for the eye.
+  // Dimension-value tokens (light|dark|mobile|desktop); the eye expands them to
+  // the (declared-or-full) product. Absent = eye uses its full default matrix.
+  fidelity: z.object({ modes: z.array(z.string()) }).optional(),
   acceptance_scenarios: z.array(z.string()),
   non_goals: z.array(z.string()),
   related_specs: z

--- a/packages/llm-anthropic/src/prompts/refine.ts
+++ b/packages/llm-anthropic/src/prompts/refine.ts
@@ -442,6 +442,7 @@ When emitting the spec: output ONLY the YAML, nothing before or after, starting 
 - invariants: string[]
 - api_contract?: [{ method, path, request_schema?, responses? }]
 - ui_behavior?: { desktop_light: string, mobile_light: string, mobile_dark: string, ... }
+- fidelity?: { modes: string[] } — which viewport/scheme cells the visual-fidelity eye must check, as dimension tokens from \`light | dark | mobile | desktop\`. **Emit this whenever the design is mode-specific** (a dark theme, a distinct mobile layout). Derive it from the \`ui_behavior\` keys you wrote: if \`ui_behavior\` mentions \`*_dark\`, include \`dark\`; if it mentions \`mobile_*\`, include \`mobile\`. A spec that only specifies one mode (e.g. light desktop) should NOT list the others — that would force the eye to check cells the design never defined. Omit entirely only when mode is genuinely irrelevant (the eye then falls back to its full default matrix).
 - acceptance_scenarios: string[] (Given/When/Then form)
 - non_goals: string[]
 - related_specs?: [{ id, relationship: "overlap"|"related"|"superseded", note? }]


### PR DESCRIPTION
Answers "how can a stage ask the eye for a particular mode": through the **spec**, not an ad-hoc agent request. **refine declares** which viewport/scheme cells are in fidelity scope; the **eye reads + enforces**; **brew is measured** against it and can't widen/narrow the scope itself (which would let it dodge a mode).

- **Spec schema**: optional `fidelity.modes: string[]` on `Spec` (round-trips via read/writeSpec). Decoupled from the not-yet-built #7 `references` field; folds in as the per-source override when #7 lands.
- **`eye/spec-modes.ts`**: `extractFidelityModes` (pure) + `loadFidelityModes(repoRoot, story)`.
- **`eye/plan.ts`**: `matrixFromModes()` — dimension tokens (`light|dark|mobile|desktop`) → product, with full-set default for an unspecified dimension (`[dark]` → dark×{mobile,desktop}) and fail-open to the full matrix on all-unrecognised input — plus `narrowMatrix()`.
- **`slowcook eye --story <id> [--cwd <dir>]`** derives the matrix from the spec's `fidelity.modes`; explicit `--viewport`/`--scheme` still narrow on top.
- **refine prompt**: emit `fidelity.modes` when the design is mode-specific, derived from the `ui_behavior` keys it already writes (`*_dark` → `dark`, `mobile_*` → `mobile`).

## Verification
- 14 new unit tests (matrixFromModes / narrowMatrix / extractFidelityModes / story flag).
- cli 1237 + llm-anthropic 42 tests green; build clean.
- Smoke-tested end-to-end: a spec with `fidelity.modes: [dark, mobile]` resolves to the `mobile-dark` cell; a missing spec falls back to the default 4-cell matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)