### PR TITLE
feat(gucdi): brand logo — tokenizer + deterministic PNG→SVG tracer (iter 5, final)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,9 +77,9 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook chef-orchestrate --pr <number> --story <id> [--cwd <path>]
   ```
-- **`brand`** — Design-system foundation agent. Emits mock/src/design-system/{tokens.ts, css.ts} from a brand brief.
+- **`brand`** — Design-system foundation agent. Emits mock/src/design-system/{tokens.ts, css.ts} from a brand brief. `brand logo` tokenizes a supplied SVG / deterministically traces a PNG (vtracer/potrace — no LLM path-authoring).
   ```
-  slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]
+  slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]  ·  slowcook brand logo --in <svg|png> [--out <dir>] [--map #hex=token,...]
   ```
 
 ### Checks + guards

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -309,8 +309,8 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "brand",
-    usage: "slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]",
-    description: "Design-system foundation agent. Emits mock/src/design-system/{tokens.ts, css.ts} from a brand brief.",
+    usage: "slowcook brand [--brief <prose>] [--refresh] [--dry-run] [--model <id>] [--cwd <path>]  ·  slowcook brand logo --in <svg|png> [--out <dir>] [--map #hex=token,...]",
+    description: "Design-system foundation agent. Emits mock/src/design-system/{tokens.ts, css.ts} from a brand brief. `brand logo` tokenizes a supplied SVG / deterministically traces a PNG (vtracer/potrace — no LLM path-authoring).",
     group: "pipeline",
   },
   {

--- a/packages/cli/src/commands/brand/index.ts
+++ b/packages/cli/src/commands/brand/index.ts
@@ -185,6 +185,13 @@ export function buildProjectContext(repoRoot: string, args: BrandArgs): string {
 }
 
 export async function brand(argv: string[], _cliVersion: string): Promise<void> {
+  // GUCDI — `brand logo` subcommand: tokenize a supplied SVG / trace a PNG.
+  if (argv[0] === "logo") {
+    const { brandLogo } = await import("./logo-cmd.js");
+    await brandLogo(argv.slice(1));
+    return;
+  }
+
   let args: BrandArgs;
   try {
     args = parseArgs(argv);

--- a/packages/cli/src/commands/brand/logo-cmd.ts
+++ b/packages/cli/src/commands/brand/logo-cmd.ts
@@ -1,0 +1,88 @@
+/**
+ * GUCDI — `slowcook brand logo`. Turns a supplied logo into a tokenized SVG for
+ * the design system. SVG → passthrough; PNG → deterministic trace (vtracer/
+ * potrace — an LLM NEVER authors paths, fixing the iterate-on-SVG pain) → then
+ * tokenize fills to design-token CSS-vars so it recolors with the brand and
+ * flips dark/light. Pure tokenizer in ./logo.ts; this is the tracer + IO shell.
+ *
+ *   slowcook brand logo --in <logo.svg|logo.png> [--out <dir>] [--cwd <dir>] [--map #hex=token,...]
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tokenizeSvg, untokenizedColors } from "./logo.js";
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function parseMap(s: string | undefined): Record<string, string> {
+  const m: Record<string, string> = {};
+  if (!s) return m;
+  for (const pair of s.split(",")) {
+    const [k, v] = pair.split("=");
+    if (k && v) m[k.trim()] = v.trim();
+  }
+  return m;
+}
+
+/** Deterministic PNG→SVG. vtracer (color) preferred, potrace (mono) fallback. */
+function traceToSvg(pngAbs: string): string {
+  const attempts: [string, string[]][] = [
+    ["vtracer", ["--input", pngAbs, "--output", "/dev/stdout"]],
+    ["potrace", ["--svg", "-o", "-", pngAbs]],
+  ];
+  for (const [bin, args] of attempts) {
+    try {
+      return execFileSync(bin, args, { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+    } catch (e) {
+      if ((e as { code?: string }).code !== "ENOENT") throw e;
+    }
+  }
+  throw new Error("no tracer found — install vtracer (`cargo install vtracer`) or potrace, or supply an .svg with --in");
+}
+
+export async function brandLogo(argv: string[]): Promise<void> {
+  const cwd = resolve(val(argv, "--cwd") ?? ".");
+  const inFile = val(argv, "--in");
+  if (!inFile) {
+    console.error("usage: slowcook brand logo --in <logo.svg|logo.png> [--out <dir>] [--map #hex=token,...]");
+    process.exit(64);
+  }
+  const inAbs = resolve(cwd, inFile);
+  if (!existsSync(inAbs)) {
+    console.error(`brand logo: input not found: ${inFile}`);
+    process.exit(64);
+  }
+  const outDir = resolve(cwd, val(argv, "--out") ?? join("mock", "src", "design-system"));
+  mkdirSync(outDir, { recursive: true });
+
+  let svg: string;
+  if (inFile.toLowerCase().endsWith(".svg")) {
+    svg = readFileSync(inAbs, "utf8");
+  } else {
+    console.log(`brand logo: tracing ${inFile} → SVG (deterministic; no LLM) ...`);
+    try {
+      svg = traceToSvg(inAbs);
+    } catch (e) {
+      console.error(`brand logo: ${String(e instanceof Error ? e.message : e)}`);
+      process.exit(69);
+    }
+  }
+
+  const map = parseMap(val(argv, "--map"));
+  const tokenized = tokenizeSvg(svg, map);
+  const outPath = join(outDir, "logo.svg");
+  writeFileSync(outPath, tokenized);
+  console.log(`brand logo: wrote ${outPath}`);
+
+  const remaining = untokenizedColors(tokenized, map);
+  if (remaining.length) {
+    console.log(`  ${remaining.length} color(s) still hardcoded — map them with --map (#hex=token):`);
+    for (const c of remaining) console.log(`    ${c}=<token>`);
+  } else if (Object.keys(map).length) {
+    console.log("  all colors tokenized → recolors with the brand + flips dark/light via CSS vars.");
+  }
+  console.log("  tip: render it + `slowcook eye` against the source to verify trace fidelity.");
+}

