### PR TITLE
feat(gucdi): spine-schema foundation — spec fields + PRD parser (iter 1)

### DIFF
--- a/packages/cli/src/commands/menu/prd.test.ts
+++ b/packages/cli/src/commands/menu/prd.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parsePrdInitiatives, slugify } from "./prd.js";
+
+describe("slugify (GitHub anchor rules)", () => {
+  it("lowercases, hyphenates spaces, drops punctuation", () => {
+    expect(slugify("User Login & Auth")).toBe("user-login-auth");
+    expect(slugify("  Spaced  Out  ")).toBe("spaced-out");
+    expect(slugify("Already-hyphen")).toBe("already-hyphen");
+  });
+});
+
+describe("parsePrdInitiatives", () => {
+  it("extracts each heading as an anchored initiative with its body", () => {
+    const md = `# Product
+intro line
+
+## Onboarding
+Users sign up.
+More detail.
+
+## Dashboard
+Shows tickets.`;
+    const inits = parsePrdInitiatives(md);
+    expect(inits.map((i) => i.anchor)).toEqual(["product", "onboarding", "dashboard"]);
+    expect(inits[1]).toMatchObject({ title: "Onboarding", level: 2 });
+    expect(inits[1]!.body).toBe("Users sign up.\nMore detail.");
+    expect(inits[2]!.body).toBe("Shows tickets.");
+  });
+
+  it("honors an explicit {#custom-anchor}", () => {
+    const inits = parsePrdInitiatives("## Patient Onboarding {#onboarding-v1}\nbody");
+    expect(inits[0]).toMatchObject({ anchor: "onboarding-v1", title: "Patient Onboarding" });
+  });
+
+  it("ignores `#` inside fenced code blocks", () => {
+    const md = `## Real Heading
+\`\`\`bash
+# this is a shell comment, not a heading
+echo hi
+\`\`\`
+after`;
+    const inits = parsePrdInitiatives(md);
+    expect(inits).toHaveLength(1);
+    expect(inits[0]!.anchor).toBe("real-heading");
+    expect(inits[0]!.body).toContain("# this is a shell comment");
+  });
+
+  it("returns [] for a PRD with no headings", () => {
+    expect(parsePrdInitiatives("just prose, no headings")).toEqual([]);
+  });
+
+  it("captures nested headings as their own initiatives", () => {
+    const inits = parsePrdInitiatives("# A\n## A1\nx\n### A1a\ny");
+    expect(inits.map((i) => `${i.level}:${i.anchor}`)).toEqual(["1:a", "2:a1", "3:a1a"]);
+  });
+});

--- a/packages/cli/src/commands/menu/prd.ts
+++ b/packages/cli/src/commands/menu/prd.ts
@@ -1,0 +1,80 @@
+/**
+ * GUCDI — PRD parsing (pure). The `menu` agent decomposes a PRD into a story
+ * set; each story anchors back to a PRD initiative. This module turns a PRD
+ * markdown file into the list of anchorable initiatives (heading → GitHub-style
+ * slug) so those anchors are stable, grep-able, and traceable by `trace check`.
+ *
+ * See docs/plans/gucdi-greenfield.md.
+ */
+
+export interface PrdInitiative {
+  /** GitHub-style slug anchor (or an explicit `{#id}`), stable across edits. */
+  anchor: string;
+  /** Heading text (the initiative title). */
+  title: string;
+  /** Heading depth (1–6). */
+  level: number;
+  /** Prose under this heading, up to the next heading of any level. */
+  body: string;
+}
+
+/**
+ * GitHub heading-anchor slug: lowercase, spaces → hyphens, drop characters that
+ * aren't alphanumeric/hyphen, collapse repeats. Matches GitHub's algorithm
+ * closely enough for stable in-repo anchors.
+ */
+export function slugify(heading: string): string {
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "") // drop punctuation (keeps word chars, spaces, hyphens)
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Parse a PRD markdown string into its initiatives. Each ATX heading
+ * (`#`…`######`) becomes an initiative. An explicit trailing `{#custom-anchor}`
+ * on the heading overrides the slug. Body text is captured up to the next
+ * heading of any level. Lines inside fenced code blocks are ignored (so a `#`
+ * comment in a code sample isn't mistaken for a heading).
+ */
+export function parsePrdInitiatives(md: string): PrdInitiative[] {
+  const lines = md.split(/\r?\n/);
+  const inits: PrdInitiative[] = [];
+  let current: PrdInitiative | null = null;
+  let inFence = false;
+
+  const flush = () => {
+    if (current) {
+      current.body = current.body.replace(/\n+$/, "");
+      inits.push(current);
+    }
+  };
+
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      if (current) current.body += line + "\n";
+      continue;
+    }
+    const h = !inFence ? /^(#{1,6})\s+(.+?)\s*$/.exec(line) : null;
+    if (h) {
+      flush();
+      const level = h[1]!.length;
+      let title = h[2]!;
+      let anchor: string | null = null;
+      const explicit = /\{#([\w-]+)\}\s*$/.exec(title);
+      if (explicit) {
+        anchor = explicit[1]!;
+        title = title.replace(/\s*\{#[\w-]+\}\s*$/, "").trim();
+      }
+      current = { anchor: anchor ?? slugify(title), title, level, body: "" };
+    } else if (current) {
+      current.body += line + "\n";
+    }
+  }
+  flush();
+  return inits;
+}

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -153,6 +153,33 @@ const SpecSchema = z.object({
   // Dimension-value tokens (light|dark|mobile|desktop); the eye expands them to
   // the (declared-or-full) product. Absent = eye uses its full default matrix.
   fidelity: z.object({ modes: z.array(z.string()) }).optional(),
+  // GUCDI — provenance anchor to a PRD initiative (greenfield only). OPTIONAL:
+  // brownfield specs trace via source_issue instead, and `trace check` NEVER
+  // demands a prd_ref (provenance is the union {issue|prd|convention|craft}).
+  prd_ref: z.object({ file: z.string(), anchor: z.string() }).optional(),
+  // GUCDI — the data contract this story needs, baked into the LCR's SQLite+ORM
+  // schema and inherited by the backend (mock→prod becomes a data-source swap).
+  data_contract: z
+    .object({
+      entities: z
+        .array(
+          z.object({
+            name: z.string(),
+            fields: z.array(z.object({ name: z.string(), type: z.string() })).optional(),
+            relations: z.array(z.string()).optional(),
+          }),
+        )
+        .optional(),
+      api: z
+        .array(z.object({ method: z.string(), path: z.string(), note: z.string().optional() }))
+        .optional(),
+    })
+    .optional(),
+  // GUCDI — open questions surfaced at decomposition or via path-discovery.
+  // addressable = must resolve before the scope is "complete"; deferred = parked.
+  open_questions: z
+    .object({ addressable: z.array(z.string()), deferred: z.array(z.string()) })
+    .optional(),
   acceptance_scenarios: z.array(z.string()),
   non_goals: z.array(z.string()),
   related_specs: z


### PR DESCRIPTION
GUCDI iteration 1: the spine-schema foundation. Additive optional Spec fields (`prd_ref`, `data_contract`, `open_questions`) + a pure PRD-markdown parser (`menu/prd.ts`). Brownfield untouched — all fields optional, no PRD demanded. 6 new tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)