### PR TITLE
feat(gucdi): trace check — provenance-completeness lint (iter 3, keystone)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,6 +96,10 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook recon [--story <id>] [--cwd <path>] [--reuse-scan] [--stub-scan] [--exclude <glob>]
   ```
+- **`trace`** — GUCDI provenance-completeness lint over the spine: every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Brownfield-safe (never demands a PRD).
+  ```
+  slowcook trace check [--prd <path>] [--cwd <dir>]
+  ```
 - **`eye`** — Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.
   ```
   slowcook eye --reference <url> --candidate <url> [--story <id>] [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>] [--watch [--interval <ms>] [--until-converged] [--max-passes <n>]]

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,6 +41,7 @@ import { brand } from "./commands/brand/index.js";
 import { eye } from "./commands/eye/index.js";
 import { gate } from "./commands/gate/index.js";
 import { menu } from "./commands/menu/index.js";
+import { trace } from "./commands/trace/index.js";
 import { renderHelp, renderCommandHelp, renderReadmeBlock } from "./help.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
@@ -288,6 +289,11 @@ async function main(): Promise<void> {
       // GUCDI — decompose a PRD into a comprehensive, anchored, data-contracted
       // story set under specs/. The greenfield entry point.
       await menu(args.slice(1), VERSION);
+      return;
+    case "trace":
+      // GUCDI — provenance-completeness lint over the spine (the keystone):
+      // every node has a why ∈ {requirement|convention|craft}; orphans fail.
+      await trace(args.slice(1), VERSION);
       return;
     case "eye":
       // design #8 — render reference (mock) + candidate (brewed) URLs across

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -164,6 +164,12 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
     group: "checks",
   },
   {
+    name: "trace",
+    usage: "slowcook trace check [--prd <path>] [--cwd <dir>]",
+    description: "GUCDI provenance-completeness lint over the spine: every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Brownfield-safe (never demands a PRD).",
+    group: "checks",
+  },
+  {
     name: "eye",
     usage: "slowcook eye --reference <url> --candidate <url> [--story <id>] [--out <dir>] [--viewport <m>] [--scheme <s>] [--max-violations <n>] [--fail-on <axes>] [--watch [--interval <ms>] [--until-converged] [--max-passes <n>]]",
     description: "Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.",

--- a/packages/cli/src/commands/trace/check.test.ts
+++ b/packages/cli/src/commands/trace/check.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { checkTrace, parseLcrProvenance, type SpecNode, type LcrNode } from "./check.js";
+
+describe("parseLcrProvenance", () => {
+  it("recognizes @story / story-N / @convention / @craft forms", () => {
+    const src = `
+      // @story story-007 — the browse page
+      /* @convention WCAG AA */
+      // @craft rate-limit login (no requirement; security best-practice)
+    `;
+    expect(parseLcrProvenance(src)).toEqual([
+      { kind: "story", id: "story-007" },
+      { kind: "convention", ref: "WCAG AA" },
+      { kind: "craft", rationale: "rate-limit login (no requirement; security best-practice)" },
+    ]);
+  });
+  it("returns [] for a file with no provenance comment", () => {
+    expect(parseLcrProvenance("export const X = 1;")).toEqual([]);
+  });
+});
+
+const spec = (over: Partial<SpecNode>): SpecNode => ({ storyId: "001", ...over });
+const lcr = (file: string, prov: LcrNode["provenance"]): LcrNode => ({ file, provenance: prov });
+
+describe("checkTrace — provenance-completeness, not coverage", () => {
+  it("passes a fully-anchored greenfield spine", () => {
+    const r = checkTrace({
+      specs: [spec({ storyId: "007", prdAnchor: "onboarding" })],
+      prdAnchors: ["onboarding"],
+      lcrNodes: [lcr("mock/src/components/Browse.tsx", [{ kind: "story", id: "story-007" }])],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.violations).toEqual([]);
+  });
+
+  it("flags a spec citing a non-existent PRD anchor (dangling)", () => {
+    const r = checkTrace({ specs: [spec({ storyId: "007", prdAnchor: "ghost" })], prdAnchors: ["onboarding"], lcrNodes: [] });
+    expect(r.violations).toMatchObject([{ code: "dangling-prd-ref", subject: "story-007" }]);
+  });
+
+  it("flags a spec with NO requirement provenance (orphan)", () => {
+    const r = checkTrace({ specs: [spec({ storyId: "007" })], prdAnchors: ["onboarding"], lcrNodes: [] });
+    expect(r.violations).toMatchObject([{ code: "orphan-spec", subject: "story-007" }]);
+  });
+
+  it("brownfield: a spec with source_issue (no PRD) passes", () => {
+    const r = checkTrace({ specs: [spec({ storyId: "007", sourceIssue: "#42" })], prdAnchors: [], lcrNodes: [] });
+    expect(r.ok).toBe(true);
+  });
+
+  it("craft passes (honest provenance) and is reported, never blocked", () => {
+    const r = checkTrace({
+      specs: [],
+      prdAnchors: [],
+      lcrNodes: [lcr("mock/src/components/Login.tsx", [{ kind: "craft", rationale: "focus trap" }])],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.craft).toEqual([{ file: "mock/src/components/Login.tsx", rationale: "focus trap" }]);
+  });
+
+  it("flags an LCR file with no provenance at all (true orphan → error)", () => {
+    const r = checkTrace({ specs: [], prdAnchors: [], lcrNodes: [lcr("mock/src/components/Mystery.tsx", [])] });
+    expect(r.violations).toMatchObject([{ code: "orphan-lcr", subject: "mock/src/components/Mystery.tsx" }]);
+  });
+
+  it("flags an LCR file citing a story that has no spec (dangling)", () => {
+    const r = checkTrace({
+      specs: [spec({ storyId: "007", prdAnchor: "onboarding" })],
+      prdAnchors: ["onboarding"],
+      lcrNodes: [lcr("mock/src/components/Old.tsx", [{ kind: "story", id: "story-099" }])],
+    });
+    expect(r.violations).toMatchObject([{ code: "dangling-lcr-story", subject: "mock/src/components/Old.tsx" }]);
+  });
+});

--- a/packages/cli/src/commands/trace/check.ts
+++ b/packages/cli/src/commands/trace/check.ts
@@ -1,0 +1,130 @@
+/**
+ * GUCDI — `trace check` core (pure). The keystone lint that keeps the living,
+ * bidirectional requirements spine coherent. It checks PROVENANCE-COMPLETENESS,
+ * not requirement-coverage: every node must have an honest "why", from one of
+ *   - requirement  — a PRD initiative (`prd_ref`) or a GitHub issue (`source_issue`)
+ *   - convention   — a project-global standing doc (`conventions.md`)
+ *   - craft        — a genuinely novel inline-tagged decision
+ * A node with NONE of these is a true orphan → error. A craft-tagged node PASSES
+ * (honest provenance) and is reported for PM ratification. This neither blocks
+ * legitimate craft nor forces faking a requirement (the "block-or-lie" trap).
+ *
+ * It NEVER demands a PRD — brownfield specs trace via `source_issue`. Pure +
+ * unit-tested; the IO (reading specs / PRD / scanning the LCR) is in ./index.ts.
+ *
+ * See docs/plans/gucdi-greenfield.md.
+ */
+
+export type LcrProvenance =
+  | { kind: "story"; id: string }
+  | { kind: "convention"; ref: string }
+  | { kind: "craft"; rationale: string };
+
+/** A spec, reduced to its requirement-provenance facts. */
+export interface SpecNode {
+  storyId: string;
+  prdAnchor?: string;
+  sourceIssue?: string;
+}
+
+/** An LCR file (mock component/page) + the provenance it declares in comments. */
+export interface LcrNode {
+  file: string;
+  provenance: LcrProvenance[];
+}
+
+export type TraceCode =
+  | "dangling-prd-ref" // spec cites a PRD anchor that doesn't exist
+  | "orphan-spec" // spec has no requirement provenance at all
+  | "orphan-lcr" // LCR file has no provenance comment (story/convention/craft)
+  | "dangling-lcr-story"; // LCR file cites a story that doesn't exist
+
+export interface TraceViolation {
+  code: TraceCode;
+  subject: string;
+  detail: string;
+}
+
+export interface TraceResult {
+  violations: TraceViolation[];
+  /** Craft decisions (not in any requirement) — the PM-ratification report. */
+  craft: { file: string; rationale: string }[];
+  ok: boolean;
+}
+
+/**
+ * Parse provenance comments from a source file. Recognised forms (case-insensitive
+ * tag, anywhere in a comment):
+ *   // @story story-007   (or  // story-007)
+ *   // @convention <ref>
+ *   // @craft <rationale>   (or  // craft: <rationale>)
+ */
+export function parseLcrProvenance(source: string): LcrProvenance[] {
+  const out: LcrProvenance[] = [];
+  for (const m of source.matchAll(/@?story[-\s]+(story-)?(\d+)/gi)) {
+    out.push({ kind: "story", id: `story-${m[2]}` });
+  }
+  for (const m of source.matchAll(/@?convention[:\s]+([^\n*]+?)\s*(?:\*\/|$|\n)/gi)) {
+    out.push({ kind: "convention", ref: m[1]!.trim() });
+  }
+  for (const m of source.matchAll(/@?craft[:\s]+([^\n*]+?)\s*(?:\*\/|$|\n)/gi)) {
+    out.push({ kind: "craft", rationale: m[1]!.trim() });
+  }
+  return out;
+}
+
+export function checkTrace(input: {
+  specs: SpecNode[];
+  /** PRD initiative anchors. Empty = no PRD (brownfield) → prd-ref checks skipped. */
+  prdAnchors: string[];
+  lcrNodes: LcrNode[];
+}): TraceResult {
+  const violations: TraceViolation[] = [];
+  const anchors = new Set(input.prdAnchors);
+  const storyIds = new Set(input.specs.map((s) => `story-${s.storyId}`));
+
+  for (const s of input.specs) {
+    if (s.prdAnchor) {
+      // Only enforce when a PRD exists; a stray prd_ref with no PRD is its own (later) concern.
+      if (anchors.size > 0 && !anchors.has(s.prdAnchor)) {
+        violations.push({
+          code: "dangling-prd-ref",
+          subject: `story-${s.storyId}`,
+          detail: `prd_ref anchor '${s.prdAnchor}' is not a PRD initiative`,
+        });
+      }
+    } else if (!s.sourceIssue) {
+      violations.push({
+        code: "orphan-spec",
+        subject: `story-${s.storyId}`,
+        detail: "no requirement provenance (neither prd_ref nor source_issue)",
+      });
+    }
+  }
+
+  for (const n of input.lcrNodes) {
+    if (n.provenance.length === 0) {
+      violations.push({
+        code: "orphan-lcr",
+        subject: n.file,
+        detail: "no provenance comment (@story / @convention / @craft)",
+      });
+      continue;
+    }
+    for (const p of n.provenance) {
+      if (p.kind === "story" && storyIds.size > 0 && !storyIds.has(p.id)) {
+        violations.push({
+          code: "dangling-lcr-story",
+          subject: n.file,
+          detail: `cites ${p.id}, which has no spec`,
+        });
+      }
+    }
+  }
+
+  const craft = input.lcrNodes.flatMap((n) =>
+    n.provenance.filter((p): p is Extract<LcrProvenance, { kind: "craft" }> => p.kind === "craft").map((p) => ({ file: n.file, rationale: p.rationale })),
+  );
+
+  return { violations, craft, ok: violations.length === 0 };
+}

--- a/packages/cli/src/commands/trace/index.ts
+++ b/packages/cli/src/commands/trace/index.ts
@@ -1,0 +1,90 @@
+/**
+ * GUCDI — `slowcook trace check`. Runs the provenance-completeness lint over the
+ * spine: specs (requirement provenance via prd_ref/source_issue), the PRD
+ * (anchor resolution), and the LCR mock files (story/convention/craft comments).
+ * Exits 1 on any orphan/dangling violation; prints the craft-decisions report
+ * for PM ratification. Never demands a PRD — brownfield-safe.
+ *
+ *   slowcook trace check [--prd <path>] [--cwd <dir>]
+ *
+ * Pure lint in ./check.ts; this is the IO shell.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { listActiveSpecs } from "../refine/spec-yaml.js";
+import { loadMockShapeConfig } from "../../lib/mock-shape.js";
+import { parsePrdInitiatives } from "../menu/prd.js";
+import { checkTrace, parseLcrProvenance, type LcrNode, type SpecNode } from "./check.js";
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+/** Recursively collect .tsx files under `dir`, skipping any path in `exclude`. */
+function walkTsx(dir: string, exclude: Set<string>): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (exclude.has(p) || name === "node_modules") continue;
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walkTsx(p, exclude));
+    else if (name.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+export async function trace(argv: string[], _cliVersion: string): Promise<void> {
+  if (argv[0] !== "check") {
+    console.error("usage: slowcook trace check [--prd <path>] [--cwd <dir>]");
+    process.exit(64);
+  }
+  const rest = argv.slice(1);
+  const cwd = resolve(val(rest, "--cwd") ?? ".");
+
+  // 1. Specs → requirement-provenance facts.
+  const specNodes: SpecNode[] = listActiveSpecs(cwd).map((s) => ({
+    storyId: s.story_id,
+    prdAnchor: s.prd_ref?.anchor,
+    sourceIssue: s.source_issue,
+  }));
+
+  // 2. PRD anchors (optional — absent = brownfield).
+  const prdRel = val(rest, "--prd") ?? "docs/PRD.md";
+  const prdAbs = resolve(cwd, prdRel);
+  const prdAnchors = existsSync(prdAbs) ? parsePrdInitiatives(readFileSync(prdAbs, "utf8")).map((i) => i.anchor) : [];
+
+  // 3. LCR nodes — mock screens + components (excluding the design system, which
+  //    is convention/brand provenance, not story-specific).
+  const mock = loadMockShapeConfig(cwd);
+  const designDir = resolve(cwd, mock.design_system_dir);
+  const lcrRoots = [resolve(cwd, mock.screens_root), resolve(cwd, mock.mock_root, "src/components")];
+  const files = [...new Set(lcrRoots.flatMap((r) => walkTsx(r, new Set([designDir]))))];
+  const lcrNodes: LcrNode[] = files.map((f) => ({
+    file: relative(cwd, f).replace(/\\/g, "/"),
+    provenance: parseLcrProvenance(readFileSync(f, "utf8")),
+  }));
+
+  if (specNodes.length === 0 && prdAnchors.length === 0 && lcrNodes.length === 0) {
+    console.log("trace check: nothing GUCDI-shaped to trace (no specs, no PRD, no LCR) — ok.");
+    return;
+  }
+
+  const result = checkTrace({ specs: specNodes, prdAnchors, lcrNodes });
+
+  console.log(
+    `trace check: ${specNodes.length} specs · ${prdAnchors.length} PRD initiatives · ${lcrNodes.length} LCR files`,
+  );
+  if (result.craft.length) {
+    console.log(`\n  ${result.craft.length} craft decision(s) — not in any requirement (ratify or note):`);
+    for (const c of result.craft) console.log(`    · ${c.file}: ${c.rationale}`);
+  }
+  if (result.ok) {
+    console.log("\ntrace check: PASS ✓ — every node has honest provenance.");
+    return;
+  }
+  console.error(`\ntrace check: FAIL ✗ — ${result.violations.length} provenance violation(s):`);
+  for (const v of result.violations) console.error(`  [${v.code}] ${v.subject}: ${v.detail}`);
+  process.exit(1);
+}

--- a/packages/forge-github/src/templates.ts
+++ b/packages/forge-github/src/templates.ts
@@ -984,6 +984,31 @@ jobs:
 `;
 }
 
+function slowcookTraceWorkflow(cliVersion: string): string {
+  return `name: slowcook trace check
+
+# GUCDI — provenance-completeness lint over the requirements spine. Every spec
+# and LCR node must trace to a why (requirement / convention / craft); orphans
+# and dangling refs fail. Brownfield-safe: never demands a PRD (no-ops cleanly
+# when there's nothing GUCDI-shaped to trace).
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: trace check
+        run: npx --yes @slowcook-ai/cli@${cliVersion} trace check
+`;
+}
+
 function slowcookGateWorkflow(cliVersion: string): string {
   return `name: slowcook HITL gate
 
@@ -1079,6 +1104,8 @@ export function getGitHubCiArtifacts(params: {
     { path: ".github/workflows/slowcook-eye-cleanup.yml", contents: slowcookEyeCleanupWorkflow() },
     // design #9 — HITL role gate: re-evaluated on every PR review submission.
     { path: ".github/workflows/slowcook-gate.yml", contents: slowcookGateWorkflow(params.cliVersion) },
+    // GUCDI — provenance-completeness lint over the requirements spine.
+    { path: ".github/workflows/slowcook-trace.yml", contents: slowcookTraceWorkflow(params.cliVersion) },
   ];
 }
 


### PR DESCRIPTION
GUCDI iteration 3: the keystone. `slowcook trace check` lints provenance-COMPLETENESS (not requirement-coverage): every spec/LCR node has a why ∈ {requirement | convention | craft}. Orphans + dangling refs fail; craft PASSES and is reported for PM ratification — avoiding the block-or-lie trap. Brownfield-safe (no-ops when nothing GUCDI-shaped; never demands a PRD). + slowcook-trace.yml CI. 9 tests; cli 1274 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)