--- a/packages/cli/src/commands/brand/logo.test.ts
+++ b/packages/cli/src/commands/brand/logo.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { extractSvgColors, tokenizeSvg, untokenizedColors } from "./logo.js";
+
+const svg = `<svg><path fill="#3BAFA0" stroke="#2a8f82"/><circle fill="#FFF"/><rect fill="#3bafa0"/></svg>`;
+
+describe("extractSvgColors", () => {
+  it("returns distinct canonical colors in order", () => {
+    expect(extractSvgColors(svg)).toEqual(["#3bafa0", "#2a8f82", "#ffffff"]);
+  });
+});
+
+describe("tokenizeSvg", () => {
+  it("rewrites mapped colors to var(--token), case/shorthand-insensitive", () => {
+    const out = tokenizeSvg(svg, { "#3bafa0": "brand-primary", "#2A8F82": "brand-primary-dark", "#ffffff": "bg" });
+    expect(out).toContain('fill="var(--brand-primary)"');
+    expect(out).toContain('stroke="var(--brand-primary-dark)"');
+    expect(out).toContain('fill="var(--bg)"'); // #FFF matched via #ffffff
+    // both occurrences of the primary recolored
+    expect(out.match(/var\(--brand-primary\)/g)).toHaveLength(2);
+  });
+
+  it("leaves unmapped colors untouched", () => {
+    const out = tokenizeSvg(svg, { "#3bafa0": "brand-primary" });
+    expect(out).toContain('stroke="#2a8f82"');
+  });
+});
+
+describe("untokenizedColors", () => {
+  it("reports the colors the PM still needs to map", () => {
+    expect(untokenizedColors(svg, { "#3bafa0": "brand-primary" })).toEqual(["#2a8f82", "#ffffff"]);
+  });
+});

--- a/packages/cli/src/commands/brand/logo.ts
+++ b/packages/cli/src/commands/brand/logo.ts
@@ -1,0 +1,60 @@
+/**
+ * GUCDI — brand logo tokenizer (pure). The genuinely useful, deterministic part
+ * of the logo pipeline: take an SVG (passthrough, or PNG traced by potrace/
+ * vtracer in the command shell — an LLM NEVER authors paths) and rewrite its
+ * hardcoded colors to design-token CSS-var references so it recolors with the
+ * brand and flips for dark/light automatically.
+ *
+ * Pure + unit-tested. The tracer shell-out + IO live in ./logo-cmd.ts.
+ * See docs/plans/gucdi-greenfield.md Risk 4.
+ */
+
+/** Canonicalize a hex color to lowercase #rrggbb (expands #rgb). */
+function norm(hex: string): string {
+  let h = hex.replace("#", "").toLowerCase();
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
+  return `#${h}`;
+}
+
+function isColorLen(hex: string): boolean {
+  const n = hex.replace("#", "").length;
+  return n === 3 || n === 6;
+}
+
+/** Distinct colors (#rgb / #rrggbb), canonicalized, in document order. */
+export function extractSvgColors(svg: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of svg.matchAll(/#[0-9a-fA-F]{3,8}\b/g)) {
+    if (!isColorLen(m[0])) continue;
+    const c = norm(m[0]);
+    if (!seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+/**
+ * Replace each hardcoded hex color with `var(--<token>)` per `colorMap` (hex →
+ * token name, matched case-insensitively and #rgb/#rrggbb-equivalently). Colors
+ * not in the map are left untouched (and reported by the caller for the PM to
+ * map). Once tokenized, the same SVG flips dark/light via the CSS vars — no
+ * separate variant file needed.
+ */
+export function tokenizeSvg(svg: string, colorMap: Record<string, string>): string {
+  const map = new Map<string, string>();
+  for (const [k, v] of Object.entries(colorMap)) map.set(norm(k), v);
+  return svg.replace(/#[0-9a-fA-F]{3,8}\b/g, (hex) => {
+    if (!isColorLen(hex)) return hex;
+    const tok = map.get(norm(hex));
+    return tok ? `var(--${tok})` : hex;
+  });
+}
+
+/** Colors still hardcoded after tokenizing — what the PM must add to the map. */
+export function untokenizedColors(svg: string, colorMap: Record<string, string>): string[] {
+  const mapped = new Set(Object.keys(colorMap).map(norm));
+  return extractSvgColors(svg).filter((c) => !mapped.has(c));
+}


### PR DESCRIPTION
GUCDI iteration 5 (final): the logo pipeline. `slowcook brand logo --in <svg|png>` — SVG passthrough or deterministic PNG→SVG (vtracer/potrace; **no LLM path-authoring**, fixing the delgoosh logo back-and-forth) → tokenize hardcoded colors to `var(--brand-*)` (recolors + flips dark/light). Pure tokenizer (4 tests) + tracer shell-out seam. Completes the GUCDI 5-phase build. cli 1285 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)