### PR TITLE
feat(eye): --watch — warm-browser HMR re-eye loop (closes #189)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,7 +94,7 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
 - **`eye`** — Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.
   ```
-  slowcook eye --reference <url> --candidate <url> [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>]
+  slowcook eye --reference <url> --candidate <url> [--story <id>] [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>] [--watch [--interval <ms>] [--until-converged] [--max-passes <n>]]
   ```
 - **`gate`** — HITL review halt (design #9). Refuses to advance a stage until a human in the required role has approved on the PR; bot/agent reviews never satisfy it.
   ```

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -159,7 +159,7 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "eye",
-    usage: "slowcook eye --reference <url> --candidate <url> [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>]",
+    usage: "slowcook eye --reference <url> --candidate <url> [--story <id>] [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>] [--watch [--interval <ms>] [--until-converged] [--max-passes <n>]]",
     description: "Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.",
     group: "checks",
   },

--- a/packages/cli/src/commands/eye/index.ts
+++ b/packages/cli/src/commands/eye/index.ts
@@ -15,11 +15,11 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseEyeArgs, matrixFromModes, narrowMatrix } from "./plan.js";
 import { loadFidelityModes } from "./spec-modes.js";
-import { runEyeMatrix } from "./run.js";
+import { runEyeMatrix, runEyeWatch } from "./run.js";
 
 export async function eye(args: string[], _version: string): Promise<void> {
   if (args[0] === "--help" || args[0] === "-h") {
-    console.log("usage: slowcook eye --reference <url> --candidate <url> [--story <id>] [--cwd <dir>] [--out dir] [--viewport m] [--scheme s] [--max-violations N] [--fail-on a,b]");
+    console.log("usage: slowcook eye --reference <url> --candidate <url> [--story <id>] [--cwd <dir>] [--out dir] [--viewport m] [--scheme s] [--max-violations N] [--fail-on a,b] [--watch [--interval ms] [--until-converged] [--max-passes N]]");
     return;
   }
 
@@ -41,6 +41,25 @@ export async function eye(args: string[], _version: string): Promise<void> {
     } else {
       console.log(`eye: story-${opts.story} declares no fidelity.modes; using ${opts.matrix.length}-cell default matrix`);
     }
+  }
+
+  // sc#189 — warm-browser HMR re-eye loop for fast visual convergence.
+  if (opts.watch) {
+    console.log(`eye --watch: ${opts.matrix.length} cell(s) · interval ${opts.intervalMs}ms · max ${opts.maxPasses} passes${opts.untilConverged ? " · until-converged" : ""}`);
+    const { result, passes, converged } = await runEyeWatch({
+      referenceUrl: opts.referenceUrl,
+      candidateUrl: opts.candidateUrl,
+      matrix: opts.matrix,
+      outDir: opts.outDir,
+      gate: opts.gate,
+      intervalMs: opts.intervalMs,
+      untilConverged: opts.untilConverged,
+      maxPasses: opts.maxPasses,
+    });
+    writeFileSync(join(opts.outDir, "eye-report.json"), JSON.stringify({ ...result, passes, converged }, null, 2));
+    console.log(`\nslowcook eye --watch — ${result.passed ? "PASS ✓" : "FAIL ✗"} after ${passes} pass(es)`);
+    if (opts.untilConverged && !result.passed) process.exit(1);
+    return;
   }
 
   const { result, screenshots } = await runEyeMatrix({

--- a/packages/cli/src/commands/eye/plan.test.ts
+++ b/packages/cli/src/commands/eye/plan.test.ts
@@ -96,6 +96,22 @@ describe("parseEyeArgs", () => {
     expect(o.matrix).toHaveLength(4);
   });
 
+  it("defaults watch off with sane interval/max-passes", () => {
+    const o = parseEyeArgs(base);
+    expect(o.watch).toBe(false);
+    expect(o.intervalMs).toBe(2000);
+    expect(o.untilConverged).toBe(false);
+    expect(o.maxPasses).toBe(60);
+  });
+
+  it("parses --watch + --interval + --until-converged + --max-passes (sc#189)", () => {
+    const o = parseEyeArgs([...base, "--watch", "--interval", "500", "--until-converged", "--max-passes", "10"]);
+    expect(o.watch).toBe(true);
+    expect(o.intervalMs).toBe(500);
+    expect(o.untilConverged).toBe(true);
+    expect(o.maxPasses).toBe(10);
+  });
+
   it("DEFAULT_MATRIX is the 4-cell product", () => {
     expect(DEFAULT_MATRIX).toHaveLength(4);
   });

--- a/packages/cli/src/commands/eye/plan.ts
+++ b/packages/cli/src/commands/eye/plan.ts
@@ -31,6 +31,14 @@ export interface EyeOptions {
   /** Raw narrowing flags, re-applied after a spec-derived matrix is built. */
   viewport?: string;
   scheme?: string;
+  /** design #8 / sc#189 — warm-browser HMR re-eye loop. */
+  watch: boolean;
+  /** Poll interval between watch passes (ms). Default 2000. */
+  intervalMs: number;
+  /** In watch mode, exit 0 as soon as the gate passes. */
+  untilConverged: boolean;
+  /** Safety cap on watch passes. Default 60. */
+  maxPasses: number;
 }
 
 export const VIEWPORTS: Record<string, { width: number; height: number }> = {
@@ -108,6 +116,9 @@ export function parseEyeArgs(args: string[]): EyeOptions {
   if (maxV !== undefined) gate.maxViolations = Number.parseInt(maxV, 10);
   if (failOn) gate.failOnAxes = failOn.split(",").map((s) => s.trim()) as FidelityAxis[];
 
+  const interval = val(args, "--interval");
+  const maxPasses = val(args, "--max-passes");
+
   return {
     referenceUrl,
     candidateUrl,
@@ -118,5 +129,9 @@ export function parseEyeArgs(args: string[]): EyeOptions {
     cwd: val(args, "--cwd") ?? ".",
     viewport,
     scheme,
+    watch: args.includes("--watch"),
+    intervalMs: interval !== undefined ? Number.parseInt(interval, 10) : 2000,
+    untilConverged: args.includes("--until-converged"),
+    maxPasses: maxPasses !== undefined ? Number.parseInt(maxPasses, 10) : 60,
   };
 }

--- a/packages/cli/src/commands/eye/run.test.ts
+++ b/packages/cli/src/commands/eye/run.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { formatPassLine } from "./run.js";
+import type { FidelityGateResult } from "@slowcook-ai/gates";
+
+const res = (count: number, passed: boolean): FidelityGateResult => ({
+  passed,
+  violations: Array.from({ length: count }, () => ({
+    selector: ".x", axis: "color", property: "color",
+    expected: "a", actual: "b", evidence: "x",
+    context: { viewport: "mobile", scheme: "dark" },
+  })),
+  summary: { total: count, byAxis: { "computed-style": 0, color: count, box: 0, missing: 0 } },
+  byContext: [],
+});
+
+describe("formatPassLine (sc#189 watch loop)", () => {
+  it("omits the delta on the first pass (no previous total)", () => {
+    const line = formatPassLine(1, null, res(7, false));
+    expect(line).toContain("pass 1: 7 violation(s)");
+    expect(line).not.toContain("Δ");
+    expect(line).toContain("FAIL");
+  });
+
+  it("shows a negative delta as violations shrink", () => {
+    expect(formatPassLine(2, 7, res(3, false))).toContain("(Δ-4)");
+  });
+
+  it("shows +0 when unchanged and PASS at zero", () => {
+    expect(formatPassLine(3, 3, res(3, false))).toContain("(Δ+0)");
+    const conv = formatPassLine(4, 3, res(0, true));
+    expect(conv).toContain("0 violation(s) (Δ-3)");
+    expect(conv).toContain("PASS");
+  });
+
+  it("includes the per-axis summary", () => {
+    expect(formatPassLine(1, null, res(2, false))).toContain('"color":2');
+  });
+});

--- a/packages/cli/src/commands/eye/run.ts
+++ b/packages/cli/src/commands/eye/run.ts
@@ -7,7 +7,7 @@
  */
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { chromium } from "@playwright/test";
+import { chromium, type Page } from "@playwright/test";
 import {
   captureSnapshot,
   gradeFidelity,
@@ -69,4 +69,88 @@ export async function runEyeMatrix(opts: RunEyeOptions): Promise<RunEyeResult> {
   }
 
   return { result: gradeFidelity(pairs, opts.gate), screenshots };
+}
+
+/** Pure: one-line pass summary for the watch loop (`violations: N → M (Δ)`). */
+export function formatPassLine(pass: number, prevTotal: number | null, result: FidelityGateResult): string {
+  const c = result.violations.length;
+  const delta = prevTotal === null ? "" : ` (Δ${c - prevTotal >= 0 ? "+" : ""}${c - prevTotal})`;
+  return `pass ${pass}: ${c} violation(s)${delta} ${result.passed ? "PASS" : "FAIL"} ${JSON.stringify(result.summary.byAxis)}`;
+}
+
+export interface WatchEyeOptions extends RunEyeOptions {
+  intervalMs: number;
+  untilConverged: boolean;
+  maxPasses: number;
+  /** Injectable for tests/logging; defaults to console.log. */
+  log?: (msg: string) => void;
+}
+
+export interface WatchEyeResult {
+  result: FidelityGateResult;
+  passes: number;
+  converged: boolean;
+}
+
+/**
+ * sc#189 — warm-browser HMR re-eye loop. Captures the reference (static mock)
+ * ONCE per cell, keeps a warm candidate page per cell, and re-captures ONLY the
+ * candidate each pass (a `reload()` picks up HMR edits with no rebuild). Prints
+ * the per-axis violation delta each pass; with `untilConverged`, exits as soon
+ * as the gate passes. Bounded by `maxPasses`. The warm browser + reference-once
+ * capture is the win over re-running one-shot `eye` per iteration.
+ */
+export async function runEyeWatch(opts: WatchEyeOptions): Promise<WatchEyeResult> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  mkdirSync(opts.outDir, { recursive: true });
+  const browser = await chromium.launch();
+
+  const cells: { ctx: EyeContext; reference: StyleSnapshot; page: Page; close: () => Promise<void> }[] = [];
+  try {
+    const newCell = async (url: string, ctx: EyeContext) => {
+      const c = await browser.newContext({
+        colorScheme: ctx.scheme,
+        viewport: { width: ctx.width, height: ctx.height },
+        deviceScaleFactor: 2,
+      });
+      const p = await c.newPage();
+      await p.goto(url, { waitUntil: "networkidle" });
+      await p.waitForTimeout(400);
+      return { c, p };
+    };
+    for (const ctx of opts.matrix) {
+      const ref = await newCell(opts.referenceUrl, ctx);
+      const reference = await captureSnapshot(ref.p, { viewport: ctx.viewport, scheme: ctx.scheme });
+      await ref.c.close(); // reference is static — capture once, release it
+      const cand = await newCell(opts.candidateUrl, ctx);
+      cells.push({ ctx, reference, page: cand.p, close: () => cand.c.close() });
+    }
+
+    let prevTotal: number | null = null;
+    let result!: FidelityGateResult;
+    let converged = false;
+    let pass = 1;
+    for (; pass <= opts.maxPasses; pass++) {
+      const pairs: { reference: StyleSnapshot; candidate: StyleSnapshot }[] = [];
+      for (const cell of cells) {
+        await cell.page.reload({ waitUntil: "networkidle" });
+        await cell.page.waitForTimeout(300);
+        const candidate = await captureSnapshot(cell.page, { viewport: cell.ctx.viewport, scheme: cell.ctx.scheme });
+        pairs.push({ reference: cell.reference, candidate });
+      }
+      result = gradeFidelity(pairs, opts.gate);
+      log(formatPassLine(pass, prevTotal, result));
+      prevTotal = result.violations.length;
+      if (opts.untilConverged && result.passed) {
+        converged = true;
+        log("converged ✓");
+        break;
+      }
+      if (pass < opts.maxPasses) await new Promise((r) => setTimeout(r, opts.intervalMs));
+    }
+    return { result, passes: Math.min(pass, opts.maxPasses), converged };
+  } finally {
+    for (const cell of cells) await cell.close().catch(() => {});
+    await browser.close();
+  }
 }


### PR DESCRIPTION
Closes #189 (from the delgoosh 0.20 dogfood). Turns the one-shot `eye` into the tight inner loop the visual-fidelity stage wants: **edit → HMR → instant re-score, no cold restarts.**

- **`runEyeWatch`** (`eye/run.ts`): captures the static reference **once per cell**, keeps a **warm candidate page** per cell, and re-captures **only the candidate** each pass (`page.reload()` picks up HMR edits with no rebuild). Prints the per-axis violation delta; with `--until-converged` exits 0 as soon as the gate passes. Bounded by `--max-passes`.
- **`formatPassLine`** (pure, 4 tests): `pass N: C violation(s) (Δ±D) PASS/FAIL {byAxis}`.
- **plan**: `--watch` / `--interval <ms>` (default 2000) / `--until-converged` / `--max-passes` (default 60). 2 new parse tests.
- **index**: `--watch` branches to `runEyeWatch`; exits 1 if `--until-converged` and unconverged.
- manifest + README catalog updated (also adds the previously-missing `--story`).

Reuses `runEyeMatrix`'s capture + `gradeFidelity` — the only new surface is the warm-loop driver + candidate-only re-capture, exactly the shape agreed on the issue.

## Verification
cli **1249 tests** green; build clean; `--watch` in `eye --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)