### PR TITLE
feat(gucdi): greenfield status — scope-completeness dashboard (iter 4)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,10 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook menu [--prd <path>] [--cwd <dir>] [--model <id>] [--dry-run]
   ```
+- **`greenfield`** — GUCDI scope-completeness dashboard: where the project is in PRD → stories → brand → LCR → trace, and the single next action.
+  ```
+  slowcook greenfield status [--prd <path>] [--cwd <dir>]
+  ```
 - **`refine`** — Drive a GitHub issue through a clarifying-question loop until a frozen spec PR is emitted.
   ```
   slowcook refine --issue <number> [--cwd <path>] [--owner <login>] [--repo <name>]

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,6 +42,7 @@ import { eye } from "./commands/eye/index.js";
 import { gate } from "./commands/gate/index.js";
 import { menu } from "./commands/menu/index.js";
 import { trace } from "./commands/trace/index.js";
+import { greenfield } from "./commands/greenfield/index.js";
 import { renderHelp, renderCommandHelp, renderReadmeBlock } from "./help.js";
 
 // Read VERSION from package.json at runtime so the CLI's self-reported
@@ -294,6 +295,11 @@ async function main(): Promise<void> {
       // GUCDI — provenance-completeness lint over the spine (the keystone):
       // every node has a why ∈ {requirement|convention|craft}; orphans fail.
       await trace(args.slice(1), VERSION);
+      return;
+    case "greenfield":
+      // GUCDI — scope-completeness dashboard: PRD → stories → brand → LCR →
+      // trace, and the single next action.
+      await greenfield(args.slice(1), VERSION);
       return;
     case "eye":
       // design #8 — render reference (mock) + candidate (brewed) URLs across

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -50,6 +50,12 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
     group: "pipeline",
   },
   {
+    name: "greenfield",
+    usage: "slowcook greenfield status [--prd <path>] [--cwd <dir>]",
+    description: "GUCDI scope-completeness dashboard: where the project is in PRD → stories → brand → LCR → trace, and the single next action.",
+    group: "pipeline",
+  },
+  {
     name: "refine",
     usage: "slowcook refine --issue <number> [--cwd <path>] [--owner <login>] [--repo <name>]",
     description: "Drive a GitHub issue through a clarifying-question loop until a frozen spec PR is emitted.",

--- a/packages/cli/src/commands/greenfield/index.ts
+++ b/packages/cli/src/commands/greenfield/index.ts
@@ -1,0 +1,88 @@
+/**
+ * GUCDI — `slowcook greenfield status`. The scope-completeness dashboard: where
+ * the project is in PRD → stories → brand → LCR → trace, and the single next
+ * action. Makes the step-by-step greenfield flow navigable (the individual
+ * agents — menu/brand/vibe/eye/trace — already exist).
+ *
+ *   slowcook greenfield status [--prd <path>] [--cwd <dir>]
+ *
+ * Pure planner in ./status.ts; this is the IO shell.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { listActiveSpecs } from "../refine/spec-yaml.js";
+import { loadMockShapeConfig } from "../../lib/mock-shape.js";
+import { parsePrdInitiatives } from "../menu/prd.js";
+import { checkTrace, parseLcrProvenance, type LcrNode, type SpecNode } from "../trace/check.js";
+import { computeGreenfieldStatus, type GreenfieldSpecFact } from "./status.js";
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function walkTsx(dir: string, exclude: Set<string>): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (exclude.has(p) || name === "node_modules") continue;
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walkTsx(p, exclude));
+    else if (name.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+export async function greenfield(argv: string[], _cliVersion: string): Promise<void> {
+  if (argv[0] !== "status") {
+    console.error("usage: slowcook greenfield status [--prd <path>] [--cwd <dir>]");
+    process.exit(64);
+  }
+  const rest = argv.slice(1);
+  const cwd = resolve(val(rest, "--cwd") ?? ".");
+
+  const specs = listActiveSpecs(cwd);
+
+  const prdRel = val(rest, "--prd") ?? "docs/PRD.md";
+  const prdAbs = resolve(cwd, prdRel);
+  const prdInitiatives = existsSync(prdAbs) ? parsePrdInitiatives(readFileSync(prdAbs, "utf8")) : [];
+
+  const mock = loadMockShapeConfig(cwd);
+  const designDir = resolve(cwd, mock.design_system_dir);
+  const lcrRoots = [resolve(cwd, mock.screens_root), resolve(cwd, mock.mock_root, "src/components")];
+  const files = [...new Set(lcrRoots.flatMap((r) => walkTsx(r, new Set([designDir]))))];
+  const lcrNodes: LcrNode[] = files.map((f) => ({
+    file: relative(cwd, f).replace(/\\/g, "/"),
+    provenance: parseLcrProvenance(readFileSync(f, "utf8")),
+  }));
+  const referenced = new Set(
+    lcrNodes.flatMap((n) => n.provenance.filter((p): p is { kind: "story"; id: string } => p.kind === "story").map((p) => p.id)),
+  );
+
+  const brandPresent = existsSync(resolve(cwd, mock.design_system_dir, "tokens.ts"));
+
+  const specNodes: SpecNode[] = specs.map((s) => ({ storyId: s.story_id, prdAnchor: s.prd_ref?.anchor, sourceIssue: s.source_issue }));
+  const traceViolations = checkTrace({ specs: specNodes, prdAnchors: prdInitiatives.map((i) => i.anchor), lcrNodes }).violations.length;
+
+  const specFacts: GreenfieldSpecFact[] = specs.map((s) => ({
+    storyId: s.story_id,
+    anchored: Boolean(s.prd_ref?.anchor || s.source_issue),
+    addressableQuestions: s.open_questions?.addressable?.length ?? 0,
+    hasLcr: referenced.has(`story-${s.story_id}`),
+  }));
+
+  const status = computeGreenfieldStatus({
+    prdInitiatives: prdInitiatives.length,
+    specs: specFacts,
+    brandPresent,
+    traceViolations,
+  });
+
+  console.log("slowcook greenfield — scope status\n");
+  for (const st of status.stages) {
+    console.log(`  ${st.done ? "✓" : "·"} ${st.name.padEnd(18)} ${st.detail}`);
+  }
+  console.log(`\n  scope-complete: ${status.scopeComplete ? "YES ✓" : "not yet"}`);
+  console.log(`  next: ${status.nextAction}`);
+}

--- a/packages/cli/src/commands/greenfield/status.test.ts
+++ b/packages/cli/src/commands/greenfield/status.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { computeGreenfieldStatus, type GreenfieldInput } from "./status.js";
+
+const base: GreenfieldInput = {
+  prdInitiatives: 3,
+  specs: [
+    { storyId: "001", anchored: true, addressableQuestions: 0, hasLcr: true },
+    { storyId: "002", anchored: true, addressableQuestions: 0, hasLcr: true },
+  ],
+  brandPresent: true,
+  traceViolations: 0,
+};
+
+describe("computeGreenfieldStatus", () => {
+  it("reports scope-complete when every stage is done", () => {
+    const s = computeGreenfieldStatus(base);
+    expect(s.scopeComplete).toBe(true);
+    expect(s.stages.every((st) => st.done)).toBe(true);
+    expect(s.nextAction).toMatch(/ready for backend/i);
+  });
+
+  it("next action is `menu` when the PRD exists but no stories", () => {
+    const s = computeGreenfieldStatus({ ...base, specs: [] });
+    expect(s.scopeComplete).toBe(false);
+    expect(s.nextAction).toMatch(/slowcook menu/);
+  });
+
+  it("next action is to write the PRD when there's none", () => {
+    const s = computeGreenfieldStatus({ ...base, prdInitiatives: 0, specs: [] });
+    expect(s.nextAction).toMatch(/Write the PRD/);
+  });
+
+  it("flags provenance gaps before brand", () => {
+    const s = computeGreenfieldStatus({
+      ...base,
+      brandPresent: false,
+      specs: [{ storyId: "001", anchored: false, addressableQuestions: 0, hasLcr: false }],
+    });
+    expect(s.nextAction).toMatch(/provenance gap/i);
+  });
+
+  it("points at the next un-vibed story", () => {
+    const s = computeGreenfieldStatus({
+      ...base,
+      specs: [
+        { storyId: "001", anchored: true, addressableQuestions: 0, hasLcr: true },
+        { storyId: "007", anchored: true, addressableQuestions: 0, hasLcr: false },
+      ],
+    });
+    expect(s.nextAction).toMatch(/Vibe story-007/);
+    expect(s.stages.find((st) => st.name === "LCR (vibe×eye)")!.detail).toBe("1/2 stories vibed");
+  });
+
+  it("blocks scope-complete on addressable open questions even when everything else is done", () => {
+    const s = computeGreenfieldStatus({
+      ...base,
+      specs: [{ storyId: "001", anchored: true, addressableQuestions: 2, hasLcr: true }],
+    });
+    expect(s.scopeComplete).toBe(false);
+    expect(s.nextAction).toMatch(/2 addressable open question/);
+  });
+
+  it("surfaces trace violations before open questions", () => {
+    const s = computeGreenfieldStatus({ ...base, traceViolations: 3 });
+    expect(s.nextAction).toMatch(/trace check/i);
+  });
+});

--- a/packages/cli/src/commands/greenfield/status.ts
+++ b/packages/cli/src/commands/greenfield/status.ts
@@ -1,0 +1,79 @@
+/**
+ * GUCDI — `greenfield status` core (pure). Computes where a greenfield project
+ * is in the PRD → stories → brand → LCR → trace pipeline, and the next action.
+ * It is also the **scope-completeness signal**: a scope is "complete" when every
+ * addressable question is answered, the trace is green, every story is in the
+ * LCR, and the brand is set — only then does the backend phase begin.
+ *
+ * Pure + unit-tested; the IO (reading PRD/specs/brand/LCR) is in ./index.ts.
+ * See docs/plans/gucdi-greenfield.md.
+ */
+
+export interface GreenfieldSpecFact {
+  storyId: string;
+  /** Has requirement provenance (prd_ref anchor or source_issue). */
+  anchored: boolean;
+  /** Count of unresolved *addressable* open questions (block scope-complete). */
+  addressableQuestions: number;
+  /** A mock LCR component references this story (it's been vibed). */
+  hasLcr: boolean;
+}
+
+export interface GreenfieldInput {
+  prdInitiatives: number;
+  specs: GreenfieldSpecFact[];
+  brandPresent: boolean;
+  traceViolations: number;
+}
+
+export interface GreenfieldStage {
+  name: string;
+  done: boolean;
+  detail: string;
+}
+
+export interface GreenfieldStatus {
+  stages: GreenfieldStage[];
+  scopeComplete: boolean;
+  /** The single next action to advance the pipeline (or the backend handoff). */
+  nextAction: string;
+}
+
+export function computeGreenfieldStatus(input: GreenfieldInput): GreenfieldStatus {
+  const { prdInitiatives, specs, brandPresent, traceViolations } = input;
+  const anchored = specs.filter((s) => s.anchored).length;
+  const vibed = specs.filter((s) => s.hasLcr).length;
+  const addressable = specs.reduce((n, s) => n + s.addressableQuestions, 0);
+
+  const prdDone = prdInitiatives > 0;
+  const storiesDone = specs.length > 0 && anchored === specs.length;
+  const brandDone = brandPresent;
+  const lcrDone = specs.length > 0 && vibed === specs.length;
+  const traceDone = traceViolations === 0;
+  const questionsDone = addressable === 0;
+
+  const stages: GreenfieldStage[] = [
+    { name: "PRD", done: prdDone, detail: `${prdInitiatives} initiative(s)` },
+    { name: "Stories (menu)", done: storiesDone, detail: `${specs.length} stories, ${anchored} anchored` },
+    { name: "Brand", done: brandDone, detail: brandPresent ? "design system present" : "no design system" },
+    { name: "LCR (vibe×eye)", done: lcrDone, detail: `${vibed}/${specs.length} stories vibed` },
+    { name: "Trace", done: traceDone, detail: traceViolations === 0 ? "provenance complete" : `${traceViolations} violation(s)` },
+    { name: "Open questions", done: questionsDone, detail: `${addressable} addressable unresolved` },
+  ];
+
+  const scopeComplete = prdDone && storiesDone && brandDone && lcrDone && traceDone && questionsDone;
+
+  let nextAction: string;
+  if (!prdDone) nextAction = "Write the PRD (default docs/PRD.md), then run `slowcook menu`.";
+  else if (specs.length === 0) nextAction = "Run `slowcook menu` to decompose the PRD into stories.";
+  else if (!storiesDone) nextAction = `Fix provenance gaps: ${specs.length - anchored} story(ies) lack a PRD anchor / source_issue (see \`trace check\`).`;
+  else if (!brandDone) nextAction = "Run `slowcook brand` to turn the brand brief into the design system.";
+  else if (!lcrDone) {
+    const next = specs.find((s) => !s.hasLcr);
+    nextAction = `Vibe story-${next!.storyId} into the mock, then \`slowcook eye --story ${next!.storyId}\` to converge it.`;
+  } else if (!traceDone) nextAction = "Resolve `trace check` violations (orphans / dangling refs).";
+  else if (!questionsDone) nextAction = `Resolve ${addressable} addressable open question(s) before the scope is complete.`;
+  else nextAction = "Scope complete ✓ — ready for backend: refine → recipe → brew → chef (data-source swap from the LCR's SQLite+ORM).";
+
+  return { stages, scopeComplete, nextAction };
+}


### PR DESCRIPTION
GUCDI iteration 4: `slowcook greenfield status` — the scope-completeness dashboard (PRD → stories → brand → LCR → trace + the single next action). Pure `computeGreenfieldStatus` (7 tests) + an IO shell that reuses menu/prd + trace/check + mock-shape. Makes the step-by-step greenfield flow navigable. cli 1281 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)