### PR TITLE
feat: eye + mock live feedback loop — warm mock server + Playwright through refine/brew, behind-auth preview, 1-1 fixtures (#189/#191/#192)

### DIFF
--- a/docs/design/eye-mock-feedback-loop.md
+++ b/docs/design/eye-mock-feedback-loop.md
@@ -1,0 +1,66 @@
+# Eye + mock: a live, watchable, behind-auth fidelity feedback loop
+
+Status: proposal (consolidates #189, #191, #192 + the delgoosh dogfood findings).
+
+The eye is most valuable as a **continuous** signal, not a one-shot gate at the end.
+This doc specifies slowcook standing up + **keeping warm** the pieces that make
+visual convergence a live feedback loop the refine and brew agents (and the PM)
+use throughout a story — not just at brew's end.
+
+## 1. Live HMR mock reference server — stood up + announced, kept running
+
+- On `refine` start, slowcook starts the consumer mock in **HMR/dev** mode
+  (`vite dev`/`next dev`, stable rotating port) and **announces the URL**
+  (printed + PM-pushable): `mock (reference): https://…`.
+- It is **kept running across refine → brew → eye** (not torn down per stage), so:
+  - refine can open the exact mock surface it's writing a spec for;
+  - brew can diff its candidate against the live mock continuously;
+  - the PM watches convergence on a constant URL ("fun to watch").
+- Refuse/​warn if eye is invoked with no live reference.
+
+## 2. Warm eye / Playwright across the cycle (extends #189 `eye --watch`)
+
+- Launch the Playwright browser **once per cycle** and **reuse** it for every
+  re-eye (reference captured once; candidate reloaded each pass). No cold
+  relaunch per check → re-eye is ~instant.
+- Keep the warm eye **available during refine and brew**, not only at the end:
+  brew can call `eye --watch` after each edit and get a live violation-delta;
+  refine can sanity-check the surface it's spec'ing. Eye becomes the inner loop.
+- Browser install is environment-resilient: run locally if Playwright is
+  available; otherwise on the dev box (the delgoosh dogfood ran it locally with
+  Playwright 1.60 `chrome-headless-shell`).
+
+## 3. Behind-auth: dev-only preview seam (#192)
+
+Most surfaces are gated; eye must reach them. A **dev-only, env-gated** seam,
+scaffolded by `slowcook init` and documented in the managed agent-docs:
+two independent gates (build-time flag never set in prod → dead-stripped, **+**
+`?__preview`; backend NODE_ENV/origin check), a fake "Preview User" (no real
+session/PII), render-only. Applies to **both** the candidate **and** the mock
+reference (else you compare login-vs-page).
+
+## 4. 1-1 comparison: shared canonical fixtures via a dev-only data adaptor
+
+For eye to be 1-1 (only real UI drift, not data noise), **both** sides must
+render the **same** data:
+
+- A single **canonical fixtures** source (committed) is consumed by BOTH the
+  mock's mock-data layer AND the candidate's **dev-only data adaptor**.
+- The candidate's adaptor is **env-gated and excluded from the prod build** (it
+  only feeds fixtures in preview mode; prod uses the real client).
+- `eye … ?__preview&scenario=<name>` selects the same named fixture on both
+  sides → deterministic, reproducible, **1-1** screenshots. Without this, eye
+  noise is dominated by differing row counts / names (seen in the dogfood).
+
+## 5. Orchestration summary
+
+For a story's lifecycle slowcook keeps alive + announces:
+`{ mock HMR reference, warm eye browser, candidate dev server }`, feeds both
+sides the same fixtures, and runs eye as a **continuous** drift signal during
+refine/brew + a **gate** at brew end. Tear down on story close.
+
+### Provenance (delgoosh dogfood, 2026-06)
+Validated piecemeal: local eye run (Playwright 1.60) caught real login drift;
+a minimal #192 preview let eye render the authed `/patient/therapists`; the mock
+needed the same `?__preview` bypass; and ad-hoc (non-shared) fixtures made the
+comparison noisy — motivating §4.

--- a/docs/design/eye-mock-feedback-loop.md
+++ b/docs/design/eye-mock-feedback-loop.md
@@ -64,3 +64,21 @@ Validated piecemeal: local eye run (Playwright 1.60) caught real login drift;
 a minimal #192 preview let eye render the authed `/patient/therapists`; the mock
 needed the same `?__preview` bypass; and ad-hoc (non-shared) fixtures made the
 comparison noisy — motivating §4.
+
+## 6. Mode matrix must include locale / direction (not just viewport × scheme)
+
+Today eye's matrix is `viewport × scheme` (≤4). Bilingual / RTL apps add a **third
+axis — locale/direction** — so the full space is `viewport × scheme × locale`
+(e.g. desktop/mobile × light/dark × fa/en = 8). RTL layouts drift independently
+of LTR, so an en-LTR page can be broken while fa-RTL looks fine (and vice-versa).
+
+- **First-class axis.** `eye` should accept `--locale fa,en` (and `spec.fidelity.modes`
+  should express locale), driving the consumer's language the same dev way it drives
+  auth/preview — via a query param (`?lang=`/`?__preview`) honored on **both** the
+  candidate AND the mock reference. (A consumer that reads `?lang` only on one side
+  yields a 100%-mirror false-diff — observed in the delgoosh dogfood: en run jumped
+  to 1077 violations until the mock honored `?lang`, then collapsed to the fa baseline.)
+- **Consumer-declared subset (not always all 2^N).** Exhaustive 2^N is often overkill;
+  the consumer declares the *necessary* subset in `fidelity.modes`. delgoosh's call:
+  **6 of 8** — primary language (fa) full incl. dark (4), secondary (en) light-only (2).
+  eye runs exactly the declared cells.

--- a/docs/design/eye-mock-feedback-loop.md
+++ b/docs/design/eye-mock-feedback-loop.md
@@ -1,6 +1,8 @@
 # Eye + mock: a live, watchable, behind-auth fidelity feedback loop
 
-Status: proposal (consolidates #189, #191, #192 + the delgoosh dogfood findings).
+Status: in progress (consolidates #189, #191, #192 + the delgoosh dogfood findings).
+§4 (shared-fixture `--scenario`) and §6 (locale axis `--locale`) are **implemented**
+in `slowcook eye` (see `packages/cli/src/commands/eye`); §1/§2/§3/§5 remain proposed.
 
 The eye is most valuable as a **continuous** signal, not a one-shot gate at the end.
 This doc specifies slowcook standing up + **keeping warm** the pieces that make

--- a/packages/cli/src/commands/eye/index.ts
+++ b/packages/cli/src/commands/eye/index.ts
@@ -9,17 +9,23 @@
  *
  *   slowcook eye --reference http://localhost:33010 --candidate http://localhost:3001 \
  *     [--story 020] [--cwd .] [--out .brewing/eye] [--viewport mobile|desktop] \
- *     [--scheme light|dark] [--max-violations N] [--fail-on color,box,computed-style,missing]
+ *     [--scheme light|dark] [--locale fa,en] [--scenario <name>] \
+ *     [--max-violations N] [--fail-on color,box,computed-style,missing]
+ *
+ * --locale (§6) drives the consumer's language via `?lang=<code>` on BOTH sides
+ * (the locale/direction axis: viewport × scheme × locale). --scenario (§4) appends
+ * `?scenario=<name>` to BOTH sides so the mock + the candidate's dev-only data
+ * adaptor render the same fixture → a 1-1, data-noise-free diff.
  */
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseEyeArgs, matrixFromModes, narrowMatrix } from "./plan.js";
+import { parseEyeArgs, matrixFromModes, narrowMatrix, applyLocaleAxis } from "./plan.js";
 import { loadFidelityModes } from "./spec-modes.js";
-import { runEyeMatrix, runEyeWatch } from "./run.js";
+import { runEyeMatrix, runEyeWatch, cellLabel } from "./run.js";
 
 export async function eye(args: string[], _version: string): Promise<void> {
   if (args[0] === "--help" || args[0] === "-h") {
-    console.log("usage: slowcook eye --reference <url> --candidate <url> [--story <id>] [--cwd <dir>] [--out dir] [--viewport m] [--scheme s] [--max-violations N] [--fail-on a,b] [--watch [--interval ms] [--until-converged] [--max-passes N]]");
+    console.log("usage: slowcook eye --reference <url> --candidate <url> [--story <id>] [--cwd <dir>] [--out dir] [--viewport m] [--scheme s] [--locale fa,en] [--scenario name] [--max-violations N] [--fail-on a,b] [--watch [--interval ms] [--until-converged] [--max-passes N]]");
     return;
   }
 
@@ -36,7 +42,12 @@ export async function eye(args: string[], _version: string): Promise<void> {
   if (opts.story) {
     const modes = loadFidelityModes(opts.cwd, opts.story);
     if (modes && modes.length) {
-      opts.matrix = narrowMatrix(matrixFromModes(modes), { viewport: opts.viewport, scheme: opts.scheme });
+      // Spec declares the axes (incl. `locale:` tokens); CLI --locale narrows a
+      // declared locale axis, or opts one in if the spec declared none.
+      opts.matrix = applyLocaleAxis(
+        narrowMatrix(matrixFromModes(modes), { viewport: opts.viewport, scheme: opts.scheme, locales: opts.locales }),
+        opts.locales,
+      );
       console.log(`eye: matrix from story-${opts.story} fidelity.modes [${modes.join(", ")}] → ${opts.matrix.length} cell(s)`);
     } else {
       console.log(`eye: story-${opts.story} declares no fidelity.modes; using ${opts.matrix.length}-cell default matrix`);
@@ -52,6 +63,7 @@ export async function eye(args: string[], _version: string): Promise<void> {
       matrix: opts.matrix,
       outDir: opts.outDir,
       gate: opts.gate,
+      scenario: opts.scenario,
       intervalMs: opts.intervalMs,
       untilConverged: opts.untilConverged,
       maxPasses: opts.maxPasses,
@@ -68,13 +80,14 @@ export async function eye(args: string[], _version: string): Promise<void> {
     matrix: opts.matrix,
     outDir: opts.outDir,
     gate: opts.gate,
+    scenario: opts.scenario,
   });
   writeFileSync(join(opts.outDir, "eye-report.json"), JSON.stringify({ ...result, screenshots }, null, 2));
 
   console.log(`\nslowcook eye — ${result.passed ? "PASS ✓" : "FAIL ✗"} (${result.violations.length} violation(s) across ${opts.matrix.length} render(s))`);
   for (const ctx of result.byContext) {
     if (ctx.violations.length === 0) continue;
-    console.log(`  [${ctx.context.viewport}/${ctx.context.scheme}] ${ctx.violations.length}: ${JSON.stringify(ctx.summary.byAxis)}`);
+    console.log(`  [${cellLabel({ ...ctx.context, width: 0, height: 0 })}] ${ctx.violations.length}: ${JSON.stringify(ctx.summary.byAxis)}`);
     for (const v of ctx.violations.slice(0, 5)) console.log(`     ${v.axis}: ${v.evidence}`);
   }
   console.log(`  screenshots + report → ${opts.outDir}/`);

--- a/packages/cli/src/commands/eye/plan.test.ts
+++ b/packages/cli/src/commands/eye/plan.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { parseEyeArgs, DEFAULT_MATRIX, VIEWPORTS, matrixFromModes, narrowMatrix } from "./plan.js";
+import {
+  parseEyeArgs, DEFAULT_MATRIX, VIEWPORTS, matrixFromModes, narrowMatrix,
+  localesFromModes, applyLocaleAxis,
+} from "./plan.js";
 
 const base = ["--reference", "http://ref", "--candidate", "http://cand"];
 
-const cell = (c: { viewport: string; scheme: string }) => `${c.viewport}-${c.scheme}`;
+const cell = (c: { viewport: string; scheme: string; locale?: string }) =>
+  `${c.viewport}-${c.scheme}${c.locale ? `-${c.locale}` : ""}`;
 
 describe("matrixFromModes", () => {
   it("expands a full mode list to the 4-cell product", () => {
@@ -45,6 +49,60 @@ describe("narrowMatrix", () => {
     expect(() => narrowMatrix(DEFAULT_MATRIX, { viewport: "watch" })).toThrow(/unknown --viewport/);
     expect(() => narrowMatrix(DEFAULT_MATRIX, { scheme: "sepia" })).toThrow(/light\|dark/);
   });
+
+  it("narrows a locale axis when the matrix already has one (CLI can't widen the spec)", () => {
+    const m = applyLocaleAxis([{ viewport: "mobile", scheme: "light", width: 390, height: 844 }], ["fa", "en"]);
+    expect(narrowMatrix(m, { locales: ["fa"] }).map(cell)).toEqual(["mobile-light-fa"]);
+  });
+
+  it("ignores --locale when the matrix has no locale dimension (opt-in happens elsewhere)", () => {
+    expect(narrowMatrix(DEFAULT_MATRIX, { locales: ["fa"] }).map(cell).sort()).toEqual(
+      DEFAULT_MATRIX.map(cell).sort(),
+    );
+  });
+});
+
+describe("localesFromModes (§6)", () => {
+  it("extracts namespaced locale: tokens", () => {
+    expect(localesFromModes(["light", "dark", "locale:fa", "locale:en"])).toEqual(["fa", "en"]);
+  });
+  it("is case-insensitive, trims, ignores non-locale tokens", () => {
+    expect(localesFromModes([" Locale:FA ", "mobile"])).toEqual(["fa"]);
+  });
+  it("returns [] when none are declared", () => {
+    expect(localesFromModes(["light", "mobile"])).toEqual([]);
+  });
+});
+
+describe("applyLocaleAxis (§6)", () => {
+  const oneCell = [{ viewport: "mobile", scheme: "light" as const, width: 390, height: 844 }];
+
+  it("multiplies a locale-less matrix by the locales", () => {
+    expect(applyLocaleAxis(oneCell, ["fa", "en"]).map(cell)).toEqual(["mobile-light-fa", "mobile-light-en"]);
+  });
+  it("narrows an existing locale dimension instead of multiplying", () => {
+    const withLoc = applyLocaleAxis(oneCell, ["fa", "en"]);
+    expect(applyLocaleAxis(withLoc, ["en"]).map(cell)).toEqual(["mobile-light-en"]);
+  });
+  it("is a no-op when locales is empty/undefined", () => {
+    expect(applyLocaleAxis(oneCell, undefined)).toEqual(oneCell);
+    expect(applyLocaleAxis(oneCell, [])).toEqual(oneCell);
+  });
+});
+
+describe("matrixFromModes — locale axis", () => {
+  it("expands viewport × scheme × locale when locale: tokens are present", () => {
+    expect(matrixFromModes(["mobile", "dark", "locale:fa", "locale:en"]).map(cell).sort()).toEqual([
+      "mobile-dark-en", "mobile-dark-fa",
+    ]);
+  });
+  it("delgoosh's declared 6-of-8 subset: fa full + en light (via two specs is overkill; here the product)", () => {
+    // fa × {mobile,desktop} × {light,dark} = 4 ; declaring locale alone keeps viewport/scheme full
+    expect(matrixFromModes(["locale:fa"]).length).toBe(4);
+  });
+  it("no locale token → no locale dimension (unchanged behaviour)", () => {
+    expect(matrixFromModes(["mobile", "dark"]).every((c) => c.locale == null)).toBe(true);
+  });
 });
 
 describe("parseEyeArgs", () => {
@@ -80,6 +138,24 @@ describe("parseEyeArgs", () => {
   it("rejects unknown viewport / scheme", () => {
     expect(() => parseEyeArgs([...base, "--viewport", "watch"])).toThrow(/unknown --viewport/);
     expect(() => parseEyeArgs([...base, "--scheme", "sepia"])).toThrow(/light\|dark/);
+  });
+
+  it("adds a locale axis from --locale (CLI opts the axis in on the default matrix)", () => {
+    const o = parseEyeArgs([...base, "--locale", "fa,en"]);
+    expect(o.locales).toEqual(["fa", "en"]);
+    expect(o.matrix).toHaveLength(8); // 4 cells × 2 locales
+    expect(o.matrix.map(cell)).toContain("desktop-light-fa");
+    expect(o.matrix.map(cell)).toContain("mobile-dark-en");
+  });
+
+  it("--locale composes with --viewport/--scheme narrowing", () => {
+    const o = parseEyeArgs([...base, "--viewport", "mobile", "--scheme", "dark", "--locale", "fa,en"]);
+    expect(o.matrix.map(cell).sort()).toEqual(["mobile-dark-en", "mobile-dark-fa"]);
+  });
+
+  it("records --scenario for the shared-fixture data adaptor (§4)", () => {
+    expect(parseEyeArgs([...base, "--scenario", "matched-3"]).scenario).toBe("matched-3");
+    expect(parseEyeArgs(base).scenario).toBeUndefined();
   });
 
   it("maps --max-violations and --fail-on into gate options", () => {

--- a/packages/cli/src/commands/eye/plan.ts
+++ b/packages/cli/src/commands/eye/plan.ts
@@ -16,6 +16,13 @@ export interface EyeContext {
   scheme: "light" | "dark";
   width: number;
   height: number;
+  /**
+   * design §6 — locale/direction axis. When set, the runner drives the
+   * consumer's language by appending `?lang=<locale>` to BOTH the reference
+   * and the candidate URL (RTL/LTR layouts drift independently). Absent on
+   * the default matrix → unchanged viewport×scheme behaviour.
+   */
+  locale?: string;
 }
 
 export interface EyeOptions {
@@ -31,6 +38,18 @@ export interface EyeOptions {
   /** Raw narrowing flags, re-applied after a spec-derived matrix is built. */
   viewport?: string;
   scheme?: string;
+  /**
+   * design §6 — locale codes from `--locale fa,en`. Applied as a third matrix
+   * axis (driven via `?lang=` on both sides). When the spec/CLI declares none,
+   * the matrix has no locale dimension and behaviour is unchanged.
+   */
+  locales?: string[];
+  /**
+   * design §4 — shared-fixture scenario from `--scenario <name>`. Appended as
+   * `?scenario=<name>` to BOTH sides so the mock's mock-data layer and the
+   * candidate's dev-only data adaptor render the SAME fixture → 1-1 diff.
+   */
+  scenario?: string;
   /** design #8 / sc#189 — warm-browser HMR re-eye loop. */
   watch: boolean;
   /** Poll interval between watch passes (ms). Default 2000. */
@@ -54,25 +73,59 @@ export const DEFAULT_MATRIX: EyeContext[] = Object.entries(VIEWPORTS).flatMap(([
 );
 
 /**
+ * design §6 — extract locale codes from `fidelity.modes`. Locales are namespaced
+ * tokens (`locale:fa`, `locale:en`) so they never collide with viewport/scheme
+ * values and a typo stays ignored (fail-open). Returns [] when none declared.
+ */
+export function localesFromModes(modes: string[]): string[] {
+  return modes
+    .map((m) => String(m).toLowerCase().trim())
+    .filter((m) => m.startsWith("locale:"))
+    .map((m) => m.slice("locale:".length))
+    .filter(Boolean);
+}
+
+/**
+ * Add (or filter) the locale axis on a matrix (pure). If the matrix already
+ * carries a locale dimension, narrow it to `locales`; otherwise multiply each
+ * cell by the locales (CLI/spec opting the axis in). No-op when `locales` empty.
+ */
+export function applyLocaleAxis(matrix: EyeContext[], locales: string[] | undefined): EyeContext[] {
+  if (!locales || !locales.length) return matrix;
+  const set = new Set(locales);
+  if (matrix.some((c) => c.locale != null)) {
+    return matrix.filter((c) => c.locale != null && set.has(c.locale));
+  }
+  return matrix.flatMap((c) => locales.map((locale) => ({ ...c, locale })));
+}
+
+/**
  * Build the capture matrix from a spec's declared `fidelity.modes` (pure).
- * Tokens are dimension VALUES (`light`/`dark`/`mobile`/`desktop`), expanded to
- * the product: a dimension with no declared value defaults to its full set
- * (so `[dark]` → dark × {mobile,desktop}; `[mobile]` → {light,dark} × mobile).
- * Unrecognised tokens are ignored; if NONE are recognised, the full default
- * matrix is returned (fail-open — a typo never silently checks nothing).
+ * Tokens are dimension VALUES (`light`/`dark`/`mobile`/`desktop`, plus
+ * `locale:<code>` for the §6 locale axis), expanded to the product: a dimension
+ * with no declared value defaults to its full set (so `[dark]` → dark ×
+ * {mobile,desktop}; `[mobile]` → {light,dark} × mobile). Locale is OPTIONAL — no
+ * `locale:` token means no locale dimension. Unrecognised tokens are ignored; if
+ * NONE are recognised, the full default matrix is returned (fail-open — a typo
+ * never silently checks nothing).
  */
 export function matrixFromModes(modes: string[]): EyeContext[] {
   const wanted = new Set(modes.map((m) => String(m).toLowerCase().trim()));
   const viewports = Object.keys(VIEWPORTS).filter((v) => wanted.has(v));
   const schemes = SCHEMES.filter((s) => wanted.has(s));
-  if (!viewports.length && !schemes.length) return DEFAULT_MATRIX;
+  const locales = localesFromModes(modes);
+  if (!viewports.length && !schemes.length && !locales.length) return DEFAULT_MATRIX;
   const vps = viewports.length ? viewports : Object.keys(VIEWPORTS);
   const schs = schemes.length ? schemes : SCHEMES;
-  return vps.flatMap((viewport) => schs.map((scheme) => ({ viewport, scheme, ...VIEWPORTS[viewport]! })));
+  const base = vps.flatMap((viewport) => schs.map((scheme) => ({ viewport, scheme, ...VIEWPORTS[viewport]! })));
+  return applyLocaleAxis(base, locales);
 }
 
-/** Narrow a matrix by explicit --viewport / --scheme flags (pure). Validates. */
-export function narrowMatrix(base: EyeContext[], opts: { viewport?: string; scheme?: string }): EyeContext[] {
+/** Narrow a matrix by explicit --viewport / --scheme / --locale flags (pure). Validates. */
+export function narrowMatrix(
+  base: EyeContext[],
+  opts: { viewport?: string; scheme?: string; locales?: string[] },
+): EyeContext[] {
   let m = base;
   if (opts.viewport) {
     if (!VIEWPORTS[opts.viewport]) {
@@ -83,6 +136,11 @@ export function narrowMatrix(base: EyeContext[], opts: { viewport?: string; sche
   if (opts.scheme) {
     if (opts.scheme !== "light" && opts.scheme !== "dark") throw new Error("eye: --scheme must be light|dark");
     m = m.filter((c) => c.scheme === opts.scheme);
+  }
+  // Locale flags can only NARROW a spec-declared locale axis here; when the base
+  // has no locale dimension, applyLocaleAxis (in parseEyeArgs/index) opts it in.
+  if (opts.locales && opts.locales.length && m.some((c) => c.locale != null)) {
+    m = applyLocaleAxis(m, opts.locales);
   }
   return m;
 }
@@ -96,6 +154,7 @@ function val(args: string[], flag: string): string | undefined {
  * Parse `slowcook eye` flags. Required: --reference <url>, --candidate <url>.
  * Optional: --story <id> (derive the matrix from the spec's fidelity.modes),
  * --cwd <dir>, --out <dir>, --viewport <name> + --scheme <light|dark> (narrow),
+ * --locale <fa,en> (§6 locale axis), --scenario <name> (§4 shared fixture),
  * --max-violations <n>, --fail-on <a,b>. The returned `matrix` is the flag-only
  * default; when `story` is set the runner rebuilds it from the spec.
  */
@@ -108,7 +167,12 @@ export function parseEyeArgs(args: string[]): EyeOptions {
 
   const viewport = val(args, "--viewport");
   const scheme = val(args, "--scheme");
-  const matrix = narrowMatrix(DEFAULT_MATRIX, { viewport, scheme });
+  const localeArg = val(args, "--locale");
+  const locales = localeArg
+    ? localeArg.split(",").map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  // CLI default matrix has no locale dimension → applyLocaleAxis multiplies it in.
+  const matrix = applyLocaleAxis(narrowMatrix(DEFAULT_MATRIX, { viewport, scheme }), locales);
 
   const maxV = val(args, "--max-violations");
   const failOn = val(args, "--fail-on");
@@ -129,6 +193,8 @@ export function parseEyeArgs(args: string[]): EyeOptions {
     cwd: val(args, "--cwd") ?? ".",
     viewport,
     scheme,
+    locales,
+    scenario: val(args, "--scenario"),
     watch: args.includes("--watch"),
     intervalMs: interval !== undefined ? Number.parseInt(interval, 10) : 2000,
     untilConverged: args.includes("--until-converged"),

--- a/packages/cli/src/commands/eye/run.test.ts
+++ b/packages/cli/src/commands/eye/run.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { formatPassLine } from "./run.js";
+import { formatPassLine, withEyeParams, cellLabel } from "./run.js";
+import type { EyeContext } from "./plan.js";
 import type { FidelityGateResult } from "@slowcook-ai/gates";
+
+const ctx = (over: Partial<EyeContext> = {}): EyeContext => ({
+  viewport: "desktop", scheme: "light", width: 1280, height: 800, ...over,
+});
 
 const res = (count: number, passed: boolean): FidelityGateResult => ({
   passed,
@@ -34,5 +39,39 @@ describe("formatPassLine (sc#189 watch loop)", () => {
 
   it("includes the per-axis summary", () => {
     expect(formatPassLine(1, null, res(2, false))).toContain('"color":2');
+  });
+});
+
+describe("withEyeParams (§6 locale + §4 scenario)", () => {
+  it("returns the url unchanged when neither locale nor scenario applies", () => {
+    expect(withEyeParams("http://ref/patient", ctx())).toBe("http://ref/patient");
+  });
+
+  it("appends ?lang= for the locale axis", () => {
+    expect(withEyeParams("http://ref/p", ctx({ locale: "fa" }))).toBe("http://ref/p?lang=fa");
+  });
+
+  it("appends ?scenario= for the shared fixture", () => {
+    expect(withEyeParams("http://ref/p", ctx(), "matched-3")).toBe("http://ref/p?scenario=matched-3");
+  });
+
+  it("merges into an existing query (e.g. ?__preview=1) without clobbering it", () => {
+    const out = withEyeParams("http://ref/p?__preview=1", ctx({ locale: "en" }), "empty");
+    expect(out).toContain("__preview=1");
+    expect(out).toContain("lang=en");
+    expect(out).toContain("scenario=empty");
+  });
+
+  it("overwrites a stale lang param rather than duplicating it", () => {
+    expect(withEyeParams("http://ref/p?lang=en", ctx({ locale: "fa" }))).toBe("http://ref/p?lang=fa");
+  });
+});
+
+describe("cellLabel", () => {
+  it("is viewport-scheme without a locale", () => {
+    expect(cellLabel(ctx({ viewport: "mobile", scheme: "dark" }))).toBe("mobile-dark");
+  });
+  it("appends the locale when present", () => {
+    expect(cellLabel(ctx({ viewport: "mobile", scheme: "dark", locale: "fa" }))).toBe("mobile-dark-fa");
   });
 });

--- a/packages/cli/src/commands/eye/run.ts
+++ b/packages/cli/src/commands/eye/run.ts
@@ -21,11 +21,47 @@ export interface RunEyeOptions {
   referenceUrl: string;
   candidateUrl: string;
   matrix: EyeContext[];
-  /** Directory for screenshots. Files named `<label>-<viewport>-<scheme>.png`. */
+  /** Directory for screenshots. Files named `<label>-<viewport>-<scheme>[-<locale>].png`. */
   outDir: string;
   gate?: FidelityGateOptions;
   /** Screenshot filename prefix (e.g. `eye-pr-123`); default none. */
   shotPrefix?: string;
+  /**
+   * design §4 — shared-fixture scenario, appended as `?scenario=<name>` to BOTH
+   * sides so the mock's mock-data layer + the candidate's dev-only data adaptor
+   * render the SAME data → only real UI drift, no data noise.
+   */
+  scenario?: string;
+}
+
+/**
+ * Pure: build the per-cell URL by merging the §6 locale (`lang=`) and §4
+ * scenario (`scenario=`) query params into `url`, preserving any params already
+ * present (e.g. `?__preview=1`). Applied identically to reference + candidate so
+ * both render the same locale/fixture. Returns `url` unchanged when neither
+ * applies and the URL has no params to normalise.
+ */
+export function withEyeParams(url: string, ctx: EyeContext, scenario?: string): string {
+  if (!ctx.locale && !scenario) return url;
+  try {
+    const u = new URL(url);
+    if (ctx.locale) u.searchParams.set("lang", ctx.locale);
+    if (scenario) u.searchParams.set("scenario", scenario);
+    return u.toString();
+  } catch {
+    // Relative/opaque URL — fall back to naive append (keeps existing query).
+    const sep = url.includes("?") ? "&" : "?";
+    const extra = [
+      ctx.locale ? `lang=${encodeURIComponent(ctx.locale)}` : "",
+      scenario ? `scenario=${encodeURIComponent(scenario)}` : "",
+    ].filter(Boolean).join("&");
+    return extra ? `${url}${sep}${extra}` : url;
+  }
+}
+
+/** Pure: screenshot/label suffix for a cell — locale appended only when present. */
+export function cellLabel(ctx: EyeContext): string {
+  return `${ctx.viewport}-${ctx.scheme}${ctx.locale ? `-${ctx.locale}` : ""}`;
 }
 
 export interface RunEyeResult {
@@ -47,12 +83,12 @@ export async function runEyeMatrix(opts: RunEyeOptions): Promise<RunEyeResult> {
       deviceScaleFactor: 2,
     });
     const page = await c.newPage();
-    await page.goto(url, { waitUntil: "networkidle" });
+    await page.goto(withEyeParams(url, ctx, opts.scenario), { waitUntil: "networkidle" });
     await page.waitForTimeout(400); // let lazy / client styles settle
-    const shot = join(opts.outDir, `${prefix}${label}-${ctx.viewport}-${ctx.scheme}.png`);
+    const shot = join(opts.outDir, `${prefix}${label}-${cellLabel(ctx)}.png`);
     await page.screenshot({ path: shot, fullPage: true });
     screenshots.push(shot);
-    const snap = await captureSnapshot(page, { viewport: ctx.viewport, scheme: ctx.scheme });
+    const snap = await captureSnapshot(page, { viewport: ctx.viewport, scheme: ctx.scheme, locale: ctx.locale });
     await c.close();
     return snap;
   };
@@ -114,13 +150,13 @@ export async function runEyeWatch(opts: WatchEyeOptions): Promise<WatchEyeResult
         deviceScaleFactor: 2,
       });
       const p = await c.newPage();
-      await p.goto(url, { waitUntil: "networkidle" });
+      await p.goto(withEyeParams(url, ctx, opts.scenario), { waitUntil: "networkidle" });
       await p.waitForTimeout(400);
       return { c, p };
     };
     for (const ctx of opts.matrix) {
       const ref = await newCell(opts.referenceUrl, ctx);
-      const reference = await captureSnapshot(ref.p, { viewport: ctx.viewport, scheme: ctx.scheme });
+      const reference = await captureSnapshot(ref.p, { viewport: ctx.viewport, scheme: ctx.scheme, locale: ctx.locale });
       await ref.c.close(); // reference is static — capture once, release it
       const cand = await newCell(opts.candidateUrl, ctx);
       cells.push({ ctx, reference, page: cand.p, close: () => cand.c.close() });
@@ -135,7 +171,7 @@ export async function runEyeWatch(opts: WatchEyeOptions): Promise<WatchEyeResult
       for (const cell of cells) {
         await cell.page.reload({ waitUntil: "networkidle" });
         await cell.page.waitForTimeout(300);
-        const candidate = await captureSnapshot(cell.page, { viewport: cell.ctx.viewport, scheme: cell.ctx.scheme });
+        const candidate = await captureSnapshot(cell.page, { viewport: cell.ctx.viewport, scheme: cell.ctx.scheme, locale: cell.ctx.locale });
         pairs.push({ reference: cell.reference, candidate });
       }
       result = gradeFidelity(pairs, opts.gate);

--- a/packages/cli/src/commands/upsert-agent-docs.ts
+++ b/packages/cli/src/commands/upsert-agent-docs.ts
@@ -153,6 +153,17 @@ This is a HARD halt, and the integrity of it depends on you NOT bypassing it:
 
 The bot pipeline enforces the same gate via \`.github/workflows/slowcook-gate.yml\`; the local pipeline enforces it by your honouring this section.
 
+### Eye behind auth — dev-only preview (always available, design #192)
+
+Most real surfaces sit behind auth, so \`eye\` (headless) and PM preview links can only reach public pages **unless the consumer ships a dev-only preview seam**. Every consumer should stand one up so eye converges EVERY route deterministically — gated so it can NEVER work in prod:
+
+- **Two independent gates, both required.** Active only when a build-time flag is set (e.g. \`VITE_EYE_PREVIEW=1\` / \`EYE_PREVIEW=1\`) — never set in prod builds, so the branch is dead-stripped — AND the URL carries \`?__preview\`. If a backend is consulted it independently refuses the preview header unless \`NODE_ENV !== 'production'\` and the request origin is on a dev allowlist.
+- **No real session, no PII.** In preview the app short-circuits auth to a fake "Preview User" and resolves data through the fixture seam (\`useScenarioFixture\` / a fixture-returning API stub) to committed mock fixtures — so screenshots are reproducible.
+- **How eye uses it.** Pass the candidate as \`…/<route>?__preview[&scenario=<name>]\`. The mock *reference* needs the same bypass so BOTH sides render the authed route (else you compare login-vs-page).
+- **Safety.** The prod build asserts the flag is unset (guard/CI); any token is dev-secret-signed, short-lived, and render-only (mints no real identity).
+
+Stand this up once per consumer; thereafter eye is a real drift-guard on authed surfaces, not just public ones. See slowcook#192.
+
 ### Working alongside other agents (multi-agent choreography)
 
 When your work depends on another agent's still-open PR — common when one agent owns the app shell + another owns a feature inside it — follow this:

--- a/packages/gates/src/fidelity/snapshot.ts
+++ b/packages/gates/src/fidelity/snapshot.ts
@@ -19,6 +19,12 @@ export interface SnapshotContext {
   /** Color scheme the page was rendered under. */
   scheme: "light" | "dark";
   /**
+   * design §6 — locale/direction the page was rendered under (e.g. "fa"/"en").
+   * Absent on single-locale runs; present so the report distinguishes the
+   * RTL/LTR cells of the viewport×scheme×locale matrix.
+   */
+  locale?: string;
+  /**
    * Behavioural step label for stepped (event-sequence) captures, e.g.
    * "after:click [data-testid=submit]". Absent for static captures.
    */


### PR DESCRIPTION
Consolidates the mock + eye feedback-loop features surfaced in the delgoosh dogfood. Two parts:

### 1. Managed agent-docs section (code) — always-on behind-auth preview
`upsert-agent-docs` now writes an **"Eye behind auth — dev-only preview"** section into every consumer's AGENTS.md, so eye can converge **behind-auth** routes everywhere (secure contract: two independent gates, fake Preview User + fixture seam, no PII, prod build asserts the flag is unset). (#192)

### 2. Design doc — `docs/design/eye-mock-feedback-loop.md`
Specifies eye as a **continuous, live** signal, with emphasis on **keeping the mock server + Playwright warm through refine AND brew** (not just at eye-time):
- **Live HMR mock reference** stood up + **announced**, **kept running across refine → brew → eye** so those agents (and the PM) reference/​watch it continuously. (#191)
- **Warm Playwright reused per cycle** + available **during refine/brew** so re-eye is instant inner-loop feedback. (extends #189 `eye --watch`)
- **Dev-only auth-preview** on **both** candidate and mock reference (#192).
- **1-1 comparison via shared canonical fixtures** fed to both the mock and the candidate's **dev-only, prod-excluded data adaptor** — so eye shows real UI drift, not data noise.

### Provenance (dogfood)
Ran eye locally (Playwright 1.60) → caught real login drift; a minimal #192 preview rendered the authed `/patient/therapists`; the mock needed the same `?__preview` bypass; ad-hoc fixtures made comparison noisy → motivates the shared-fixtures adaptor.

Follow-ups (code): `init` scaffold for the preview seam + the data adaptor; eye keeping the mock+browser warm across stages; eye auto-appending `?__preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)