### PR TITLE
feat(plate): free-navigation commenting for LCR mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ coverage/
 # artifacts and shouldn't be committed.
 /packages/cli/REPORTING.md
 /packages/cli/AGENTS.md
+
+# local OAuth-app credentials — never commit (client secret lives here; device flow doesn't even use it)
+github-slowcook-app-secret.txt
+*-app-secret.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## 0.21.1 — fix: publish llm-anthropic 0.18.0 (MENU_SYSTEM)
+
+`@slowcook-ai/cli` 0.21.1 · `@slowcook-ai/llm-anthropic` 0.18.0. The GUCDI `menu` command imports `MENU_SYSTEM`/`MenuStoryDraft` from llm-anthropic, but llm-anthropic was never republished after they were added — so cli 0.21.0 (pinning `^0.17.0`) crashed at load with `does not provide an export named 'MENU_SYSTEM'`. Bump llm-anthropic to 0.18.0 (with the menu prompt) and republish cli so it pins `^0.18.0`.
+
 ## 0.21.0 — multi-person LCR review (free-nav + GitHub identity + contextualised issues) · GUCDI commands
 
 `@slowcook-ai/cli` 0.21.0 · `@slowcook-ai/core` 0.15.0 · `@slowcook-ai/forge-github` 0.14.0 · `@slowcook-ai/review-overlay` 0.6.0. (Also the first release carrying the GUCDI greenfield commands — `menu`, `trace check`, `greenfield status`, `brand logo` — that landed on main after 0.20.0.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## 0.21.2 — trace-check coverage + persona-surface lints · review-overlay 0.7.2 (docs studio, persona pane, write-gate)
+
+`@slowcook-ai/cli` 0.21.2 · `@slowcook-ai/review-overlay` 0.7.2. (core/forge-github/llm-anthropic unchanged since 0.21.1.) Ships the two trace-check lints and the overlay 0.6.1→0.7.2 arc that had accumulated on the LCR-review branch under stale version numbers — npm's `cli@0.21.1` predated both lints, and `review-overlay` was still at 0.6.0.
+
+**`trace check` — two new lints:**
+- `--coverage` — the inverse of provenance: reports stories/requirements with no LCR mock surface. Opt-in hard-fail (backend-only stories legitimately have no surface, so it's off by default).
+- **persona-surface lint** (always-on hard fail): every spec's `persona` + `surfaces[].route` must resolve to a real mock router path (`/u/:handle` matches `/u/you`). Catches a promised-but-unbuilt surface.
+
+**review-overlay 0.6.1 → 0.7.2** (LCR multi-person review polish):
+- **0.7.0 Docs studio** — a 📄 mode that fetches/commits the spine markdown (PRD/stories/etc.) via the Contents API on the branch, so a reviewer's doc edit is itself a scope change.
+- **0.6.18 write-access apply-gate** — `GET /repos` `permissions.push` decides `vibe` auto-apply vs `community-review` held-for-PM; requires a GitHub login (no anon).
+- **0.7.1** persona switcher moves out of the mock into the pane (`surfaces` prop + `SurfaceSwitcher`, pushState nav); login-dialog z-index above the Docs panel.
+- **0.7.2** compact pane select (beats host `select{16px!important}`) + pane flex-wraps to 2 rows on portrait mobile.
+- **0.6.16/0.6.17** sticky pins, scroll-lock, page/element split, style-isolation; per-author pin identity + hide resolved pins.
+
 ## 0.21.1 — fix: publish llm-anthropic 0.18.0 (MENU_SYSTEM)
 
 `@slowcook-ai/cli` 0.21.1 · `@slowcook-ai/llm-anthropic` 0.18.0. The GUCDI `menu` command imports `MENU_SYSTEM`/`MenuStoryDraft` from llm-anthropic, but llm-anthropic was never republished after they were added — so cli 0.21.0 (pinning `^0.17.0`) crashed at load with `does not provide an export named 'MENU_SYSTEM'`. Bump llm-anthropic to 0.18.0 (with the menu prompt) and republish cli so it pins `^0.18.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
-## Unreleased — plate free-navigation commenting for LCRs
+## 0.21.0 — multi-person LCR review (free-nav + GitHub identity + contextualised issues) · GUCDI commands
 
-On `feat/plate-lcr-free-nav` (not yet cut/published). Pairs with the GUCDI LCR shape: a mock is now a full navigable app, so review must let a human roam every route and comment anywhere, not pick a scenario.
+`@slowcook-ai/cli` 0.21.0 · `@slowcook-ai/core` 0.15.0 · `@slowcook-ai/forge-github` 0.14.0 · `@slowcook-ai/review-overlay` 0.6.0. (Also the first release carrying the GUCDI greenfield commands — `menu`, `trace check`, `greenfield status`, `brand logo` — that landed on main after 0.20.0.)
+
+Pairs with the GUCDI LCR shape: a mock is now a full navigable app, so review lets a human roam every route and comment anywhere, not pick a scenario — and several reviewers can each sign in as themselves.
+
+**Multi-person LCR review** (review-overlay 0.6.0 + the new reviewer-identity seam):
+- `reviewMode: "scenarios" | "lcr"` (env `NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE`). In `lcr` mode the overlay shows on every route (incl. `/`), captures each comment's `pathname`/`route_query`/`route_story`, and files a standalone `[LCR] story-NNN` issue labelled `lcr-review`+`vibe` instead of a PR comment.
+- **Reviewer identity** — core `ForgeReviewerAuth` seam + forge-github `GitHubReviewerAuth` (OAuth device flow). run-mock in lcr mode hosts a device-flow auth-helper (`--expose` for a remote box); the overlay's "Sign in with GitHub" posts each comment as that reviewer's own account. Ships a default shared OAuth client-id (overridable via `.brewing/mock.yaml` `review_oauth_client_id`/`review_oauth_scope`).
+- **Lifecycle** — applied/declined/noop comments hide behind a "show already-applied" toggle; the new `needs-clarification` status stays visible.
+- `useStoryMarker`/`readCurrentStory` — an LCR page self-reports its story at runtime (`data-slowcook-story`) so the issue is tagged with the exact requirement.
+
+On `feat/plate-lcr-free-nav`.
 
 - **`@slowcook-ai/review-overlay` 0.6.0** — new `reviewMode: "scenarios" | "lcr"` prop (env `NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE`, default `scenarios`). In `lcr` mode the overlay no longer hides on the `/` route (an LCR's home is a first-class surface) and every comment payload now carries `pathname` + `route_query` (the route it was left on), rendered as a `**Route:**` line. Back-compat: scenario-mode payloads omit the fields; the parser ignores extras.
 - **plate** reads `payload.pathname` (falling back to parsing `url`) and prefixes each comment fed to the amendment agent with `` on route `/x` `` (new pure `plate/route-hint.ts`), so it amends the component rendering THAT page instead of guessing from the selector alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.8.0 → 0.8.2 — free-nav comment mode, deterministic auth guidance, test hardening
+
+`@slowcook-ai/review-overlay` 0.8.0–0.8.2 (overlay-only). The 0.8.0/0.8.1 features came from a slowcook session dogfooding the overlay on the **delgoosh** SPA (a private, RTL, mobile-reviewed mock) and feeding fixes back upstream; 0.8.2 backfills the test coverage + this changelog entry.
+
+**0.8.0 — arm-to-pick free navigation in LCR comment mode.** Comment mode used to capture *every* page click into a composer, exitable only via Escape — so mobile reviewers (no Esc key) were locked out of navigating the mock. Now a review session navigates the app freely; the reviewer arms a single element-pick ("📍 Pin a comment") and only the *next* click is captured, after which it auto-disarms. Mobile-safe on-screen cancels at every layer (armed banner, composer Cancel, toolbar toggle); Escape steps back one layer at a time (composer → armed pick → mode) instead of nuking the whole mode. The page tint shows only while a pick is live.
+
+**0.8.1 — deterministic auth guidance + classic-PAT sign-in.** Being signed in via the GitHub device-flow OAuth app is *not* enough to comment on a private repo or an OAuth-restricted org — the app's token is blocked and only carries `public_repo`, so reviewers hit an opaque `403 …OAuth App access restrictions…` toast. Now `describeAuthError()` maps 401/403/404 + GitHub's message to a plain-English reason and fix (keyed off the org/repo); the sign-in dialog always offers a classic-PAT path with baked-in instructions and a prefilled "create a classic token (`repo` scope)" link; `signInWithPat()` validates the token and derives identity + write-access tier; write failures that are really auth route to the dialog (`reportFailure()`) instead of a dead-end toast. Plus a docs note: statically-hosted mocks must serve `index.html` as `Cache-Control: no-cache` or reviewers keep seeing a stale mock after each redeploy (content-hashed assets stay immutable).
+
+**0.8.2 — test hardening.** `describeAuthError` is now exported and unit-tested (7 cases incl. the OAuth-restriction dead-end, case-insensitive match, and the 401/404/fallback paths); a jsdom render test covers the 0.8.0 arm-to-pick contract end-to-end (unarmed click navigates, armed click captures + auto-disarms) — which also proves the 0.7.3 shadow-DOM portal still delivers React click events. 73 overlay tests green (was 65).
+
 ## review-overlay 0.7.3 — Shadow-DOM style firewall (fixes host-CSS bleed on RTL / hard-reset hosts)
 
 `@slowcook-ai/review-overlay` 0.7.3 (overlay-only; cli unchanged). Fixes a real bug found dogfooding the overlay on the **delgoosh** SPA (a Persian, RTL app): the floating disk "lost its shape" and couldn't be gripped/dragged, and buttons were unclickable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## Unreleased — plate free-navigation commenting for LCRs
+
+On `feat/plate-lcr-free-nav` (not yet cut/published). Pairs with the GUCDI LCR shape: a mock is now a full navigable app, so review must let a human roam every route and comment anywhere, not pick a scenario.
+
+- **`@slowcook-ai/review-overlay` 0.6.0** — new `reviewMode: "scenarios" | "lcr"` prop (env `NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE`, default `scenarios`). In `lcr` mode the overlay no longer hides on the `/` route (an LCR's home is a first-class surface) and every comment payload now carries `pathname` + `route_query` (the route it was left on), rendered as a `**Route:**` line. Back-compat: scenario-mode payloads omit the fields; the parser ignores extras.
+- **plate** reads `payload.pathname` (falling back to parsing `url`) and prefixes each comment fed to the amendment agent with `` on route `/x` `` (new pure `plate/route-hint.ts`), so it amends the component rendering THAT page instead of guessing from the selector alone.
+- **run-mock** reads `review_mode` from `.brewing/mock.yaml` and passes it through as `NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE`. New `review_mode` field on the mock-shape config (default `scenarios`; GUCDI mocks set `lcr`).
+- Remaining for a full Vite LCR demo: the Vite mock template must mount `<SlowcookReviewOverlay reviewMode="lcr" />` (today only the Next.js template mounts the overlay), and the consumer must pin review-overlay 0.6.0 — both land once 0.6.0 publishes.
+
 ## 0.20.0 — anti-drift + HITL-halt pipeline: fidelity eye, role gates, dense extraction (sc#173 #12–#14)
 
 Cut 2026-06-07. `@slowcook-ai/cli` 0.20.0 · `@slowcook-ai/gates` 0.11.0 · `@slowcook-ai/llm-anthropic` 0.17.0 · `@slowcook-ai/forge-github` 0.13.0. (Also folds the unpublished 0.19.7 `slowcook serve` fixes, which never reached npm.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.7.3 — Shadow-DOM style firewall (fixes host-CSS bleed on RTL / hard-reset hosts)
+
+`@slowcook-ai/review-overlay` 0.7.3 (overlay-only; cli unchanged). Fixes a real bug found dogfooding the overlay on the **delgoosh** SPA (a Persian, RTL app): the floating disk "lost its shape" and couldn't be gripped/dragged, and buttons were unclickable.
+
+**Root cause — host CSS leaked *into* the overlay.** The overlay rendered straight into the host's DOM (no isolation boundary), so the host's *global* CSS bled onto it. Two delgoosh rules broke it: a universal reset `*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}` collapsed the disk's internal geometry, and `body{direction:rtl}` mirrored the toolbar and inverted the disk's `right`-anchored drag math. It "worked in rewo" only because rewo is LTR with a benign reset — and because earlier `!important` patches had been written reactively against rewo's *specific* CSS. (No rewo code/styles were ever bundled into the overlay — verified; the leak is purely host→overlay.)
+
+**Fix.** The whole UI now mounts inside a **Shadow DOM** on a body-level host element (`createPortal` into an open `shadowRoot`). Selector-based host CSS (`*{}` resets, `button{}` styles) physically can't cross the boundary. Inherited properties (direction/font/color) still cross, so an in-root `:host{ all: initial; direction: ltr; unicode-bidi: isolate; … }` reset re-establishes them — note `all` deliberately skips `direction`/`unicode-bidi`, which is exactly what un-mirrors the toolbar on RTL hosts. The host element carries no transform/filter, so `position: fixed` children still resolve to the viewport; comment-mode still queries the host document directly (the shadow only encapsulates the overlay's *own* UI). +2 jsdom tests reproducing the RTL+reset host (65 overlay tests green).
+
+**Also closes #205** (signed-in reviewer badge overlapped the draggable toolbar, grip unreachable): that was a 0.6.0-only bug already fixed in **0.6.2** by folding the sign-in into the floating disk (the separate `ReviewerSignInBadge` is gone). delgoosh was pinned to the npm-stale 0.6.0; 0.7.3 carries both fixes. Consumers on 0.6.x should bump.
+
 ## 0.21.2 — trace-check coverage + persona-surface lints · review-overlay 0.7.2 (docs studio, persona pane, write-gate)
 
 `@slowcook-ai/cli` 0.21.2 · `@slowcook-ai/review-overlay` 0.7.2. (core/forge-github/llm-anthropic unchanged since 0.21.1.) Ships the two trace-check lints and the overlay 0.6.1→0.7.2 arc that had accumulated on the LCR-review branch under stale version numbers — npm's `cli@0.21.1` predated both lints, and `review-overlay` was still at 0.6.0.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Status
 
+**0.21.2** (2026-06-22) — **GUCDI greenfield + multi-person LCR review.** The greenfield design-first flow (`slowcook menu` PRD→stories · `trace check` provenance + `--coverage` + persona-surface lints · `greenfield status` · `brand logo` tracer) turns a PRD into a navigable **Living Coded Requirement** mock before any backend. Review of that mock is now multi-person: the **review-overlay** (`0.7.2`) lets a human roam every route, comment anywhere, sign in as themselves (GitHub device-flow identity), edit the spine docs in a **Docs studio**, and switch personas in the pane; comments file as contextualised `[LCR] story-NNN` issues labelled `lcr-review`+`vibe`. A write-access apply-gate decides `vibe` auto-apply vs PM-held. Validated end-to-end dogfooding the rewo mock on a hosted box.
+
 **0.20.0 stable** (cut 2026-06-07) — the **anti-drift + HITL-halt pipeline** (designs #8/#9/#10, from the delgoosh design-react dogfood). The fidelity **eye** (`slowcook eye` — renders mock vs brewed across the viewport×scheme matrix, grades visual drift by computed-style/color/box, exits 1); **HITL role gates** (`slowcook gate check` — a stage advances only once a *human* in the required role approves on the PR; bot/agent reviews never satisfy a gate); **dense mock-style extraction** (recon pins each element's full className set, brewed ⊇ mock, instead of a 17-token allowlist). Specs declare `fidelity.modes`; the eye enforces them; brew is measured against them. Details in [`docs/plans/0.20-design-discussions.md`](./docs/plans/0.20-design-discussions.md).
 
 **0.19.5** (2026-06-01) — post-0.19.0 hardening batch. Five point releases over the 0.19.1 → 0.19.5 arc landed the post-emit refine lint chain (`validateEntityFieldReferences`, `validateComponentReuseShape`, `validateRouteCollisions`, `validatePlateDtoColumns`), `slowcook check spec` for PR-amendment safety, `slowcook cost log` for non-Actions agents, the chef DTO-rename surface grep, the brew dual-path + mirror-stories prompt tightening, and managed-block additions (`upsert-agent-docs`) for multi-agent choreography, no-import-stub, doc-audience, and combined-PR patterns. All four 0.20 design discussions are locked + documented in [`docs/plans/0.20-design-discussions.md`](./docs/plans/0.20-design-discussions.md): per-framework backend-adapter packages, `slowcook mirror` codegen, story-ID tombstones, recipe-emitted `brew_strategy`.
@@ -19,13 +21,15 @@ The 0.19.0 foundation — `.brewing/repo-knowledge/{auto,curated}/` deterministi
 
 | Package | Version | Brings |
 |---|---|---|
-| `@slowcook-ai/cli` | `0.20.0` (latest) | `slowcook eye` + `slowcook gate` commands · dense recon containment · spec `fidelity.modes` · now depends on `@slowcook-ai/gates` + `@playwright/test` |
-| `@slowcook-ai/gates` | `0.11.0` (latest) | fidelity engine: `diffSnapshots` / `captureSnapshot` / `gradeFidelity` / `runFidelityGate` (visual mock-vs-brewed diff) |
-| `@slowcook-ai/llm-anthropic` | `0.17.0` (latest) | brew plate-mode contract (verbatim presentation, data-wiring-only edits) + refine emits `fidelity.modes` |
-| `@slowcook-ai/forge-github` | `0.13.0` (latest) | `slowcook-eye` / `slowcook-eye-cleanup` / `slowcook-gate` workflows |
+| `@slowcook-ai/cli` | `0.21.2` (latest) | GUCDI commands (`menu` · `trace check` w/ `--coverage` + persona-surface lints · `greenfield status` · `brand logo`) · LCR free-nav review wiring · on top of `0.20.0`'s `eye` + `gate` |
+| `@slowcook-ai/review-overlay` | `0.7.2` (latest) | multi-person LCR review: GitHub device-flow identity, contextualised `[LCR]` issues, Docs studio, persona pane, write-access apply-gate, sticky pins |
+| `@slowcook-ai/core` | `0.15.0` (latest) | spine schema on `Spec` (`prd_ref` / `data_contract` / `open_questions` / `fidelity`) + `ForgeReviewerAuth` seam |
+| `@slowcook-ai/forge-github` | `0.14.0` (latest) | `GitHubReviewerAuth` (device flow) · `slowcook-trace` workflow · `slowcook-eye` / `slowcook-gate` |
+| `@slowcook-ai/llm-anthropic` | `0.18.0` (latest) | `MENU_SYSTEM` / `MenuStoryDraft` (PRD→stories prompt) + plate-mode contract |
+| `@slowcook-ai/gates` | `0.11.0` (latest) | fidelity engine: `diffSnapshots` / `captureSnapshot` / `gradeFidelity` / `runFidelityGate` |
 | `@slowcook-ai/stack-ts` | `0.9.9` (latest) | (no changes since 0.19.0) |
 
-**Adopting:** `npm install @slowcook-ai/cli@0.20.0`. Pin in your `.brewing/slowcook-cli-version`. First-run consumers get the full knowledge-layer bedrock automatically via `slowcook init`.
+**Adopting:** `npm install @slowcook-ai/cli@0.21.2`. Pin in your `.brewing/slowcook-cli-version`. First-run consumers get the full knowledge-layer bedrock automatically via `slowcook init`.
 
 **Milestone 2026-05-27 — knowledge layer + chef-on-brew-halt loop closed (cli α.51 → α.65):** Eleven alphas shipped over two days. Highlights: chef stops hallucinating spec fields (α.51); brew `legacy` renamed to `freehand` with navigator default-on (α.52); chef-drift parse-tolerant (α.53); chef owns test infrastructure incl. vitest.config + package.json devDeps (α.54); navigator gets scope + hallucination discipline (α.55); chef-on-brew-halt loop fully wired: halt artifact → enrichment from iteration_diffs → checkout brew_branch → push fix as PR (α.56-α.60); refine sees NestJS/TypeORM backend digest (α.61); ten disk-cached repo-knowledge digests + curated git-history-mined files (α.62-α.63); AGENTS.md managed block (α.64); init wires the whole bedrock automatically (α.65). Empirical wins from dogfood consumers: chef wrote a real layout component (not className-padded regex bait); refine cited exact mock file paths + brand-token vocabulary + cross-story context — zero hallucinations vs the α.61 baseline that invented routes.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "CLI for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -171,8 +171,8 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "trace",
-    usage: "slowcook trace check [--prd <path>] [--cwd <dir>]",
-    description: "GUCDI provenance-completeness lint over the spine: every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Brownfield-safe (never demands a PRD).",
+    usage: "slowcook trace check [--prd <path>] [--cwd <dir>] [--coverage]",
+    description: "GUCDI traceability lint over the spine. Provenance (forward): every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Coverage (inverse): reports stories with no LCR surface; --coverage makes them a hard failure (for UI milestones). Brownfield-safe (never demands a PRD).",
     group: "checks",
   },
   {

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -172,7 +172,7 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   {
     name: "trace",
     usage: "slowcook trace check [--prd <path>] [--cwd <dir>] [--coverage]",
-    description: "GUCDI traceability lint over the spine. Provenance (forward): every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Coverage (inverse): reports stories with no LCR surface; --coverage makes them a hard failure (for UI milestones). Brownfield-safe (never demands a PRD).",
+    description: "GUCDI traceability lint over the spine. Provenance (forward): every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Coverage (inverse): reports stories with no LCR surface; --coverage makes them a hard failure (for UI milestones). Persona surfaces: each spec's declared persona surface route must resolve to a real mock router path (a promised surface the mock doesn't expose fails). Brownfield-safe (never demands a PRD).",
     group: "checks",
   },
   {

--- a/packages/cli/src/commands/plate/index.ts
+++ b/packages/cli/src/commands/plate/index.ts
@@ -23,6 +23,7 @@ import {
 import { runPlate, type PlateContext } from "./agent.js";
 import { writeVibeFiles } from "../vibe/emit.js";
 import { classifyComment, type Classification } from "./classify.js";
+import { routeHint } from "./route-hint.js";
 import type { PlateFeedback } from "./prompts.js";
 
 const APPROVED_LABEL = "slowcook-mockup-approved";
@@ -461,10 +462,13 @@ export async function plate(argv: string[], cliVersion: string): Promise<void> {
       const anchorPreview = el
         ? `selector \`${el.selector}\` (${el.tag}${el.text_hint ? ` · "${el.text_hint}"` : ""})`
         : "general note (no element anchor)";
+      // 0.6.0 — LCR free-nav: surface the route the comment was left on so
+      // the agent amends the component that renders THAT page, not a guess
+      // from the element selector alone. (See ./route-hint.ts.)
       return {
         author: o.raw.author,
         body:
-          `[${o.classification}] ${anchorPreview}:\n\n` +
+          `[${o.classification}]${routeHint(o.payload)} ${anchorPreview}:\n\n` +
           o.payload.prose +
           `\n\n_(Plate classifier: ${o.rationale})_`,
         createdAt: o.raw.createdAt,

--- a/packages/cli/src/commands/plate/route-hint.test.ts
+++ b/packages/cli/src/commands/plate/route-hint.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { routeOf, routeHint } from "./route-hint.js";
+
+describe("routeOf — LCR free-nav route derivation", () => {
+  it("prefers the explicit pathname + route_query (LCR-mode payload)", () => {
+    expect(
+      routeOf({ pathname: "/r/webb-deep-field", route_query: "?clean=1", url: "http://x/ignored" }),
+    ).toBe("/r/webb-deep-field?clean=1");
+  });
+
+  it("uses pathname alone when there is no query", () => {
+    expect(routeOf({ pathname: "/discover", url: "http://x" })).toBe("/discover");
+  });
+
+  it("falls back to parsing url when pathname is absent (scenario / old payload)", () => {
+    expect(routeOf({ url: "http://localhost:3100/u/lena?x=1" })).toBe("/u/lena");
+  });
+
+  it("returns undefined when neither pathname nor a parseable url exists", () => {
+    expect(routeOf({ url: "not a url" })).toBeUndefined();
+  });
+});
+
+describe("routeHint — agent timeline fragment", () => {
+  it("formats a backticked route fragment", () => {
+    expect(routeHint({ pathname: "/blocks", url: "http://x" })).toBe(" on route `/blocks`");
+  });
+
+  it("is empty when the route is unknowable", () => {
+    expect(routeHint({ url: "::::" })).toBe("");
+  });
+});

--- a/packages/cli/src/commands/plate/route-hint.ts
+++ b/packages/cli/src/commands/plate/route-hint.ts
@@ -1,0 +1,34 @@
+/**
+ * 0.6.0 — LCR free-nav route hint (pure).
+ *
+ * In LCR review mode the reviewer roams the mock's own router and leaves
+ * comments on arbitrary routes (`/r/<slug>`, `/discover`, ...). Each
+ * review-overlay comment carries the route it was left on. Plate surfaces
+ * that route to the amendment agent so it edits the component rendering
+ * THAT page rather than guessing from the element selector alone.
+ *
+ * `pathname` is set by the overlay in LCR mode; older / scenario-mode
+ * payloads omit it, so we fall back to parsing the captured `url`.
+ */
+import type { ReviewCommentPayload } from "@slowcook-ai/review-overlay";
+
+/** The route (path + query) a comment was left on, or undefined if unknowable. */
+export function routeOf(payload: Pick<ReviewCommentPayload, "pathname" | "route_query" | "url">): string | undefined {
+  const path =
+    payload.pathname ??
+    (() => {
+      try {
+        return new URL(payload.url).pathname;
+      } catch {
+        return undefined;
+      }
+    })();
+  if (!path) return undefined;
+  return `${path}${payload.route_query ?? ""}`;
+}
+
+/** A `" on route \`/x\`"` fragment for the agent timeline, or "" when unknown. */
+export function routeHint(payload: Pick<ReviewCommentPayload, "pathname" | "route_query" | "url">): string {
+  const route = routeOf(payload);
+  return route ? ` on route \`${route}\`` : "";
+}

--- a/packages/cli/src/commands/run-mock/index.ts
+++ b/packages/cli/src/commands/run-mock/index.ts
@@ -62,6 +62,12 @@ interface Args {
    * NEXT_PUBLIC_SLOWCOOK_REVIEW). PM uses DevTools instead.
    */
   garnish: boolean;
+  /**
+   * 0.6.0 — bind the reviewer auth-helper on 0.0.0.0 (not 127.0.0.1) so a
+   * co-worker's browser can reach it for LCR review hosted on a remote box.
+   * Safe: the helper carries no host secret. Only meaningful in lcr mode.
+   */
+  expose: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -72,6 +78,7 @@ function parseArgs(argv: string[]): Args {
     skipInstall: false,
     branchOverride: null,
     garnish: false,
+    expose: false,
   };
   // Positional first arg is story id (consumer convenience).
   if (argv.length > 0 && argv[0] && !argv[0].startsWith("-")) {
@@ -88,6 +95,7 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--no-poll") { args.pollSeconds = 0; }
     else if (a === "--skip-install") { args.skipInstall = true; }
     else if (a === "--garnish") { args.garnish = true; }
+    else if (a === "--expose") { args.expose = true; }
     else if (a === "--help" || a === "-h") { printHelp(); process.exit(0); }
   }
   if (!args.story) {
@@ -119,6 +127,9 @@ Options:
   --poll-seconds <n>       Auto-pull interval (default 15; 0 disables).
   --no-poll                Disable auto-pull.
   --skip-install           Skip npm install even on lockfile drift.
+  --expose                 (0.6.0) Bind the LCR reviewer sign-in helper on
+                           0.0.0.0 so a co-worker on another machine can reach
+                           it. Use when hosting LCR review on a remote box.
   --garnish                (0.19.0-α.16) DevTools Workspaces mode. Disables
                            the review-overlay; instead prints Chrome
                            Workspaces pairing instructions + watches
@@ -270,10 +281,40 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
   // local gh CLI; falls back silently when gh isn't installed or the
   // user hasn't logged in (overlay then uses its old PAT-prompt path).
   //
-  // 0.19.0-α.16 — in --garnish mode the overlay is disabled, so we
-  // skip starting the proxy (saves a port + a couple of stderr lines).
+  // 0.19.0+ (sc#82) — detect mock shape so the log message is honest.
+  // `npm run dev` works for both shapes (Next.js: `next dev`; Vite:
+  // `vite`) — only the cosmetic label here needs branching.
+  // 0.6.0 — also read review_mode so an LCR mock gets the free-nav
+  // overlay (shows on every route + per-route comment capture).
+  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
+  const mockConfig = loadMockShapeConfig(args.repoRoot);
+  const mockShape = mockConfig.shape;
+  const isLcr = mockConfig.review_mode === "lcr";
+
+  // Host the comment-submission helpers. Two distinct identity models:
+  //  - scenarios mode → gh-proxy: substitutes the HOST's `gh auth token` so
+  //    the solo PM never pastes a PAT. Must stay on 127.0.0.1 (it carries a
+  //    privileged token).
+  //  - lcr mode → reviewer auth-helper: device-flow endpoints so EACH reviewer
+  //    signs in as themselves (per-person attribution). Carries no host secret,
+  //    so it's safe to expose off-host with --expose for the remote-box case.
+  // 0.6.0 — in --garnish mode the overlay is disabled, so we skip both.
   let proxy: ProxyHandle | null = null;
-  if (!args.garnish) {
+  let authServer: { url: string; close: () => void } | null = null;
+  let reviewClientId = "";
+  const bindHost = args.expose ? "0.0.0.0" : "127.0.0.1";
+  if (!args.garnish && isLcr) {
+    const { GitHubReviewerAuth, SLOWCOOK_REVIEW_OAUTH_CLIENT_ID } = await import("@slowcook-ai/forge-github");
+    const { startReviewerAuthServer } = await import("./reviewer-auth-server.js");
+    reviewClientId = mockConfig.review_oauth_client_id ?? SLOWCOOK_REVIEW_OAUTH_CLIENT_ID;
+    try {
+      const auth = new GitHubReviewerAuth({ clientId: reviewClientId, scope: mockConfig.review_oauth_scope });
+      authServer = await startReviewerAuthServer(auth, { clientId: reviewClientId, host: bindHost });
+      console.log(`  auth   reviewer sign-in helper on ${authServer.url} (device flow; each reviewer signs in as themselves)${args.expose ? " — exposed on 0.0.0.0" : ""}`);
+    } catch (e) {
+      console.warn(`  auth   reviewer auth-helper failed to start (${(e as Error).message}); overlay will fall back to PAT prompt.`);
+    }
+  } else if (!args.garnish) {
     const ghToken = readGhToken();
     if (ghToken) {
       try {
@@ -289,31 +330,35 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
     console.log(`  proxy  skipped (--garnish mode; overlay disabled)`);
   }
 
-  // 0.19.0+ (sc#82) — detect mock shape so the log message is honest.
-  // `npm run dev` works for both shapes (Next.js: `next dev`; Vite:
-  // `vite`) — only the cosmetic label here needs branching.
-  // 0.6.0 — also read review_mode so an LCR mock gets the free-nav
-  // overlay (shows on every route + per-route comment capture).
-  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
-  const mockConfig = loadMockShapeConfig(args.repoRoot);
-  const mockShape = mockConfig.shape;
-
-  // Step 4: spawn next dev with env vars.
+  // Step 4: spawn next dev with env vars. Set BOTH NEXT_PUBLIC_* (Next.js
+  // inlines these) and VITE_* (Vite only exposes VITE_-prefixed vars to
+  // import.meta.env) so the overlay mount reads the same values in either
+  // mock shape.
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (!args.garnish) {
-    env["NEXT_PUBLIC_SLOWCOOK_REVIEW"] = "1";
-    env["NEXT_PUBLIC_SLOWCOOK_OWNER"] = detected.owner;
-    env["NEXT_PUBLIC_SLOWCOOK_REPO"] = detected.repo;
-    env["NEXT_PUBLIC_SLOWCOOK_PR_NUMBER"] = prNumber ? String(prNumber) : "0";
-    env["NEXT_PUBLIC_SLOWCOOK_STORY_ID"] = args.story;
-    env["NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE"] = mockConfig.review_mode;
-    if (proxy) env["NEXT_PUBLIC_SLOWCOOK_GH_PROXY"] = proxy.url;
+    const overlayEnv: Record<string, string> = {
+      REVIEW: "1",
+      OWNER: detected.owner,
+      REPO: detected.repo,
+      PR_NUMBER: prNumber ? String(prNumber) : "0",
+      STORY_ID: args.story,
+      REVIEW_MODE: mockConfig.review_mode,
+    };
+    if (proxy) overlayEnv["GH_PROXY"] = proxy.url;
+    if (authServer) {
+      overlayEnv["AUTH_BASE"] = authServer.url;
+      overlayEnv["REVIEW_CLIENT_ID"] = reviewClientId;
+    }
+    for (const [k, v] of Object.entries(overlayEnv)) {
+      env[`NEXT_PUBLIC_SLOWCOOK_${k}`] = v;
+      env[`VITE_SLOWCOOK_${k}`] = v;
+    }
   }
 
   const devLabel = mockShape === "vite" ? "vite :3100" : "next dev :3100";
   console.log(`  npm    run dev (${devLabel})`);
   if (!args.garnish) {
-    console.log(`         overlay env: REVIEW=1 MODE=${mockConfig.review_mode} OWNER=${detected.owner} REPO=${detected.repo} PR=${prNumber ?? "?"} STORY=${args.story}${proxy ? ` GH_PROXY=${proxy.url}` : ""}`);
+    console.log(`         overlay env: REVIEW=1 MODE=${mockConfig.review_mode} OWNER=${detected.owner} REPO=${detected.repo} PR=${prNumber ?? "?"} STORY=${args.story}${proxy ? ` GH_PROXY=${proxy.url}` : ""}${authServer ? ` AUTH_BASE=${authServer.url}` : ""}`);
     if (!prNumber) {
       console.warn(`         (no open mockup PR found for branch ${branch}; overlay submits will fail until one exists)`);
     }
@@ -420,6 +465,7 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
     if (watcher) { try { watcher.close(); } catch { /* ignore */ } }
     if (watcherDebounceTimer) { clearTimeout(watcherDebounceTimer); watcherDebounceTimer = null; }
     if (proxy) { try { proxy.close(); } catch { /* ignore */ } }
+    if (authServer) { try { authServer.close(); } catch { /* ignore */ } }
     if (dev && !dev.killed) {
       try { dev.kill(signal as NodeJS.Signals ?? "SIGTERM"); } catch { /* ignore */ }
     }

--- a/packages/cli/src/commands/run-mock/index.ts
+++ b/packages/cli/src/commands/run-mock/index.ts
@@ -289,6 +289,15 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
     console.log(`  proxy  skipped (--garnish mode; overlay disabled)`);
   }
 
+  // 0.19.0+ (sc#82) — detect mock shape so the log message is honest.
+  // `npm run dev` works for both shapes (Next.js: `next dev`; Vite:
+  // `vite`) — only the cosmetic label here needs branching.
+  // 0.6.0 — also read review_mode so an LCR mock gets the free-nav
+  // overlay (shows on every route + per-route comment capture).
+  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
+  const mockConfig = loadMockShapeConfig(args.repoRoot);
+  const mockShape = mockConfig.shape;
+
   // Step 4: spawn next dev with env vars.
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (!args.garnish) {
@@ -297,18 +306,14 @@ export async function runMock(argv: string[], _cliVersion: string): Promise<void
     env["NEXT_PUBLIC_SLOWCOOK_REPO"] = detected.repo;
     env["NEXT_PUBLIC_SLOWCOOK_PR_NUMBER"] = prNumber ? String(prNumber) : "0";
     env["NEXT_PUBLIC_SLOWCOOK_STORY_ID"] = args.story;
+    env["NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE"] = mockConfig.review_mode;
     if (proxy) env["NEXT_PUBLIC_SLOWCOOK_GH_PROXY"] = proxy.url;
   }
 
-  // 0.19.0+ (sc#82) — detect mock shape so the log message is honest.
-  // `npm run dev` works for both shapes (Next.js: `next dev`; Vite:
-  // `vite`) — only the cosmetic label here needs branching.
-  const { loadMockShapeConfig } = await import("../../lib/mock-shape.js");
-  const mockShape = loadMockShapeConfig(args.repoRoot).shape;
   const devLabel = mockShape === "vite" ? "vite :3100" : "next dev :3100";
   console.log(`  npm    run dev (${devLabel})`);
   if (!args.garnish) {
-    console.log(`         overlay env: REVIEW=1 OWNER=${detected.owner} REPO=${detected.repo} PR=${prNumber ?? "?"} STORY=${args.story}${proxy ? ` GH_PROXY=${proxy.url}` : ""}`);
+    console.log(`         overlay env: REVIEW=1 MODE=${mockConfig.review_mode} OWNER=${detected.owner} REPO=${detected.repo} PR=${prNumber ?? "?"} STORY=${args.story}${proxy ? ` GH_PROXY=${proxy.url}` : ""}`);
     if (!prNumber) {
       console.warn(`         (no open mockup PR found for branch ${branch}; overlay submits will fail until one exists)`);
     }

--- a/packages/cli/src/commands/run-mock/reviewer-auth-server.test.ts
+++ b/packages/cli/src/commands/run-mock/reviewer-auth-server.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { ForgeReviewerAuth, DeviceCodeGrant, PollResult, ReviewerIdentity } from "@slowcook-ai/core";
+import { startReviewerAuthServer, type AuthServerHandle } from "./reviewer-auth-server.js";
+
+class FakeAuth implements ForgeReviewerAuth {
+  pollResult: PollResult = { status: "pending" };
+  async requestDeviceCode(): Promise<DeviceCodeGrant> {
+    return { deviceCode: "DC123", userCode: "WXYZ-1234", verificationUri: "https://github.com/login/device", intervalSeconds: 5, expiresInSeconds: 900 };
+  }
+  async pollAccessToken(deviceCode: string): Promise<PollResult> {
+    return deviceCode === "DC123" ? this.pollResult : { status: "denied" };
+  }
+  async identify(): Promise<ReviewerIdentity> {
+    return { login: "x", name: "x" };
+  }
+}
+
+describe("reviewer-auth-server", () => {
+  let handle: AuthServerHandle | null = null;
+  afterEach(() => { handle?.close(); handle = null; });
+
+  it("serves health with the client-id suffix", async () => {
+    handle = await startReviewerAuthServer(new FakeAuth(), { clientId: "Ov23liABCDwxyz", preferredPort: 4310 });
+    const r = await fetch(`${handle.url}/__slowcook/auth/health`);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ ok: true, clientIdSuffix: "wxyz" });
+  });
+
+  it("starts a device grant + polls a deviceCode", async () => {
+    const fake = new FakeAuth();
+    fake.pollResult = { status: "authorized", token: "tok-abc" };
+    handle = await startReviewerAuthServer(fake, { clientId: "cid", preferredPort: 4320 });
+
+    const dev = await (await fetch(`${handle.url}/__slowcook/auth/device`, { method: "POST" })).json();
+    expect(dev.userCode).toBe("WXYZ-1234");
+    expect(dev.verificationUri).toContain("github.com/login/device");
+
+    const poll = await (await fetch(`${handle.url}/__slowcook/auth/poll`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ deviceCode: dev.deviceCode }),
+    })).json();
+    expect(poll).toEqual({ status: "authorized", token: "tok-abc" });
+  });
+
+  it("400s a poll with no deviceCode, 404s unknown paths", async () => {
+    handle = await startReviewerAuthServer(new FakeAuth(), { clientId: "cid", preferredPort: 4330 });
+    const bad = await fetch(`${handle.url}/__slowcook/auth/poll`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+    expect(bad.status).toBe(400);
+    const nope = await fetch(`${handle.url}/__slowcook/auth/nope`);
+    expect(nope.status).toBe(404);
+  });
+
+  it("sets permissive CORS + answers preflight", async () => {
+    handle = await startReviewerAuthServer(new FakeAuth(), { clientId: "cid", preferredPort: 4340 });
+    const pre = await fetch(`${handle.url}/__slowcook/auth/device`, { method: "OPTIONS", headers: { Origin: "http://box:3100" } });
+    expect(pre.status).toBe(204);
+    expect(pre.headers.get("access-control-allow-origin")).toBe("http://box:3100");
+  });
+});

--- a/packages/cli/src/commands/run-mock/reviewer-auth-server.ts
+++ b/packages/cli/src/commands/run-mock/reviewer-auth-server.ts
@@ -1,0 +1,135 @@
+/**
+ * Reviewer auth-helper server (0.6.0) — multi-person LCR review.
+ *
+ * GitHub's device-flow token endpoints (github.com/login/device/code +
+ * /login/oauth/access_token) are NOT CORS-accessible from a browser, so the
+ * overlay can't run the device dance itself. This tiny server (started by
+ * run-mock in `review_mode: lcr`) does the two server-side hops on the
+ * overlay's behalf and nothing else.
+ *
+ * Crucially it is SAFE TO EXPOSE off-host (unlike gh-proxy, which injects the
+ * host's own token): it only forwards the PUBLIC client-id + a per-session
+ * device code to GitHub's public device endpoints. The reviewer's resulting
+ * access token is returned to whoever completed the GitHub consent — the host
+ * never sees a privileged secret. So for the remote-box case it binds 0.0.0.0;
+ * for local use, 127.0.0.1.
+ *
+ * Endpoints (all JSON, permissive CORS):
+ *   POST /__slowcook/auth/device  → { userCode, verificationUri, deviceCode, intervalSeconds, expiresInSeconds }
+ *   POST /__slowcook/auth/poll    { deviceCode } → PollResult
+ *   GET  /__slowcook/auth/health  → { ok: true, clientIdSuffix }
+ */
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import type { ForgeReviewerAuth } from "@slowcook-ai/core";
+
+export interface AuthServerHandle {
+  url: string;
+  port: number;
+  close: () => void;
+}
+
+const DEVICE_PATH = "/__slowcook/auth/device";
+const POLL_PATH = "/__slowcook/auth/poll";
+const HEALTH_PATH = "/__slowcook/auth/health";
+
+function cors(res: ServerResponse, origin: string | undefined): void {
+  res.setHeader("Access-Control-Allow-Origin", origin ?? "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept");
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(c as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** Build the request handler (exported so it can be unit-tested without a socket). */
+export function makeAuthHandler(
+  auth: ForgeReviewerAuth,
+  clientIdSuffix: string,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const origin = req.headers["origin"] as string | undefined;
+    cors(res, origin);
+    if (req.method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    const path = (req.url ?? "").split("?")[0];
+
+    void (async () => {
+      try {
+        if (req.method === "GET" && path === HEALTH_PATH) {
+          sendJson(res, 200, { ok: true, clientIdSuffix });
+          return;
+        }
+        if (req.method === "POST" && path === DEVICE_PATH) {
+          const grant = await auth.requestDeviceCode();
+          sendJson(res, 200, grant);
+          return;
+        }
+        if (req.method === "POST" && path === POLL_PATH) {
+          const body = await readJson(req);
+          const deviceCode = typeof body["deviceCode"] === "string" ? body["deviceCode"] : "";
+          if (!deviceCode) {
+            sendJson(res, 400, { error: "deviceCode required" });
+            return;
+          }
+          const result = await auth.pollAccessToken(deviceCode);
+          sendJson(res, 200, result);
+          return;
+        }
+        sendJson(res, 404, { error: "not found" });
+      } catch (e) {
+        sendJson(res, 502, { error: e instanceof Error ? e.message : String(e) });
+      }
+    })();
+  };
+}
+
+/**
+ * Start the auth helper. `host` defaults to 127.0.0.1; pass "0.0.0.0" for the
+ * remote-box case so a co-worker's browser can reach it.
+ */
+export async function startReviewerAuthServer(
+  auth: ForgeReviewerAuth,
+  opts: { clientId: string; preferredPort?: number; host?: string } ,
+): Promise<AuthServerHandle> {
+  const suffix = opts.clientId.slice(-4);
+  const server: Server = createServer(makeAuthHandler(auth, suffix));
+  const host = opts.host ?? "127.0.0.1";
+  const preferredPort = opts.preferredPort ?? 4200;
+
+  return await new Promise<AuthServerHandle>((resolve, reject) => {
+    const tryListen = (port: number, attemptsLeft: number) => {
+      const onError = (err: NodeJS.ErrnoException) => {
+        server.removeListener("error", onError);
+        if (err.code === "EADDRINUSE" && attemptsLeft > 0) tryListen(port + 1, attemptsLeft - 1);
+        else reject(err);
+      };
+      server.once("error", onError);
+      server.listen(port, host, () => {
+        server.removeListener("error", onError);
+        resolve({
+          url: `http://localhost:${port}`,
+          port,
+          close: () => { try { server.close(); } catch { /* ignore */ } },
+        });
+      });
+    };
+    tryListen(preferredPort, 20);
+  });
+}

--- a/packages/cli/src/commands/trace/check.test.ts
+++ b/packages/cli/src/commands/trace/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { checkTrace, parseLcrProvenance, type SpecNode, type LcrNode } from "./check.js";
+import { checkTrace, checkCoverage, parseLcrProvenance, type SpecNode, type LcrNode } from "./check.js";
 
 describe("parseLcrProvenance", () => {
   it("recognizes @story / story-N / @convention / @craft forms", () => {
@@ -70,5 +70,34 @@ describe("checkTrace — provenance-completeness, not coverage", () => {
       lcrNodes: [lcr("mock/src/components/Old.tsx", [{ kind: "story", id: "story-099" }])],
     });
     expect(r.violations).toMatchObject([{ code: "dangling-lcr-story", subject: "mock/src/components/Old.tsx" }]);
+  });
+});
+
+describe("checkCoverage — the inverse: every story has a surface", () => {
+  const spec2 = (id: string): SpecNode => ({ storyId: id });
+  it("passes when every story is referenced by an LCR surface", () => {
+    const r = checkCoverage({
+      specs: [spec2("101"), spec2("109")],
+      lcrNodes: [
+        lcr("mock/src/components/Feed.tsx", [{ kind: "story", id: "story-101" }]),
+        lcr("mock/src/pages/rewowner/Overview.tsx", [{ kind: "story", id: "story-109" }]),
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.uncovered).toEqual([]);
+    expect(r.coveredCount).toBe(2);
+  });
+  it("flags stories with no surface (the persona-coverage gap)", () => {
+    const r = checkCoverage({
+      specs: [spec2("101"), spec2("113"), spec2("115")],
+      lcrNodes: [lcr("mock/src/components/Feed.tsx", [{ kind: "story", id: "story-101" }])],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.uncovered).toEqual(["story-113", "story-115"]);
+    expect(r.coveredCount).toBe(1);
+    expect(r.totalStories).toBe(3);
+  });
+  it("is empty-safe", () => {
+    expect(checkCoverage({ specs: [], lcrNodes: [] })).toMatchObject({ ok: true, uncovered: [] });
   });
 });

--- a/packages/cli/src/commands/trace/check.test.ts
+++ b/packages/cli/src/commands/trace/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { checkTrace, checkCoverage, parseLcrProvenance, type SpecNode, type LcrNode } from "./check.js";
+import { checkTrace, checkCoverage, checkSurfaces, routeSatisfies, parseLcrProvenance, type SpecNode, type LcrNode, type SpecSurface } from "./check.js";
 
 describe("parseLcrProvenance", () => {
   it("recognizes @story / story-N / @convention / @craft forms", () => {
@@ -99,5 +99,35 @@ describe("checkCoverage — the inverse: every story has a surface", () => {
   });
   it("is empty-safe", () => {
     expect(checkCoverage({ specs: [], lcrNodes: [] })).toMatchObject({ ok: true, uncovered: [] });
+  });
+});
+
+describe("checkSurfaces — persona surfaces resolve to real routes", () => {
+  const surf = (persona: string, route: string, home = false): SpecSurface => ({ storyId: `story-1`, persona, route, home });
+  it("routeSatisfies matches param segments", () => {
+    expect(routeSatisfies("/u/:handle", "/u/you")).toBe(true);
+    expect(routeSatisfies("/rewowner", "/rewowner")).toBe(true);
+    expect(routeSatisfies("/admin/uue", "/admin/taxonomy")).toBe(false);
+    expect(routeSatisfies("/r/:slug", "/r/x/y")).toBe(false); // segment count differs
+  });
+  it("passes when every declared surface route exists in the router", () => {
+    const r = checkSurfaces({
+      surfaces: [surf("member", "/", true), surf("member", "/u/you"), surf("rewowner", "/rewowner", true)],
+      routes: ["/", "/u/:handle", "/rewowner", "/rewowner/claim"],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.dangling).toEqual([]);
+  });
+  it("flags a surface the mock doesn't expose (dangling) — same rule as dangling-lcr-story", () => {
+    const r = checkSurfaces({
+      surfaces: [surf("moderator", "/admin/moderation", true), surf("ghost", "/admin/nope", true)],
+      routes: ["/admin/moderation"],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.dangling.map((s) => s.route)).toEqual(["/admin/nope"]);
+    expect(r.unreachablePersonas).toContain("ghost");
+  });
+  it("is empty-safe", () => {
+    expect(checkSurfaces({ surfaces: [], routes: [] })).toMatchObject({ ok: true, dangling: [] });
   });
 });

--- a/packages/cli/src/commands/trace/check.ts
+++ b/packages/cli/src/commands/trace/check.ts
@@ -112,6 +112,44 @@ export function checkCoverage(input: { specs: SpecNode[]; lcrNodes: LcrNode[] })
   };
 }
 
+// ── Persona/surface trace (0.21.x) — the SAME forward+inverse rules, applied to
+//    the persona surfaces. A spec's `surfaces[].route` is a PROMISE that the mock
+//    exposes that route; the lint checks each promise resolves to a real router
+//    path (forward), and that a declared persona actually has a resolvable home
+//    (so a persona can't be all-dangling). This is the persona analogue of
+//    dangling-lcr-story + coverage. ─────────────────────────────────────────────
+export interface SpecSurface { storyId: string; persona: string; route: string; home?: boolean }
+
+/** A concrete surface route is satisfied by a router path when every segment
+ *  matches — a param segment (`:slug`) matches anything. e.g. `/u/:handle`
+ *  satisfies `/u/you`. */
+export function routeSatisfies(routerPath: string, surfaceRoute: string): boolean {
+  const a = routerPath.split("/").filter(Boolean);
+  const b = surfaceRoute.split("/").filter(Boolean);
+  if (a.length !== b.length) return false;
+  return a.every((seg, i) => seg.startsWith(":") || seg === b[i]);
+}
+
+export interface SurfaceResult {
+  /** declared surfaces whose route resolves to no real router path. */
+  dangling: SpecSurface[];
+  /** personas whose declared home route doesn't resolve (an unreachable persona). */
+  unreachablePersonas: string[];
+  surfaceCount: number;
+  ok: boolean;
+}
+
+export function checkSurfaces(input: { surfaces: SpecSurface[]; routes: string[] }): SurfaceResult {
+  const resolves = (route: string) => input.routes.some((r) => routeSatisfies(r, route));
+  const dangling = input.surfaces.filter((s) => !resolves(s.route));
+  const homeByPersona = new Map<string, boolean>();
+  for (const s of input.surfaces) {
+    if (s.home) homeByPersona.set(s.persona, resolves(s.route) || homeByPersona.get(s.persona) === true);
+  }
+  const unreachablePersonas = [...homeByPersona.entries()].filter(([, ok]) => !ok).map(([p]) => p);
+  return { dangling, unreachablePersonas, surfaceCount: input.surfaces.length, ok: dangling.length === 0 && unreachablePersonas.length === 0 };
+}
+
 export function checkTrace(input: {
   specs: SpecNode[];
   /** PRD initiative anchors. Empty = no PRD (brownfield) → prd-ref checks skipped. */

--- a/packages/cli/src/commands/trace/check.ts
+++ b/packages/cli/src/commands/trace/check.ts
@@ -73,6 +73,45 @@ export function parseLcrProvenance(source: string): LcrProvenance[] {
   return out;
 }
 
+/**
+ * COVERAGE — the inverse of provenance. Provenance asks "does every surface
+ * trace UP to a story?"; coverage asks "does every story trace DOWN to a
+ * surface?". A story with zero LCR surfaces is either a real gap (a persona /
+ * requirement the mock forgot to build) or a legitimately surface-less backend
+ * story (DB schema, CI). The lint can't tell those apart on its own, so it
+ * REPORTS uncovered stories and only FAILS when the caller opts in
+ * (`--coverage`), or when a spec marks itself surface-bearing (future
+ * `expects_surface`). This is the dogfood fix for "the mock covered only one
+ * persona" — every story now gets checked for a home.
+ */
+export interface CoverageResult {
+  /** story ids (story-NNN) that no LCR file references. */
+  uncovered: string[];
+  coveredCount: number;
+  totalStories: number;
+  ok: boolean;
+}
+
+export function checkCoverage(input: { specs: SpecNode[]; lcrNodes: LcrNode[] }): CoverageResult {
+  const referenced = new Set<string>();
+  for (const n of input.lcrNodes) {
+    for (const p of n.provenance) {
+      if (p.kind === "story") referenced.add(p.id);
+    }
+  }
+  const uncovered: string[] = [];
+  for (const s of input.specs) {
+    const id = `story-${s.storyId}`;
+    if (!referenced.has(id)) uncovered.push(id);
+  }
+  return {
+    uncovered,
+    coveredCount: input.specs.length - uncovered.length,
+    totalStories: input.specs.length,
+    ok: uncovered.length === 0,
+  };
+}
+
 export function checkTrace(input: {
   specs: SpecNode[];
   /** PRD initiative anchors. Empty = no PRD (brownfield) → prd-ref checks skipped. */

--- a/packages/cli/src/commands/trace/index.ts
+++ b/packages/cli/src/commands/trace/index.ts
@@ -14,12 +14,13 @@ import { join, relative, resolve } from "node:path";
 import { listActiveSpecs } from "../refine/spec-yaml.js";
 import { loadMockShapeConfig } from "../../lib/mock-shape.js";
 import { parsePrdInitiatives } from "../menu/prd.js";
-import { checkTrace, parseLcrProvenance, type LcrNode, type SpecNode } from "./check.js";
+import { checkTrace, checkCoverage, parseLcrProvenance, type LcrNode, type SpecNode } from "./check.js";
 
 function val(args: string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
   return i >= 0 ? args[i + 1] : undefined;
 }
+const has = (args: string[], flag: string): boolean => args.includes(flag);
 
 /** Recursively collect .tsx files under `dir`, skipping any path in `exclude`. */
 function walkTsx(dir: string, exclude: Set<string>): string[] {
@@ -37,11 +38,12 @@ function walkTsx(dir: string, exclude: Set<string>): string[] {
 
 export async function trace(argv: string[], _cliVersion: string): Promise<void> {
   if (argv[0] !== "check") {
-    console.error("usage: slowcook trace check [--prd <path>] [--cwd <dir>]");
+    console.error("usage: slowcook trace check [--prd <path>] [--cwd <dir>] [--coverage]");
     process.exit(64);
   }
   const rest = argv.slice(1);
   const cwd = resolve(val(rest, "--cwd") ?? ".");
+  const enforceCoverage = has(rest, "--coverage"); // make uncovered stories a hard failure
 
   // 1. Specs → requirement-provenance facts.
   const specNodes: SpecNode[] = listActiveSpecs(cwd).map((s) => ({
@@ -72,6 +74,7 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
   }
 
   const result = checkTrace({ specs: specNodes, prdAnchors, lcrNodes });
+  const coverage = checkCoverage({ specs: specNodes, lcrNodes });
 
   console.log(
     `trace check: ${specNodes.length} specs · ${prdAnchors.length} PRD initiatives · ${lcrNodes.length} LCR files`,
@@ -80,11 +83,32 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
     console.log(`\n  ${result.craft.length} craft decision(s) — not in any requirement (ratify or note):`);
     for (const c of result.craft) console.log(`    · ${c.file}: ${c.rationale}`);
   }
-  if (result.ok) {
-    console.log("\ntrace check: PASS ✓ — every node has honest provenance.");
+
+  // Coverage (inverse): which stories have no surface in the mock. Informational
+  // by default (backend/infra stories legitimately have none); --coverage makes
+  // it a hard failure so a UI milestone can require every story to have a home.
+  if (specNodes.length > 0) {
+    if (coverage.ok) {
+      console.log(`\n  coverage: every story has ≥1 LCR surface (${coverage.coveredCount}/${coverage.totalStories}).`);
+    } else {
+      const stream = enforceCoverage ? console.error : console.log;
+      stream(`\n  coverage: ${coverage.uncovered.length}/${coverage.totalStories} stories have NO LCR surface${enforceCoverage ? " (FAIL — --coverage)" : " (review — backend stories may be fine)"}:`);
+      for (const id of coverage.uncovered) stream(`    ✗ ${id}`);
+    }
+  }
+
+  const provenanceOk = result.ok;
+  const coverageOk = !enforceCoverage || coverage.ok;
+  if (provenanceOk && coverageOk) {
+    console.log("\ntrace check: PASS ✓ — every node has honest provenance" + (enforceCoverage ? " and every story has a surface." : "."));
     return;
   }
-  console.error(`\ntrace check: FAIL ✗ — ${result.violations.length} provenance violation(s):`);
-  for (const v of result.violations) console.error(`  [${v.code}] ${v.subject}: ${v.detail}`);
+  if (!provenanceOk) {
+    console.error(`\ntrace check: FAIL ✗ — ${result.violations.length} provenance violation(s):`);
+    for (const v of result.violations) console.error(`  [${v.code}] ${v.subject}: ${v.detail}`);
+  }
+  if (enforceCoverage && !coverage.ok) {
+    console.error(`\ntrace check: FAIL ✗ — ${coverage.uncovered.length} story(ies) with no surface (--coverage).`);
+  }
   process.exit(1);
 }

--- a/packages/cli/src/commands/trace/index.ts
+++ b/packages/cli/src/commands/trace/index.ts
@@ -11,10 +11,37 @@
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
-import { listActiveSpecs } from "../refine/spec-yaml.js";
+import YAML from "yaml";
+import { listActiveSpecs, SPECS_DIR } from "../refine/spec-yaml.js";
 import { loadMockShapeConfig } from "../../lib/mock-shape.js";
 import { parsePrdInitiatives } from "../menu/prd.js";
-import { checkTrace, checkCoverage, parseLcrProvenance, type LcrNode, type SpecNode } from "./check.js";
+import { checkTrace, checkCoverage, checkSurfaces, parseLcrProvenance, type LcrNode, type SpecNode, type SpecSurface } from "./check.js";
+
+/** Read persona-surface declarations from the spec YAMLs (the `persona` +
+ *  `surfaces` blocks the generator compiles into the mock). */
+function readSpecSurfaces(cwd: string): SpecSurface[] {
+  const dir = resolve(cwd, SPECS_DIR);
+  if (!existsSync(dir)) return [];
+  const out: SpecSurface[] = [];
+  for (const name of readdirSync(dir)) {
+    if (!/^story-.*\.yaml$/.test(name)) continue;
+    let doc: { story_id?: string; persona?: { id?: string }; surfaces?: Array<{ route?: string; home?: boolean }> };
+    try { doc = YAML.parse(readFileSync(join(dir, name), "utf8")) ?? {}; } catch { continue; }
+    const persona = doc.persona?.id;
+    if (!persona || !Array.isArray(doc.surfaces)) continue;
+    for (const s of doc.surfaces) {
+      if (s?.route) out.push({ storyId: `story-${doc.story_id}`, persona, route: s.route, home: s.home === true });
+    }
+  }
+  return out;
+}
+
+/** Extract concrete route paths from a react-router file (path="..."). */
+function readRouterPaths(file: string): string[] {
+  if (!existsSync(file)) return [];
+  const src = readFileSync(file, "utf8");
+  return [...src.matchAll(/path\s*=\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]!).filter((p) => p && p !== "*");
+}
 
 function val(args: string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
@@ -75,6 +102,12 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
 
   const result = checkTrace({ specs: specNodes, prdAnchors, lcrNodes });
   const coverage = checkCoverage({ specs: specNodes, lcrNodes });
+  // Persona/surface trace: the same forward+inverse rules on the persona surfaces
+  // declared in specs vs the routes the mock router actually exposes.
+  const specSurfaces = readSpecSurfaces(cwd);
+  const routerFile = mock.router_file ? resolve(cwd, mock.router_file) : "";
+  const routes = routerFile ? readRouterPaths(routerFile) : [];
+  const surfaceRes = checkSurfaces({ surfaces: specSurfaces, routes });
 
   console.log(
     `trace check: ${specNodes.length} specs · ${prdAnchors.length} PRD initiatives · ${lcrNodes.length} LCR files`,
@@ -97,15 +130,34 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
     }
   }
 
+  // Persona/surface trace report (same rules as provenance, applied to surfaces).
+  if (specSurfaces.length > 0) {
+    if (surfaceRes.ok) {
+      console.log(`\n  surfaces: ${surfaceRes.surfaceCount} persona surface(s), every declared route resolves to a real mock route.`);
+    } else {
+      if (surfaceRes.dangling.length) {
+        console.error(`\n  surfaces: ${surfaceRes.dangling.length} declared surface(s) with NO matching mock route (dangling):`);
+        for (const s of surfaceRes.dangling) console.error(`    ✗ ${s.persona} → ${s.route} (${s.storyId})`);
+      }
+      if (surfaceRes.unreachablePersonas.length) {
+        console.error(`  surfaces: persona(s) whose home route is unreachable: ${surfaceRes.unreachablePersonas.join(", ")}`);
+      }
+    }
+  }
+
   const provenanceOk = result.ok;
   const coverageOk = !enforceCoverage || coverage.ok;
-  if (provenanceOk && coverageOk) {
-    console.log("\ntrace check: PASS ✓ — every node has honest provenance" + (enforceCoverage ? " and every story has a surface." : "."));
+  const surfacesOk = surfaceRes.ok;
+  if (provenanceOk && coverageOk && surfacesOk) {
+    console.log("\ntrace check: PASS ✓ — every node has honest provenance" + (enforceCoverage ? ", every story has a surface," : "") + " and every persona surface resolves.");
     return;
   }
   if (!provenanceOk) {
     console.error(`\ntrace check: FAIL ✗ — ${result.violations.length} provenance violation(s):`);
     for (const v of result.violations) console.error(`  [${v.code}] ${v.subject}: ${v.detail}`);
+  }
+  if (!surfacesOk) {
+    console.error(`\ntrace check: FAIL ✗ — ${surfaceRes.dangling.length + surfaceRes.unreachablePersonas.length} persona-surface violation(s) (a spec promises a surface the mock doesn't expose).`);
   }
   if (enforceCoverage && !coverage.ok) {
     console.error(`\ntrace check: FAIL ✗ — ${coverage.uncovered.length} story(ies) with no surface (--coverage).`);

--- a/packages/cli/src/lib/mock-shape.test.ts
+++ b/packages/cli/src/lib/mock-shape.test.ts
@@ -47,6 +47,18 @@ scenario_registry_file: mock/src/lib/scenario-registry.ts
     expect(out.shape).toBe("vite");
     expect(out.router_file).toBe("mock/src/App.tsx");
     expect(out.screens_root).toBe("mock/src/apps");
+    // 0.6.0 — review_mode defaults to scenarios when omitted.
+    expect(out.review_mode).toBe("scenarios");
+  });
+
+  it("reads review_mode: lcr for a GUCDI/LCR mock", () => {
+    mkdirSync(join(repo, ".brewing"), { recursive: true });
+    writeFileSync(
+      join(repo, ".brewing", "mock.yaml"),
+      "schema_version: 1\nshape: vite\nreview_mode: lcr\n",
+      "utf8",
+    );
+    expect(loadMockShapeConfig(repo).review_mode).toBe("lcr");
   });
 
   it("throws on schema violation", () => {

--- a/packages/cli/src/lib/mock-shape.ts
+++ b/packages/cli/src/lib/mock-shape.ts
@@ -35,6 +35,17 @@ const MockShapeConfigSchema = z.object({
    *    amends per-page. GUCDI mocks set this.
    */
   review_mode: z.enum(["scenarios", "lcr"]).default("scenarios"),
+  /**
+   * 0.6.0 — override the OAuth App Client ID reviewers sign in with (LCR
+   * multi-person review). Optional: defaults to the shared slowcook reviewer
+   * app. Set this only if a project wants its own consent-screen branding.
+   */
+  review_oauth_client_id: z.string().optional(),
+  /**
+   * 0.6.0 — OAuth scope reviewers grant. `public_repo` (default) for public
+   * repos; `repo` when the consumer repo is private.
+   */
+  review_oauth_scope: z.string().default("public_repo"),
 });
 
 export type MockShapeConfig = z.infer<typeof MockShapeConfigSchema>;
@@ -48,6 +59,7 @@ const NEXTJS_DEFAULT: MockShapeConfig = {
   scenarios_dir: "mock/scenarios",
   scenario_registry_file: "mock/src/lib/scenario-registry.ts",
   review_mode: "scenarios",
+  review_oauth_scope: "public_repo",
 };
 
 const VITE_DEFAULT: MockShapeConfig = {
@@ -60,6 +72,7 @@ const VITE_DEFAULT: MockShapeConfig = {
   scenarios_dir: "mock/scenarios",
   scenario_registry_file: "mock/src/lib/scenario-registry.ts",
   review_mode: "scenarios",
+  review_oauth_scope: "public_repo",
 };
 
 /**

--- a/packages/cli/src/lib/mock-shape.ts
+++ b/packages/cli/src/lib/mock-shape.ts
@@ -24,6 +24,17 @@ const MockShapeConfigSchema = z.object({
   router_file: z.string().optional(),
   scenarios_dir: z.string().default("mock/scenarios"),
   scenario_registry_file: z.string().default("mock/src/lib/scenario-registry.ts"),
+  /**
+   * 0.6.0 — review surface shape for the overlay (run-mock passes it to
+   * the overlay via NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE).
+   *
+   *  - `"scenarios"` (default): a scenario-picker mock; the overlay hides
+   *    on `/` and comments key by story_id.
+   *  - `"lcr"`: a full navigable Living Coded Requirement; the overlay
+   *    shows on every route and each comment captures its route so plate
+   *    amends per-page. GUCDI mocks set this.
+   */
+  review_mode: z.enum(["scenarios", "lcr"]).default("scenarios"),
 });
 
 export type MockShapeConfig = z.infer<typeof MockShapeConfigSchema>;
@@ -36,6 +47,7 @@ const NEXTJS_DEFAULT: MockShapeConfig = {
   design_system_dir: "mock/src/design-system",
   scenarios_dir: "mock/scenarios",
   scenario_registry_file: "mock/src/lib/scenario-registry.ts",
+  review_mode: "scenarios",
 };
 
 const VITE_DEFAULT: MockShapeConfig = {
@@ -47,6 +59,7 @@ const VITE_DEFAULT: MockShapeConfig = {
   router_file: "mock/src/App.tsx",
   scenarios_dir: "mock/scenarios",
   scenario_registry_file: "mock/src/lib/scenario-registry.ts",
+  review_mode: "scenarios",
 };
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Core types and logic for the slowcook brewing harness",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/core/src/forge.ts
+++ b/packages/core/src/forge.ts
@@ -167,3 +167,66 @@ export interface ForgeAdapter {
    */
   findPullRequestByBranch(headBranch: string): Promise<PullRequestSummary | null>;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reviewer identity (0.6.0) — multi-person LCR review.
+//
+// Distinct from `ForgeAdapter` (which an AGENT uses with a service token). This
+// seam is REVIEWER-facing: when several people review a hosted LCR, each must
+// authenticate as THEMSELVES so the forge attributes their comments to their own
+// account. It lives in the forge layer (not the cli/overlay) because the auth
+// dance is forge-specific — GitHub OAuth device flow here; GitLab/Gitea later
+// implement the same seam in their own adapter packages.
+//
+// Why a server-side helper exists: GitHub's device-flow token-exchange endpoint
+// is not CORS-accessible from a browser, so the overlay cannot complete login on
+// its own. The forge adapter provides `requestDeviceCode` + `pollAccessToken`
+// (run server-side, e.g. hosted next to the mock); the browser then uses the
+// returned token directly against CORS-enabled read/write endpoints.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A reviewer authenticated against the forge (their real account). */
+export interface ReviewerIdentity {
+  /** Forge handle, e.g. GitHub login. Authoritative — the forge stamps it. */
+  login: string;
+  /** Display name when the forge exposes one; falls back to `login`. */
+  name: string;
+  /** Avatar URL when available (overlay shows it next to the reviewer's pins). */
+  avatarUrl?: string;
+}
+
+/** What the overlay shows the reviewer to start a device-flow login. */
+export interface DeviceCodeGrant {
+  /** Opaque code the server polls with (NOT shown to the user). */
+  deviceCode: string;
+  /** Short code the user types at the verification URL. */
+  userCode: string;
+  /** Where the user enters `userCode` (e.g. https://github.com/login/device). */
+  verificationUri: string;
+  /** Seconds between `pollAccessToken` attempts (forge-mandated minimum). */
+  intervalSeconds: number;
+  /** Seconds until `deviceCode` expires. */
+  expiresInSeconds: number;
+}
+
+/** Result of polling for the access token during a device-flow login. */
+export type PollResult =
+  | { status: "authorized"; token: string }
+  | { status: "pending" }            // user hasn't approved yet — poll again
+  | { status: "slow_down"; intervalSeconds: number } // back off, then poll
+  | { status: "expired" }            // deviceCode expired — restart the flow
+  | { status: "denied" };            // user declined
+
+/**
+ * Reviewer-facing auth seam. A forge adapter package implements this so a hosted
+ * LCR can let each reviewer sign in as themselves. The cli/overlay program
+ * against this interface only — never against GitHub/GitLab specifics.
+ */
+export interface ForgeReviewerAuth {
+  /** Begin a device-flow login. Server-side (token endpoints aren't CORS-open). */
+  requestDeviceCode(): Promise<DeviceCodeGrant>;
+  /** Poll once for the access token after the user has been shown the code. */
+  pollAccessToken(deviceCode: string): Promise<PollResult>;
+  /** Resolve a token to the reviewer's identity (CORS-OK read; browser or server). */
+  identify(token: string): Promise<ReviewerIdentity>;
+}

--- a/packages/forge-github/package.json
+++ b/packages/forge-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/forge-github",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "GitHub ForgeAdapter implementation for slowcook",
   "license": "MIT",
   "author": "aminazar",
@@ -13,7 +13,15 @@
   "bugs": {
     "url": "https://github.com/aminazar/slowcook/issues"
   },
-  "keywords": ["slowcook", "github", "forge", "adapter", "tdd", "ai", "agents"],
+  "keywords": [
+    "slowcook",
+    "github",
+    "forge",
+    "adapter",
+    "tdd",
+    "ai",
+    "agents"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -23,7 +31,10 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run --passWithNoTests",

--- a/packages/forge-github/src/index.ts
+++ b/packages/forge-github/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./github-adapter.js";
 export * from "./git-ops.js";
 export * from "./templates.js";
+export * from "./reviewer-auth.js";

--- a/packages/forge-github/src/reviewer-auth.test.ts
+++ b/packages/forge-github/src/reviewer-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { GitHubReviewerAuth } from "./reviewer-auth.js";
+import { GitHubReviewerAuth, SLOWCOOK_REVIEW_OAUTH_CLIENT_ID } from "./reviewer-auth.js";
 
 /** Build a fetch stub that returns the given JSON for the first matching URL substring. */
 function stubFetch(routes: Array<{ match: string; status?: number; json: unknown }>): typeof fetch {
@@ -16,8 +16,19 @@ function stubFetch(routes: Array<{ match: string; status?: number; json: unknown
 }
 
 describe("GitHubReviewerAuth", () => {
-  it("requires a clientId", () => {
-    expect(() => new GitHubReviewerAuth({ clientId: "" })).toThrow(/clientId/);
+  it("defaults to the shared slowcook OAuth app when no clientId is given", () => {
+    expect(SLOWCOOK_REVIEW_OAUTH_CLIENT_ID).toMatch(/^Ov23/); // OAuth App client-id format
+    // sends the default client_id in the device-code request body
+    let sentBody = "";
+    const auth = new GitHubReviewerAuth({
+      fetchImpl: (async (_u: unknown, init: RequestInit) => {
+        sentBody = String(init.body);
+        return { ok: true, status: 200, json: async () => ({ device_code: "d", user_code: "u", verification_uri: "v", expires_in: 1, interval: 1 }) } as Response;
+      }) as typeof fetch,
+    });
+    return auth.requestDeviceCode().then(() => {
+      expect(JSON.parse(sentBody).client_id).toBe(SLOWCOOK_REVIEW_OAUTH_CLIENT_ID);
+    });
   });
 
   it("maps the device-code grant", async () => {

--- a/packages/forge-github/src/reviewer-auth.test.ts
+++ b/packages/forge-github/src/reviewer-auth.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { GitHubReviewerAuth } from "./reviewer-auth.js";
+
+/** Build a fetch stub that returns the given JSON for the first matching URL substring. */
+function stubFetch(routes: Array<{ match: string; status?: number; json: unknown }>): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    const r = routes.find((x) => u.includes(x.match));
+    if (!r) throw new Error(`unexpected fetch: ${u}`);
+    return {
+      ok: (r.status ?? 200) < 400,
+      status: r.status ?? 200,
+      json: async () => r.json,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe("GitHubReviewerAuth", () => {
+  it("requires a clientId", () => {
+    expect(() => new GitHubReviewerAuth({ clientId: "" })).toThrow(/clientId/);
+  });
+
+  it("maps the device-code grant", async () => {
+    const auth = new GitHubReviewerAuth({
+      clientId: "cid",
+      fetchImpl: stubFetch([
+        { match: "login/device/code", json: {
+          device_code: "DC", user_code: "WXYZ-1234",
+          verification_uri: "https://github.com/login/device", expires_in: 900, interval: 5,
+        } },
+      ]),
+    });
+    const g = await auth.requestDeviceCode();
+    expect(g).toEqual({
+      deviceCode: "DC", userCode: "WXYZ-1234",
+      verificationUri: "https://github.com/login/device", intervalSeconds: 5, expiresInSeconds: 900,
+    });
+  });
+
+  it("maps every poll outcome", async () => {
+    const make = (json: unknown) =>
+      new GitHubReviewerAuth({ clientId: "cid", fetchImpl: stubFetch([{ match: "oauth/access_token", json }]) });
+    expect(await make({ access_token: "tok" }).pollAccessToken("DC")).toEqual({ status: "authorized", token: "tok" });
+    expect(await make({ error: "authorization_pending" }).pollAccessToken("DC")).toEqual({ status: "pending" });
+    expect(await make({ error: "slow_down", interval: 10 }).pollAccessToken("DC")).toEqual({ status: "slow_down", intervalSeconds: 10 });
+    expect(await make({ error: "expired_token" }).pollAccessToken("DC")).toEqual({ status: "expired" });
+    expect(await make({ error: "access_denied" }).pollAccessToken("DC")).toEqual({ status: "denied" });
+  });
+
+  it("throws on an unexpected device-flow error", async () => {
+    const auth = new GitHubReviewerAuth({ clientId: "cid", fetchImpl: stubFetch([{ match: "oauth/access_token", json: { error: "weird" } }]) });
+    await expect(auth.pollAccessToken("DC")).rejects.toThrow(/unexpected device-flow error/);
+  });
+
+  it("resolves identity, falling back name→login", async () => {
+    const named = new GitHubReviewerAuth({ clientId: "c", fetchImpl: stubFetch([{ match: "api.github.com/user", json: { login: "ana", name: "Ana Q", avatar_url: "http://a/x.png" } }]) });
+    expect(await named.identify("t")).toEqual({ login: "ana", name: "Ana Q", avatarUrl: "http://a/x.png" });
+    const unnamed = new GitHubReviewerAuth({ clientId: "c", fetchImpl: stubFetch([{ match: "api.github.com/user", json: { login: "ben", name: null } }]) });
+    expect(await unnamed.identify("t")).toMatchObject({ login: "ben", name: "ben" });
+  });
+});

--- a/packages/forge-github/src/reviewer-auth.ts
+++ b/packages/forge-github/src/reviewer-auth.ts
@@ -24,9 +24,21 @@ const TOKEN_URL = "https://github.com/login/oauth/access_token";
 const USER_URL = "https://api.github.com/user";
 const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
+/**
+ * Default OAuth App Client ID for the shared "slowcook reviewer" app
+ * (Device Flow enabled). A Client ID is a PUBLIC identifier — not a secret —
+ * so it ships as the zero-config default. Because device flow uses no
+ * callback URL and an OAuth-App grant is per-user (scoped globally, not
+ * per-repo), this ONE app works for every consumer repo on every box: a
+ * reviewer authorizes it once and can comment on any repo they can access.
+ * Override per-project via config when someone wants their own consent-screen
+ * branding (or a tighter-scoped GitHub App).
+ */
+export const SLOWCOOK_REVIEW_OAUTH_CLIENT_ID = "Ov23liYJzTY9HiXGeTUN";
+
 export interface GitHubReviewerAuthOptions {
-  /** OAuth App Client ID (Device Flow enabled). */
-  clientId: string;
+  /** OAuth App Client ID (Device Flow enabled). Defaults to the shared slowcook app. */
+  clientId?: string;
   /**
    * OAuth scope to request. `public_repo` lets reviewers comment on public
    * repos; private repos need `repo`. Default `public_repo`.
@@ -41,9 +53,8 @@ export class GitHubReviewerAuth implements ForgeReviewerAuth {
   private readonly scope: string;
   private readonly f: typeof fetch;
 
-  constructor(opts: GitHubReviewerAuthOptions) {
-    if (!opts.clientId) throw new Error("GitHubReviewerAuth: clientId is required");
-    this.clientId = opts.clientId;
+  constructor(opts: GitHubReviewerAuthOptions = {}) {
+    this.clientId = opts.clientId ?? SLOWCOOK_REVIEW_OAUTH_CLIENT_ID;
     this.scope = opts.scope ?? "public_repo";
     this.f = opts.fetchImpl ?? fetch;
   }

--- a/packages/forge-github/src/reviewer-auth.ts
+++ b/packages/forge-github/src/reviewer-auth.ts
@@ -1,0 +1,121 @@
+/**
+ * GitHub reviewer-identity via OAuth device flow (0.6.0).
+ *
+ * Implements core's `ForgeReviewerAuth` so a hosted LCR can let each reviewer
+ * sign in as THEMSELVES — their comments are then attributed to their own
+ * GitHub account, not a shared host token. See core/forge.ts for the seam + why
+ * the token-exchange must run server-side (GitHub's token endpoints aren't
+ * CORS-open to browsers; only `api.github.com` reads/writes with a user token
+ * are). The cli/overlay host `requestDeviceCode` + `pollAccessToken` next to the
+ * mock; the browser uses the resulting token directly.
+ *
+ * Needs a GitHub OAuth App **Client ID** with Device Flow enabled. No client
+ * secret is used (device flow is a public-client grant).
+ */
+import type {
+  ForgeReviewerAuth,
+  DeviceCodeGrant,
+  PollResult,
+  ReviewerIdentity,
+} from "@slowcook-ai/core";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const TOKEN_URL = "https://github.com/login/oauth/access_token";
+const USER_URL = "https://api.github.com/user";
+const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+export interface GitHubReviewerAuthOptions {
+  /** OAuth App Client ID (Device Flow enabled). */
+  clientId: string;
+  /**
+   * OAuth scope to request. `public_repo` lets reviewers comment on public
+   * repos; private repos need `repo`. Default `public_repo`.
+   */
+  scope?: string;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export class GitHubReviewerAuth implements ForgeReviewerAuth {
+  private readonly clientId: string;
+  private readonly scope: string;
+  private readonly f: typeof fetch;
+
+  constructor(opts: GitHubReviewerAuthOptions) {
+    if (!opts.clientId) throw new Error("GitHubReviewerAuth: clientId is required");
+    this.clientId = opts.clientId;
+    this.scope = opts.scope ?? "public_repo";
+    this.f = opts.fetchImpl ?? fetch;
+  }
+
+  async requestDeviceCode(): Promise<DeviceCodeGrant> {
+    const res = await this.f(DEVICE_CODE_URL, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: this.clientId, scope: this.scope }),
+    });
+    if (!res.ok) throw new Error(`device code request failed: ${res.status}`);
+    const j = (await res.json()) as {
+      device_code: string;
+      user_code: string;
+      verification_uri: string;
+      expires_in: number;
+      interval: number;
+    };
+    return {
+      deviceCode: j.device_code,
+      userCode: j.user_code,
+      verificationUri: j.verification_uri,
+      intervalSeconds: j.interval,
+      expiresInSeconds: j.expires_in,
+    };
+  }
+
+  async pollAccessToken(deviceCode: string): Promise<PollResult> {
+    const res = await this.f(TOKEN_URL, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: this.clientId,
+        device_code: deviceCode,
+        grant_type: DEVICE_GRANT,
+      }),
+    });
+    if (!res.ok) throw new Error(`token poll failed: ${res.status}`);
+    const j = (await res.json()) as {
+      access_token?: string;
+      error?: string;
+      interval?: number;
+    };
+    if (j.access_token) return { status: "authorized", token: j.access_token };
+    switch (j.error) {
+      case "authorization_pending":
+        return { status: "pending" };
+      case "slow_down":
+        return { status: "slow_down", intervalSeconds: j.interval ?? 5 };
+      case "expired_token":
+        return { status: "expired" };
+      case "access_denied":
+        return { status: "denied" };
+      default:
+        throw new Error(`unexpected device-flow error: ${j.error ?? "unknown"}`);
+    }
+  }
+
+  async identify(token: string): Promise<ReviewerIdentity> {
+    const res = await this.f(USER_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) throw new Error(`identify failed: ${res.status}`);
+    const j = (await res.json()) as { login: string; name: string | null; avatar_url?: string };
+    return {
+      login: j.login,
+      name: j.name ?? j.login,
+      avatarUrl: j.avatar_url,
+    };
+  }
+}

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/llm-anthropic",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Anthropic (Claude) LlmClient adapter for slowcook — implements the core LlmClient interface, provider-specific pricing, and Anthropic-tuned system prompts + tool defs for refine / testgen / brew / sift / investigate agents",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/README.md
+++ b/packages/review-overlay/README.md
@@ -53,6 +53,37 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
 The `enabled` gate keeps the overlay out of production-style builds. Slowcook's preview-deploy workflow (0.16-α.5) sets `NEXT_PUBLIC_SLOWCOOK_REVIEW=1` plus the owner/repo/PR env vars when it builds the mock for a `slowcook-mockup` PR.
 
+## Hosting the built mock — cache headers (required)
+
+When you serve a **statically built** mock (Vite/Next export rsynced to a box, an
+S3 bucket, etc.), the HTML shell **must not be hard-cached**, or reviewers keep
+seeing a stale mock after every redeploy and your overlay fixes never reach them.
+
+Rule of thumb:
+
+- **`index.html` (and any app shell / chooser) → `Cache-Control: no-cache`** so the
+  browser revalidates each load and picks up the newest build immediately.
+- **Content-hashed assets (`/assets/*.js`, `*.css`) → long, immutable cache** —
+  their filename changes every build, so caching them is safe.
+
+nginx example (mirrors the delgoosh mock at `mock.delgoosh.com`):
+
+```nginx
+# hashed build assets are immutable — a new build emits new filenames
+location ~* /assets/ {
+  expires 30d;
+  add_header Cache-Control "public, max-age=2592000, immutable";
+}
+# app shell — always revalidate so a redeploy is seen on the next load
+location = /index.html { add_header Cache-Control "no-cache"; }
+location / { try_files $uri $uri/ /index.html; }   # SPA fallback
+```
+
+> If a CDN (Cloudflare, etc.) fronts the host, it may apply its own Browser-Cache-TTL
+> to cacheable responses — harmless for hashed assets, but make sure the shell stays
+> `no-cache` (don't let the CDN cache `index.html`). `slowcook run-mock` already serves
+> with no-store dev headers; this note is for **self-hosted static deploys**.
+
 ## How a comment lands in the PR
 
 1. PM clicks the floating toggle → **💬 Comment**.

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.18",
+  "version": "0.7.0",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",
@@ -49,12 +49,13 @@
     "react-dom": ">=19"
   },
   "devDependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.7",
+    "@slowcook-ai/core": "workspace:^",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
+    "@types/react-dom": "^19",
     "jsdom": "^29.1.1",
-    "@slowcook-ai/core": "workspace:^"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -53,7 +53,8 @@
     "react-dom": "^19.2.7",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
-    "jsdom": "^29.1.1"
+    "jsdom": "^29.1.1",
+    "@slowcook-ai/core": "workspace:^"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/review-overlay/src/comment-format.test.ts
+++ b/packages/review-overlay/src/comment-format.test.ts
@@ -67,6 +67,44 @@ describe("buildPayload", () => {
     });
     expect(p.story_id).toBeNull();
   });
+
+  // 0.6.0 — LCR free-nav: the comment carries the route it was left on.
+  it("captures pathname + route_query when supplied (LCR mode)", () => {
+    const p = buildPayload({
+      overlayVersion: "0.6.0",
+      storyId: "rewo-lcr",
+      url: "http://localhost:3100/r/webb-deep-field?clean=1",
+      pathname: "/r/webb-deep-field",
+      routeQuery: "?clean=1",
+      prose: "Bucket order looks off here.",
+      viewport: sampleViewport,
+      userAgent: "x",
+    });
+    expect(p.pathname).toBe("/r/webb-deep-field");
+    expect(p.route_query).toBe("?clean=1");
+    // round-trips through the markdown body + survives the parser
+    const body = formatReviewComment({ payload: p });
+    expect(body).toContain("**Route:** `/r/webb-deep-field?clean=1`");
+    const back = parseReviewComment(body);
+    expect(back?.pathname).toBe("/r/webb-deep-field");
+    expect(back?.route_query).toBe("?clean=1");
+  });
+
+  it("omits route fields when not supplied (scenarios mode / back-compat)", () => {
+    const p = buildPayload({
+      overlayVersion: "0.6.0",
+      storyId: "017",
+      url: "http://localhost:3100/",
+      prose: "x",
+      selector: sampleSelector,
+      bbox: { x: 0, y: 0, w: 0, h: 0 },
+      viewport: sampleViewport,
+      userAgent: "x",
+    });
+    expect(p.pathname).toBeUndefined();
+    expect(p.route_query).toBeUndefined();
+    expect(formatReviewComment({ payload: p })).not.toContain("**Route:**");
+  });
 });
 
 describe("formatReviewComment + parseReviewComment round trip", () => {

--- a/packages/review-overlay/src/comment-format.test.ts
+++ b/packages/review-overlay/src/comment-format.test.ts
@@ -6,6 +6,7 @@ import {
   formatLcrIssue,
   LCR_REVIEW_LABEL,
   VIBE_LABEL,
+  COMMUNITY_LABEL,
   PAYLOAD_MARKER,
 } from "./comment-format.js";
 import type { ExtractedSelector } from "./selector.js";
@@ -222,5 +223,24 @@ describe("formatLcrIssue", () => {
     const issue = formatLcrIssue({ payload: p });
     expect(issue.title).toContain("/r/webb-deep-field");
     expect(issue.labels).toEqual([LCR_REVIEW_LABEL, VIBE_LABEL]); // no story label
+  });
+  it("write-access reviewers (canApply) get the vibe label", () => {
+    const p = buildPayload({ ...base, prose: "x" });
+    const issue = formatLcrIssue({ payload: p, canApply: true });
+    expect(issue.labels).toContain(VIBE_LABEL);
+    expect(issue.labels).not.toContain(COMMUNITY_LABEL);
+    expect(issue.body).toContain("for vibe to apply");
+  });
+  it("non-write reviewers (canApply false) get community-review, never vibe", () => {
+    const p = buildPayload({ ...base, prose: "x" });
+    const issue = formatLcrIssue({ payload: p, canApply: false });
+    expect(issue.labels).toContain(COMMUNITY_LABEL);
+    expect(issue.labels).not.toContain(VIBE_LABEL);
+    expect(issue.labels).toEqual([LCR_REVIEW_LABEL, COMMUNITY_LABEL, "story-104"]);
+    expect(issue.body).toContain("without repo write access");
+  });
+  it("defaults to applied (vibe) when canApply is omitted (back-compat)", () => {
+    const p = buildPayload({ ...base, prose: "x" });
+    expect(formatLcrIssue({ payload: p }).labels).toContain(VIBE_LABEL);
   });
 });

--- a/packages/review-overlay/src/comment-format.test.ts
+++ b/packages/review-overlay/src/comment-format.test.ts
@@ -3,6 +3,9 @@ import {
   formatReviewComment,
   parseReviewComment,
   buildPayload,
+  formatLcrIssue,
+  LCR_REVIEW_LABEL,
+  VIBE_LABEL,
   PAYLOAD_MARKER,
 } from "./comment-format.js";
 import type { ExtractedSelector } from "./selector.js";
@@ -193,5 +196,31 @@ trailing prose
     const p = parseReviewComment(body);
     expect(p).not.toBeNull();
     expect(p!.element.selector).toBe("#a");
+  });
+});
+
+describe("formatLcrIssue", () => {
+  const base = {
+    overlayVersion: "0.6.0", storyId: "rewo-lcr",
+    url: "http://localhost:3100/r/webb-deep-field",
+    pathname: "/r/webb-deep-field", routeStory: "104",
+    viewport: sampleViewport, userAgent: "x",
+  };
+  it("titles + labels by story, embeds route + payload, carries vibe label", () => {
+    const p = buildPayload({ ...base, prose: "The fascinate bucket should lead." });
+    const issue = formatLcrIssue({ payload: p });
+    expect(issue.title).toContain("[LCR]");
+    expect(issue.title).toContain("story-104");
+    expect(issue.labels).toEqual([LCR_REVIEW_LABEL, VIBE_LABEL, "story-104"]);
+    expect(issue.body).toContain("**Story / requirement:** `story-104`");
+    expect(issue.body).toContain("**Route:** `/r/webb-deep-field`");
+    // round-trips: the hidden payload survives for plate/vibe to parse
+    expect(parseReviewComment(issue.body)?.route_story).toBe("104");
+  });
+  it("falls back to route in the title when no story is declared", () => {
+    const p = buildPayload({ ...base, routeStory: undefined, prose: "x" });
+    const issue = formatLcrIssue({ payload: p });
+    expect(issue.title).toContain("/r/webb-deep-field");
+    expect(issue.labels).toEqual([LCR_REVIEW_LABEL, VIBE_LABEL]); // no story label
   });
 });

--- a/packages/review-overlay/src/comment-format.ts
+++ b/packages/review-overlay/src/comment-format.ts
@@ -73,10 +73,20 @@ export const PAYLOAD_MARKER = "slowcook:review-overlay";
 export const PLATE_REPLY_MARKER = "slowcook:plate-reply";
 
 export type PlateReplyStatus =
-  | "applied"        // plate amended the mock per the comment
-  | "declined"       // plate read the comment but chose not to amend (cosmetic-but-already-fine)
-  | "spec-altering"  // plate escalated; PM must confirm a spec change
-  | "noop";          // plate considered, no diff produced (re-emit yielded byte-identical files)
+  | "applied"            // plate/vibe amended the mock per the comment
+  | "declined"           // read the comment but chose not to amend (cosmetic-but-already-fine)
+  | "spec-altering"      // escalated; PM must confirm a spec change
+  | "needs-clarification" // 0.6.0 — couldn't act on it; asked the reviewer to clarify
+  | "noop";              // considered, no diff produced (re-emit yielded byte-identical files)
+
+/**
+ * 0.6.0 — which reply statuses are "resolved" (the comment can be hidden behind
+ * the overlay's "show applied" toggle). `needs-clarification` is intentionally
+ * NOT resolved: it stays visible so the reviewer sees the question and answers.
+ */
+export function isResolvedStatus(s: PlateReplyStatus): boolean {
+  return s === "applied" || s === "declined" || s === "noop";
+}
 
 export interface PlateReplyEntry {
   /** GitHub comment id of the overlay comment this reply addresses. */

--- a/packages/review-overlay/src/comment-format.ts
+++ b/packages/review-overlay/src/comment-format.ts
@@ -39,6 +39,13 @@ export interface ReviewCommentPayload {
   pathname?: string;
   /** 0.6.0 — the query string at comment time (e.g. `?clean=1`), if any. */
   route_query?: string;
+  /**
+   * 0.6.0 — the story/requirement the commented route belongs to, when the LCR
+   * declares it at runtime (data-slowcook-story). Lets an LCR review comment
+   * become a contextualised issue tagged with the exact requirement; absent
+   * when the LCR doesn't self-report (vibe can still derive it from the route).
+   */
+  route_story?: string;
   timestamp: string;
   prose: string;
   /**
@@ -248,6 +255,60 @@ function isReviewCommentPayload(v: unknown): v is ReviewCommentPayload {
   );
 }
 
+/**
+ * 0.6.0 — LCR contextualised issue. In LCR review a comment isn't about one PR;
+ * it's about a route → a story/requirement of the living spec. So an LCR comment
+ * becomes a standalone issue that says (a) it's about the LCR, (b) which story,
+ * (c) carries the `vibe` label so vibe picks it up + applies the fix to the mock.
+ */
+export const LCR_REVIEW_LABEL = "lcr-review";
+export const VIBE_LABEL = "vibe";
+
+export interface LcrIssue {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+/** Build the title/body/labels for an LCR review issue (pure). */
+export function formatLcrIssue(args: {
+  payload: ReviewCommentPayload;
+  screenshotDataUrl?: string;
+}): LcrIssue {
+  const { payload } = args;
+  const route = payload.pathname ? `${payload.pathname}${payload.route_query ?? ""}` : undefined;
+  const story = payload.route_story;
+  const oneLine = payload.prose.replace(/\s+/g, " ").trim().slice(0, 60);
+  const titleBits = ["[LCR]"];
+  if (story) titleBits.push(`story-${story.replace(/^story-/, "")}`);
+  else if (route) titleBits.push(route);
+  titleBits.push(`— ${oneLine}${payload.prose.length > 60 ? "…" : ""}`);
+
+  const lines: string[] = [];
+  lines.push(`**Living Coded Requirement review note**`);
+  lines.push("");
+  if (story) lines.push(`**Story / requirement:** \`story-${story.replace(/^story-/, "")}\``);
+  if (route) lines.push(`**Route:** \`${route}\``);
+  if (payload.element) {
+    lines.push(`**Element:** \`${payload.element.selector}\` (${payload.element.tag}${payload.element.text_hint ? ` · "${payload.element.text_hint}"` : ""})`);
+  }
+  lines.push(`**Viewport:** ${payload.viewport.width}×${payload.viewport.height} ${payload.viewport.colorScheme}`);
+  lines.push("");
+  lines.push(`> ${payload.prose.split("\n").join("\n> ")}`);
+  lines.push("");
+  if (args.screenshotDataUrl) { lines.push(`![screenshot](${args.screenshotDataUrl})`); lines.push(""); }
+  lines.push(`_Filed from the LCR review overlay — labelled \`${VIBE_LABEL}\` for vibe to apply to the mock._`);
+  lines.push("");
+  lines.push("<!--");
+  lines.push(PAYLOAD_MARKER);
+  lines.push(JSON.stringify(payload));
+  lines.push("-->");
+
+  const labels = [LCR_REVIEW_LABEL, VIBE_LABEL];
+  if (story) labels.push(`story-${story.replace(/^story-/, "")}`);
+  return { title: titleBits.join(" "), body: lines.join("\n"), labels };
+}
+
 export function buildPayload(args: {
   overlayVersion: string;
   storyId: string | null;
@@ -256,6 +317,8 @@ export function buildPayload(args: {
   pathname?: string;
   /** 0.6.0 — current query string (window.location.search). */
   routeQuery?: string;
+  /** 0.6.0 — story the route belongs to (LCR runtime self-report). */
+  routeStory?: string;
   prose: string;
   /**
    * 0.5.0 — selector + bbox are now optional. Pass both for
@@ -283,6 +346,7 @@ export function buildPayload(args: {
     url: args.url,
     ...(args.pathname ? { pathname: args.pathname } : {}),
     ...(args.routeQuery ? { route_query: args.routeQuery } : {}),
+    ...(args.routeStory ? { route_story: args.routeStory } : {}),
     timestamp: new Date().toISOString(),
     prose: args.prose,
     element,

--- a/packages/review-overlay/src/comment-format.ts
+++ b/packages/review-overlay/src/comment-format.ts
@@ -263,6 +263,10 @@ function isReviewCommentPayload(v: unknown): v is ReviewCommentPayload {
  */
 export const LCR_REVIEW_LABEL = "lcr-review";
 export const VIBE_LABEL = "vibe";
+// Comments from reviewers WITHOUT repo write access carry this label instead of
+// `vibe`. The apply pipeline only acts on `vibe`, so these are never auto-applied
+// — they're gathered for the team/PM to triage (and promote to `vibe` if wanted).
+export const COMMUNITY_LABEL = "community-review";
 
 export interface LcrIssue {
   title: string;
@@ -270,11 +274,16 @@ export interface LcrIssue {
   labels: string[];
 }
 
-/** Build the title/body/labels for an LCR review issue (pure). */
+/** Build the title/body/labels for an LCR review issue (pure).
+ *  `canApply` (default true) reflects the reviewer's repo write access: when
+ *  false the issue is labelled `community-review` (held for the team) rather
+ *  than `vibe` (auto-applied). */
 export function formatLcrIssue(args: {
   payload: ReviewCommentPayload;
   screenshotDataUrl?: string;
+  canApply?: boolean;
 }): LcrIssue {
+  const canApply = args.canApply !== false;
   const { payload } = args;
   const route = payload.pathname ? `${payload.pathname}${payload.route_query ?? ""}` : undefined;
   const story = payload.route_story;
@@ -297,14 +306,16 @@ export function formatLcrIssue(args: {
   lines.push(`> ${payload.prose.split("\n").join("\n> ")}`);
   lines.push("");
   if (args.screenshotDataUrl) { lines.push(`![screenshot](${args.screenshotDataUrl})`); lines.push(""); }
-  lines.push(`_Filed from the LCR review overlay — labelled \`${VIBE_LABEL}\` for vibe to apply to the mock._`);
+  lines.push(canApply
+    ? `_Filed from the LCR review overlay — labelled \`${VIBE_LABEL}\` for vibe to apply to the mock._`
+    : `_Filed from the LCR review overlay by a reviewer without repo write access — labelled \`${COMMUNITY_LABEL}\` and gathered for the team to review (not auto-applied)._`);
   lines.push("");
   lines.push("<!--");
   lines.push(PAYLOAD_MARKER);
   lines.push(JSON.stringify(payload));
   lines.push("-->");
 
-  const labels = [LCR_REVIEW_LABEL, VIBE_LABEL];
+  const labels = [LCR_REVIEW_LABEL, canApply ? VIBE_LABEL : COMMUNITY_LABEL];
   if (story) labels.push(`story-${story.replace(/^story-/, "")}`);
   return { title: titleBits.join(" "), body: lines.join("\n"), labels };
 }

--- a/packages/review-overlay/src/comment-format.ts
+++ b/packages/review-overlay/src/comment-format.ts
@@ -28,6 +28,17 @@ export interface ReviewCommentPayload {
   slowcook_overlay_version: string;
   story_id: string | null;
   url: string;
+  /**
+   * 0.6.0 — the route the comment was left on, split out from `url` for
+   * convenience. In LCR review mode the reviewer roams the mock's own
+   * router (e.g. `/r/webb-deep-field`, `/discover`), so plate keys
+   * amendments by route, not by a single per-PR story_id. Optional for
+   * back-compat: older payloads (and scenario-mode comments) omit it,
+   * and consumers can recover it from `url` when absent.
+   */
+  pathname?: string;
+  /** 0.6.0 — the query string at comment time (e.g. `?clean=1`), if any. */
+  route_query?: string;
   timestamp: string;
   prose: string;
   /**
@@ -161,6 +172,9 @@ export function formatReviewComment(args: FormatArgs): string {
   lines.push(
     `**Viewport:** ${payload.viewport.width}×${payload.viewport.height} ${payload.viewport.colorScheme} (dpr ${payload.viewport.dpr})`
   );
+  if (payload.pathname) {
+    lines.push(`**Route:** \`${payload.pathname}${payload.route_query ?? ""}\``);
+  }
   lines.push(`**URL:** ${payload.url}`);
   lines.push("");
 
@@ -228,6 +242,10 @@ export function buildPayload(args: {
   overlayVersion: string;
   storyId: string | null;
   url: string;
+  /** 0.6.0 — current route path (window.location.pathname). */
+  pathname?: string;
+  /** 0.6.0 — current query string (window.location.search). */
+  routeQuery?: string;
   prose: string;
   /**
    * 0.5.0 — selector + bbox are now optional. Pass both for
@@ -253,6 +271,8 @@ export function buildPayload(args: {
     slowcook_overlay_version: args.overlayVersion,
     story_id: args.storyId,
     url: args.url,
+    ...(args.pathname ? { pathname: args.pathname } : {}),
+    ...(args.routeQuery ? { route_query: args.routeQuery } : {}),
     timestamp: new Date().toISOString(),
     prose: args.prose,
     element,

--- a/packages/review-overlay/src/github.test.ts
+++ b/packages/review-overlay/src/github.test.ts
@@ -6,6 +6,7 @@ import {
   clearPat,
   submitComment,
   createIssue,
+  fetchLcrIssues,
   type RepoCoord,
 } from "./github.js";
 
@@ -188,5 +189,30 @@ describe("createIssue", () => {
     const fetchImpl = (async () => ({ ok: false, status: 403, json: async () => ({ message: "Forbidden" }) } as Response)) as typeof fetch;
     const res = await createIssue({ owner: "o", repo: "r", pat: "t", title: "x", body: "y", fetchImpl });
     expect(res).toEqual({ ok: false, status: 403, message: "Forbidden" });
+  });
+});
+
+describe("fetchLcrIssues", () => {
+  const issueBody = (story) => "x\n<!--\nslowcook:review-overlay\n" + JSON.stringify({
+    slowcook_overlay_version:"0.6.4", story_id:"lcr", url:"http://x/", pathname:"/", route_story:story,
+    timestamp:"2026-06-09T00:00:00Z", prose:"p", element:null, viewport:{width:1,height:1,colorScheme:"dark",dpr:1}, user_agent:"x"
+  }) + "\n-->";
+  it("maps open→shown, closed→applied(hidden), needs-clarification→visible; skips PRs", async () => {
+    const fetchImpl = (async () => ({ ok:true, status:200, json: async () => ([
+      { number: 10, user:{login:"ali"}, body: issueBody("102"), created_at:"t", html_url:"u", state:"open", labels:[{name:"lcr-review"}] },
+      { number: 11, user:{login:"ben"}, body: issueBody("104"), created_at:"t", html_url:"u", state:"closed", labels:[{name:"lcr-review"}] },
+      { number: 12, user:{login:"ana"}, body: issueBody("106"), created_at:"t", html_url:"u", state:"open", labels:[{name:"lcr-review"},{name:"needs-clarification"}] },
+      { number: 13, user:{login:"x"}, body: issueBody("1"), created_at:"t", html_url:"u", state:"open", labels:[], pull_request:{} }, // a PR — skip
+      { number: 14, user:{login:"x"}, body: "no payload", created_at:"t", html_url:"u", state:"open", labels:[] }, // not an overlay issue — skip
+    ])} as Response)) as typeof fetch;
+    const recs = await fetchLcrIssues({ owner:"reworthy", repo:"app", token:"t", fetchImpl });
+    expect(recs.map(r => r.commentId)).toEqual([10, 11, 12]);
+    expect(recs[0].plateReply).toBeNull();                       // open → shown
+    expect(recs[1].plateReply?.status).toBe("applied");          // closed → resolved/hidden
+    expect(recs[2].plateReply?.status).toBe("needs-clarification"); // visible
+  });
+  it("returns [] on a non-OK response", async () => {
+    const fetchImpl = (async () => ({ ok:false, status:401 } as Response)) as typeof fetch;
+    expect(await fetchLcrIssues({ owner:"o", repo:"r", token:"t", fetchImpl })).toEqual([]);
   });
 });

--- a/packages/review-overlay/src/github.test.ts
+++ b/packages/review-overlay/src/github.test.ts
@@ -5,6 +5,7 @@ import {
   savePat,
   clearPat,
   submitComment,
+  createIssue,
   type RepoCoord,
 } from "./github.js";
 
@@ -163,5 +164,29 @@ describe("submitComment", () => {
     expect(fetchImpl.mock.calls[0]![0]).toBe(
       "https://github.example.com/api/v3/repos/o/r/issues/5/comments"
     );
+  });
+});
+
+describe("createIssue", () => {
+  it("POSTs to /issues with title+body+labels and returns the issue number", async () => {
+    let captured: { url: string; body: unknown } | null = null;
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      captured = { url, body: JSON.parse(String(init.body)) };
+      return { ok: true, status: 201, json: async () => ({ number: 42, html_url: "http://gh/issues/42" }) } as Response;
+    }) as unknown as typeof fetch;
+    const res = await createIssue({
+      owner: "aminazar", repo: "slowcook", pat: "tok",
+      title: "[LCR] story-104 — x", body: "body", labels: ["lcr-review", "vibe"],
+      fetchImpl,
+    });
+    expect(res).toEqual({ ok: true, commentId: 42, htmlUrl: "http://gh/issues/42" });
+    expect(captured!.url).toBe("https://api.github.com/repos/aminazar/slowcook/issues");
+    expect(captured!.body).toEqual({ title: "[LCR] story-104 — x", body: "body", labels: ["lcr-review", "vibe"] });
+  });
+
+  it("surfaces a GitHub error", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 403, json: async () => ({ message: "Forbidden" }) } as Response)) as typeof fetch;
+    const res = await createIssue({ owner: "o", repo: "r", pat: "t", title: "x", body: "y", fetchImpl });
+    expect(res).toEqual({ ok: false, status: 403, message: "Forbidden" });
   });
 });

--- a/packages/review-overlay/src/github.ts
+++ b/packages/review-overlay/src/github.ts
@@ -204,8 +204,15 @@ export async function fetchLcrIssues(args: FetchLcrArgs): Promise<OverlayComment
     html_url: string;
     state: "open" | "closed";
     labels: Array<{ name: string }>;
+    comments: number;
+    comments_url: string;
     pull_request?: unknown;
   }>;
+  const headers = {
+    Authorization: `Bearer ${args.token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
 
   const out: OverlayCommentRecord[] = [];
   for (const it of issues) {
@@ -214,20 +221,48 @@ export async function fetchLcrIssues(args: FetchLcrArgs): Promise<OverlayComment
     if (!payload) continue;
     const needsClarification = it.labels?.some((l) => l.name === "needs-clarification");
     const resolved = it.state === "closed" && !needsClarification;
+    // closed → applied (hidden behind the toggle); open → needs-clarification
+    // (always visible — it still wants the reviewer's attention).
+    const status: PlateReplyEntry["status"] = resolved ? "applied" : "needs-clarification";
+
+    // 0.6.7 — pull the latest reply so the answer shows IN the overlay (pin
+    // popover + list), not only on GitHub. Maintainer/fixer comments are the
+    // reply channel; the issue body is the original note.
+    let reply: { body: string; htmlUrl: string } | null = null;
+    if (it.comments > 0) {
+      try {
+        const cres = await fetchImpl(`${it.comments_url}?per_page=100`, { headers });
+        if (cres.ok) {
+          const cs = (await cres.json()) as Array<{ body: string | null; html_url: string }>;
+          const last = cs[cs.length - 1];
+          if (last?.body) reply = { body: cleanReplyBody(last.body), htmlUrl: last.html_url };
+        }
+      } catch { /* keep going without a reply */ }
+    }
+
+    const plateReply: PlateReplyEntry | null =
+      reply ? { to_comment_id: it.number, status, summary: reply.body }
+      : resolved ? { to_comment_id: it.number, status: "applied", summary: "Resolved — issue closed." }
+      : needsClarification ? { to_comment_id: it.number, status: "needs-clarification", summary: "Awaiting your clarification." }
+      : null;
+
     out.push({
       commentId: it.number,
       author: it.user?.login ?? "unknown",
       createdAt: it.created_at,
       htmlUrl: it.html_url,
       payload,
-      plateReply: resolved
-        ? { to_comment_id: it.number, status: "applied", summary: "Resolved — issue closed." }
-        : needsClarification
-          ? { to_comment_id: it.number, status: "needs-clarification", summary: "Awaiting your clarification." }
-          : null,
+      plateReply,
+      plateCommentUrl: reply?.htmlUrl,
     });
   }
   return out;
+}
+
+/** Strip hidden payload/plate markers + trim a reply body for the overlay. */
+function cleanReplyBody(body: string): string {
+  const cut = (body.split("<!--")[0] ?? "").trim();
+  return cut.length > 500 ? cut.slice(0, 500) + "…" : cut;
 }
 
 /**

--- a/packages/review-overlay/src/github.ts
+++ b/packages/review-overlay/src/github.ts
@@ -495,3 +495,49 @@ export async function submitComment(args: SubmitArgs): Promise<SubmitResult> {
   const j = (await res.json()) as { id: number; html_url: string };
   return { ok: true, commentId: j.id, htmlUrl: j.html_url };
 }
+
+export interface CreateIssueArgs extends RepoCoord {
+  pat: string;
+  title: string;
+  body: string;
+  labels?: string[];
+  apiBase?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * 0.6.0 — open a standalone issue (LCR review). Distinct from submitComment
+ * (which comments on a PR): an LCR review note is about a story/route of the
+ * living spec, so it becomes its own `vibe`-labelled issue. Returns the same
+ * SubmitResult shape (commentId = issue number).
+ */
+export async function createIssue(args: CreateIssueArgs): Promise<SubmitResult> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const apiBase = args.apiBase ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/issues`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${args.pat}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ title: args.title, body: args.body, labels: args.labels ?? [] }),
+    });
+  } catch (e) {
+    return { ok: false, status: 0, message: `network error: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const j = (await res.json()) as { message?: string };
+      detail = j.message ?? "";
+    } catch { /* non-JSON body */ }
+    return { ok: false, status: res.status, message: detail || res.statusText };
+  }
+  const j = (await res.json()) as { number: number; html_url: string };
+  return { ok: true, commentId: j.number, htmlUrl: j.html_url };
+}

--- a/packages/review-overlay/src/github.ts
+++ b/packages/review-overlay/src/github.ts
@@ -645,3 +645,88 @@ export async function createIssue(args: CreateIssueArgs): Promise<SubmitResult> 
   const j = (await res.json()) as { number: number; html_url: string };
   return { ok: true, commentId: j.number, htmlUrl: j.html_url };
 }
+
+// ── Docs studio (0.7.0) — the textual half of review. Read + commit the spine
+//    markdown docs on the working branch via the GitHub Contents API, so a
+//    scope-change edit lands as a real commit that `refine` picks up. ──────────
+
+/** UTF-8-safe base64 (the docs carry emoji/unicode). */
+function b64decodeUtf8(b64: string): string {
+  const bin = atob(b64.replace(/\s/g, ""));
+  const bytes = Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+function b64encodeUtf8(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export interface DocFile { path: string; content: string; sha: string }
+
+/** Read one markdown doc at a ref (branch). `pat` optional for public repos. */
+export async function fetchDocFile(args: RepoCoord & {
+  path: string; ref: string; pat?: string; apiBase?: string; fetchImpl?: typeof fetch;
+}): Promise<{ ok: true; file: DocFile } | { ok: false; status: number; message: string }> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const apiBase = args.apiBase ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/contents/${args.path.split("/").map(encodeURIComponent).join("/")}?ref=${encodeURIComponent(args.ref)}`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      headers: {
+        ...(args.pat ? { Authorization: `Bearer ${args.pat}` } : {}),
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (e) {
+    return { ok: false, status: 0, message: `network error: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail = "";
+    try { detail = ((await res.json()) as { message?: string }).message ?? ""; } catch { /* */ }
+    return { ok: false, status: res.status, message: detail || res.statusText };
+  }
+  const j = (await res.json()) as { content?: string; sha: string; encoding?: string };
+  const content = j.content && j.encoding === "base64" ? b64decodeUtf8(j.content) : (j.content ?? "");
+  return { ok: true, file: { path: args.path, content, sha: j.sha } };
+}
+
+/** Commit an edited doc to a branch (the "scope change"). Requires write access. */
+export async function commitDocFile(args: RepoCoord & {
+  path: string; content: string; sha: string; branch: string; message: string;
+  pat: string; apiBase?: string; fetchImpl?: typeof fetch;
+}): Promise<{ ok: true; htmlUrl?: string; commit?: string } | { ok: false; status: number; message: string }> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const apiBase = args.apiBase ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/contents/${args.path.split("/").map(encodeURIComponent).join("/")}`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${args.pat}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({
+        message: args.message,
+        content: b64encodeUtf8(args.content),
+        sha: args.sha,
+        branch: args.branch,
+      }),
+    });
+  } catch (e) {
+    return { ok: false, status: 0, message: `network error: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail = "";
+    try { detail = ((await res.json()) as { message?: string }).message ?? ""; } catch { /* */ }
+    return { ok: false, status: res.status, message: detail || res.statusText };
+  }
+  const j = (await res.json()) as { commit?: { html_url?: string; sha?: string } };
+  return { ok: true, htmlUrl: j.commit?.html_url, commit: j.commit?.sha };
+}

--- a/packages/review-overlay/src/github.ts
+++ b/packages/review-overlay/src/github.ts
@@ -162,6 +162,75 @@ export async function fetchOverlayComments(args: FetchArgs): Promise<OverlayComm
 }
 
 /**
+ * 0.6.4 — LCR mode retrieval. In lcr mode a comment IS a `lcr-review` issue
+ * (not a PR comment), so the pin layer + comments list must read the repo's
+ * issues, not a PR's comments. Lists `lcr-review` issues (open + closed),
+ * decodes each one's hidden payload, and maps the issue STATE onto the
+ * reply-status the list-panel filter understands: a CLOSED issue is treated as
+ * resolved/applied (hidden behind "show already-applied"); an OPEN one shows.
+ * A `needs-clarification` label keeps it visible (status stays unresolved).
+ *
+ * Requires a token with read access (the signed-in reviewer's token; the repo
+ * is typically private). Returns [] on any error so the overlay degrades to its
+ * cached state.
+ */
+export interface FetchLcrArgs extends RepoCoord {
+  token: string;
+  apiBase?: string;
+  fetchImpl?: typeof fetch;
+}
+export async function fetchLcrIssues(args: FetchLcrArgs): Promise<OverlayCommentRecord[]> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const apiBase = args.apiBase ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/issues?labels=lcr-review&state=all&per_page=100`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${args.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch {
+    return [];
+  }
+  if (!res.ok) return [];
+  const issues = (await res.json()) as Array<{
+    number: number;
+    user: { login: string } | null;
+    body: string | null;
+    created_at: string;
+    html_url: string;
+    state: "open" | "closed";
+    labels: Array<{ name: string }>;
+    pull_request?: unknown;
+  }>;
+
+  const out: OverlayCommentRecord[] = [];
+  for (const it of issues) {
+    if (it.pull_request) continue; // the /issues endpoint also returns PRs
+    const payload = parseReviewComment(it.body ?? "");
+    if (!payload) continue;
+    const needsClarification = it.labels?.some((l) => l.name === "needs-clarification");
+    const resolved = it.state === "closed" && !needsClarification;
+    out.push({
+      commentId: it.number,
+      author: it.user?.login ?? "unknown",
+      createdAt: it.created_at,
+      htmlUrl: it.html_url,
+      payload,
+      plateReply: resolved
+        ? { to_comment_id: it.number, status: "applied", summary: "Resolved — issue closed." }
+        : needsClarification
+          ? { to_comment_id: it.number, status: "needs-clarification", summary: "Awaiting your clarification." }
+          : null,
+    });
+  }
+  return out;
+}
+
+/**
  * localStorage cache for the comment list — lets the pin layer render
  * instantly on refresh without waiting for the network round-trip.
  * Background-refresh fires after, updating with any newer state.

--- a/packages/review-overlay/src/react/arm-to-pick.test.tsx
+++ b/packages/review-overlay/src/react/arm-to-pick.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+//
+// 0.8.2 — coverage for 0.8.0 "arm-to-pick" free navigation, shipped untested.
+// Contract: in LCR comment mode the page is navigable by default; only after
+// the reviewer arms a single pick does the *next* page click get captured into
+// a comment, after which it auto-disarms. Driving the real toolbar buttons here
+// also proves the 0.7.3 shadow-DOM portal still delivers React click events
+// (a portal outside the root container is exactly where delegation can break).
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SlowcookReviewOverlay } from "./overlay.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let pageBtn: HTMLButtonElement;
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => ({
+    ok: true, status: 200, headers: new Headers(), json: async () => [], text: async () => "[]",
+  })));
+  vi.stubGlobal("matchMedia", vi.fn(() => ({
+    matches: false, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+  })));
+  // a plain page element the reviewer could click to navigate.
+  pageBtn = document.createElement("button");
+  pageBtn.id = "page-btn";
+  pageBtn.textContent = "go somewhere";
+  document.body.appendChild(pageBtn);
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  pageBtn.remove();
+  document.querySelectorAll("[data-slowcook-overlay-host]").forEach((n) => n.remove());
+  vi.unstubAllGlobals();
+});
+
+function shadow(): ShadowRoot {
+  const host = document.querySelector("[data-slowcook-overlay-host]") as HTMLElement;
+  return host.shadowRoot!;
+}
+function buttons(): HTMLButtonElement[] {
+  return Array.from(shadow().querySelectorAll("button"));
+}
+function clickPage(): boolean {
+  // returns true if NOT prevented (i.e. the click was left to navigate freely).
+  // Wrapped in act() so any state change the capture handler makes (e.g. the
+  // one-shot disarm) flushes — and the capture effect re-subscribes — before
+  // the next dispatch. preventDefault is called synchronously during dispatch,
+  // so the return value still reflects this click.
+  let navigable = true;
+  act(() => {
+    const evt = new MouseEvent("click", { bubbles: true, cancelable: true });
+    navigable = pageBtn.dispatchEvent(evt);
+  });
+  return navigable;
+}
+
+function render() {
+  act(() => {
+    root.render(
+      <SlowcookReviewOverlay enabled reviewMode="lcr" owner="acme" repo="app" prNumber={1} branch="main" />,
+    );
+  });
+}
+
+describe("arm-to-pick free navigation (0.8.0)", () => {
+  it("captures a page click only after arming, then auto-disarms", () => {
+    render();
+
+    // Nav mode by default: no arm affordance yet.
+    expect(buttons().find((b) => /Pin a comment/i.test(b.title))).toBeUndefined();
+
+    // Enter comment mode via the toolbar toggle ("💬 Review").
+    const toggle = buttons().find((b) => /Review/i.test(b.textContent ?? ""));
+    expect(toggle, "the Review/Reviewing mode toggle is present").toBeTruthy();
+    act(() => { toggle!.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+
+    // Comment mode, NOT armed → the page is navigable; a page click is untouched.
+    const arm = buttons().find((b) => /Pin a comment/i.test(b.title));
+    expect(arm, "arm-a-pick button appears in comment mode").toBeTruthy();
+    expect(clickPage(), "unarmed page click navigates freely (not captured)").toBe(true);
+
+    // Arm a single pick.
+    act(() => { arm!.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+
+    // Armed → the next page click is captured (prevented)...
+    expect(clickPage(), "armed page click is captured (prevented)").toBe(false);
+
+    // ...and it auto-disarmed, so a subsequent page click navigates freely again.
+    expect(clickPage(), "auto-disarm after one pick — page navigable again").toBe(true);
+  });
+});

--- a/packages/review-overlay/src/react/auth-error.test.ts
+++ b/packages/review-overlay/src/react/auth-error.test.ts
@@ -1,0 +1,56 @@
+// 0.8.2 — coverage for describeAuthError (shipped untested in 0.8.1). Pure
+// function: maps a GitHub write/auth failure to a plain-English remedy keyed
+// off HTTP status + GitHub's own message + the repo coordinate.
+import { describe, it, expect } from "vitest";
+import { describeAuthError } from "./overlay.js";
+
+const repo = { owner: "delgoosh", repo: "monorepo" };
+
+describe("describeAuthError", () => {
+  it("explains the OAuth-App org restriction (the private-repo / device-flow dead-end)", () => {
+    const msg = describeAuthError(403, "Although you appear to have the correct authorization credentials, the `delgoosh` organization has enabled OAuth App access restrictions", repo);
+    // names the org, blames the OAuth-App restriction, prescribes a classic PAT.
+    expect(msg).toContain('"delgoosh"');
+    expect(msg).toContain("OAuth App");
+    expect(msg).toContain("classic personal access token");
+    expect(msg).toContain("`repo` scope");
+  });
+
+  it("matches the OAuth-restriction case case-insensitively", () => {
+    const upper = describeAuthError(403, "OAUTH APP ACCESS RESTRICTIONS apply here", repo);
+    expect(upper).toContain("OAuth App");
+    expect(upper).toContain("classic personal access token");
+  });
+
+  it("gives a generic 403 remedy (private repo or org restriction) when the message is unspecific", () => {
+    const msg = describeAuthError(403, "Forbidden", repo);
+    expect(msg).toContain("403");
+    expect(msg).toContain("delgoosh/monorepo");
+    expect(msg).toContain("classic token");
+    expect(msg).toContain("`repo` scope");
+    // a bare 403 must NOT claim the OAuth-restriction reason.
+    expect(msg).not.toContain("OAuth App access restrictions");
+  });
+
+  it("treats 401 as an expired/insufficient token → re-sign-in", () => {
+    const msg = describeAuthError(401, "Bad credentials", repo);
+    expect(msg).toContain("401");
+    expect(msg.toLowerCase()).toMatch(/expired|missing scope/);
+    expect(msg).toContain("`repo` scope");
+  });
+
+  it("treats 404 as a private-repo-invisible-to-token case", () => {
+    const msg = describeAuthError(404, "Not Found", repo);
+    expect(msg).toContain("delgoosh/monorepo");
+    expect(msg.toLowerCase()).toContain("private");
+    expect(msg).toContain("`repo`");
+  });
+
+  it("falls back to GitHub's own message for unmapped statuses", () => {
+    expect(describeAuthError(500, "Server boom", repo)).toBe("Server boom");
+  });
+
+  it("falls back to a default prompt when there is neither status nor message", () => {
+    expect(describeAuthError(undefined, undefined, repo)).toBe("Sign-in needed to post your comment.");
+  });
+});

--- a/packages/review-overlay/src/react/index.ts
+++ b/packages/review-overlay/src/react/index.ts
@@ -1,2 +1,3 @@
 export { SlowcookReviewOverlay, type SlowcookReviewOverlayProps } from "./overlay.js";
 export { useScenarioCommentStats, type UseScenarioCommentStatsArgs } from "./use-scenario-comment-stats.js";
+export { useStoryMarker, readCurrentStory } from "./use-story-marker.js";

--- a/packages/review-overlay/src/react/markdown.test.ts
+++ b/packages/review-overlay/src/react/markdown.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { renderMarkdown } from "./markdown.js";
+
+describe("renderMarkdown", () => {
+  it("renders headings, bold, inline code, links", () => {
+    const h = renderMarkdown("# Title\n\nA **bold** and `code` and [x](https://y).");
+    expect(h).toContain("<h1>Title</h1>");
+    expect(h).toContain("<strong>bold</strong>");
+    expect(h).toContain("<code>code</code>");
+    expect(h).toContain('<a href="https://y" target="_blank" rel="noreferrer">x</a>');
+  });
+  it("renders lists, blockquotes, hr, fenced code", () => {
+    expect(renderMarkdown("- a\n- b")).toContain("<ul><li>a</li><li>b</li></ul>");
+    expect(renderMarkdown("> quote")).toContain("<blockquote>quote</blockquote>");
+    expect(renderMarkdown("---")).toContain("<hr/>");
+    expect(renderMarkdown("```\nx<y\n```")).toContain("<pre><code>x&lt;y</code></pre>");
+  });
+  it("renders GFM tables", () => {
+    const h = renderMarkdown("| A | B |\n|---|---|\n| 1 | 2 |");
+    expect(h).toContain("<table>");
+    expect(h).toContain("<th>A</th>");
+    expect(h).toContain("<td>1</td>");
+  });
+  it("escapes raw HTML in text (no injection)", () => {
+    expect(renderMarkdown("a <script>alert(1)</script>")).not.toContain("<script>");
+    expect(renderMarkdown("a <script>")).toContain("&lt;script&gt;");
+  });
+});

--- a/packages/review-overlay/src/react/markdown.ts
+++ b/packages/review-overlay/src/react/markdown.ts
@@ -1,0 +1,91 @@
+/**
+ * Tiny dependency-free Markdown → HTML renderer for the docs studio preview.
+ * Covers what the spine docs use: headings, bold/italic/inline-code, fenced code,
+ * links, ordered/unordered lists, blockquotes, hr, tables, paragraphs. Not a
+ * full CommonMark parser — deliberately small (the overlay ships zero runtime
+ * deps). Output is for `dangerouslySetInnerHTML`; all raw text is HTML-escaped
+ * first so doc content can't inject markup.
+ */
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Inline spans: code, bold, italic, links. Operates on already-escaped text. */
+function inline(s: string): string {
+  return s
+    .replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`)
+    .replace(/\*\*([^*]+)\*\*/g, (_m, c) => `<strong>${c}</strong>`)
+    .replace(/(^|[^*])\*([^*\n]+)\*/g, (_m, p, c) => `${p}<em>${c}</em>`)
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, t, href) => `<a href="${href}" target="_blank" rel="noreferrer">${t}</a>`);
+}
+
+export function renderMarkdown(md: string): string {
+  const lines = md.replace(/\r\n/g, "\n").split("\n");
+  const out: string[] = [];
+  let i = 0;
+  let para: string[] = [];
+  const flushPara = () => {
+    if (para.length) { out.push(`<p>${inline(esc(para.join(" ")))}</p>`); para = []; }
+  };
+  while (i < lines.length) {
+    const line = lines[i]!;
+    // fenced code
+    if (/^```/.test(line)) {
+      flushPara();
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i]!)) { buf.push(lines[i]!); i++; }
+      i++; // closing fence
+      out.push(`<pre><code>${esc(buf.join("\n"))}</code></pre>`);
+      continue;
+    }
+    // horizontal rule
+    if (/^\s*(-{3,}|\*{3,}|_{3,})\s*$/.test(line)) { flushPara(); out.push("<hr/>"); i++; continue; }
+    // heading
+    const h = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (h) { flushPara(); const lvl = h[1]!.length; out.push(`<h${lvl}>${inline(esc(h[2]!))}</h${lvl}>`); i++; continue; }
+    // blockquote
+    if (/^>\s?/.test(line)) {
+      flushPara();
+      const buf: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i]!)) { buf.push(lines[i]!.replace(/^>\s?/, "")); i++; }
+      out.push(`<blockquote>${inline(esc(buf.join(" ")))}</blockquote>`);
+      continue;
+    }
+    // table (GFM): a header row, a |---| separator, then rows
+    if (/^\s*\|.*\|\s*$/.test(line) && i + 1 < lines.length && /^\s*\|?[\s:|-]+\|?\s*$/.test(lines[i + 1]!)) {
+      flushPara();
+      const cells = (r: string) => r.trim().replace(/^\||\|$/g, "").split("|").map((c) => c.trim());
+      const head = cells(line);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i]!)) { rows.push(cells(lines[i]!)); i++; }
+      const thead = `<thead><tr>${head.map((c) => `<th>${inline(esc(c))}</th>`).join("")}</tr></thead>`;
+      const tbody = `<tbody>${rows.map((r) => `<tr>${r.map((c) => `<td>${inline(esc(c))}</td>`).join("")}</tr>`).join("")}</tbody>`;
+      out.push(`<table>${thead}${tbody}</table>`);
+      continue;
+    }
+    // unordered list
+    if (/^\s*[-*+]\s+/.test(line)) {
+      flushPara();
+      const buf: string[] = [];
+      while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i]!)) { buf.push(lines[i]!.replace(/^\s*[-*+]\s+/, "")); i++; }
+      out.push(`<ul>${buf.map((b) => `<li>${inline(esc(b))}</li>`).join("")}</ul>`);
+      continue;
+    }
+    // ordered list
+    if (/^\s*\d+\.\s+/.test(line)) {
+      flushPara();
+      const buf: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i]!)) { buf.push(lines[i]!.replace(/^\s*\d+\.\s+/, "")); i++; }
+      out.push(`<ol>${buf.map((b) => `<li>${inline(esc(b))}</li>`).join("")}</ol>`);
+      continue;
+    }
+    // blank line → paragraph break
+    if (/^\s*$/.test(line)) { flushPara(); i++; continue; }
+    para.push(line.trim());
+    i++;
+  }
+  flushPara();
+  return out.join("\n");
+}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1384,6 +1384,7 @@ function Composer(props: {
             border: "1px solid rgba(0,0,0,0.15)",
             borderRadius: 6,
             font: "inherit",
+            fontSize: 16, // 0.6.12 — ≥16px stops iOS Safari auto-zooming on focus
             resize: "vertical",
             boxSizing: "border-box",
           }}
@@ -2096,6 +2097,7 @@ function GeneralComposer(props: {
           border: "1px solid rgba(0,0,0,0.15)",
           borderRadius: 6,
           font: "inherit",
+          fontSize: 16, // 0.6.12 — ≥16px stops iOS Safari auto-zooming on focus
           resize: "vertical",
           boxSizing: "border-box",
         }}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -392,6 +392,20 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
+  // 0.6.6 — entering Nav clears the whole comment surface: any open composer,
+  // the comments-list panel, a general-note composer, an open pin popover, the
+  // approve confirm, the hover preview. Nav = "done reviewing, clean slate".
+  useEffect(() => {
+    if (mode !== "nav") return;
+    setComposerOpen(false);
+    setTarget(null);
+    setGeneralComposerOpen(false);
+    setListPanelOpen(false);
+    setOpenCommentId(null);
+    setApproveConfirmOpen(false);
+    setHoverEl(null);
+  }, [mode]);
+
   const onApproveClicked = useCallback(() => {
     // 0.2.0 — two-step confirm; protects against fat-finger approval.
     setMode("approve");

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -28,12 +28,15 @@ import { extractSelector, resolveStoredSelector } from "../selector.js";
 import {
   buildPayload,
   formatReviewComment,
+  formatLcrIssue,
   type ViewportInfo,
+  type ReviewCommentPayload,
 } from "../comment-format.js";
 import {
   loadPat,
   savePat,
   submitComment,
+  createIssue,
   fetchOverlayComments,
   loadCachedComments,
   saveCachedComments,
@@ -54,6 +57,7 @@ import {
   identifyReviewer,
 } from "../reviewer-session.js";
 import { isResolvedStatus } from "../comment-format.js";
+import { readCurrentStory } from "./use-story-marker.js";
 import type { ReviewerIdentity } from "@slowcook-ai/core";
 
 export interface SlowcookReviewOverlayProps {
@@ -260,6 +264,31 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     setFeedback("Signed out.");
   }, [owner, repo]);
 
+  // 0.6.0 — where a comment lands depends on context:
+  //  - scenarios mode → a comment on the mockup PR (vibe applies it).
+  //  - lcr mode → a standalone [LCR] issue tagged with the route's story +
+  //    the `vibe` label, since an LCR note is about a requirement, not a PR.
+  const postPayload = useCallback(
+    async (payload: ReviewCommentPayload, pat: string) => {
+      if (reviewMode === "lcr") {
+        const issue = formatLcrIssue({ payload });
+        const res = await createIssue({
+          owner: repoCoord.owner, repo: repoCoord.repo, pat,
+          title: issue.title, body: issue.body, labels: issue.labels,
+          apiBase: getProxyApiBase() ?? undefined,
+        });
+        return { res, kind: "issue" as const };
+      }
+      const res = await submitComment({
+        owner: repoCoord.owner, repo: repoCoord.repo, pr: prNumber, pat,
+        body: formatReviewComment({ payload }),
+        apiBase: getProxyApiBase() ?? undefined,
+      });
+      return { res, kind: "comment" as const };
+    },
+    [reviewMode, repoCoord, prNumber],
+  );
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     // 0.2.0 — hide on the picker route (homepage). The picker is for
@@ -424,23 +453,16 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           url: window.location.href,
           pathname: window.location.pathname,
           routeQuery: window.location.search,
+          routeStory: readCurrentStory(),
           prose,
           selector: sel,
           bbox: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
           viewport,
           userAgent: navigator.userAgent,
         });
-        const body = formatReviewComment({ payload });
-        const result = await submitComment({
-          owner: repoCoord.owner,
-          repo: repoCoord.repo,
-          pr: prNumber,
-          pat,
-          body,
-          apiBase: getProxyApiBase() ?? undefined,
-        });
+        const { res: result, kind } = await postPayload(payload, pat);
         if (result.ok) {
-          setFeedback(`Comment posted (#${result.commentId}).`);
+          setFeedback(kind === "issue" ? `LCR issue filed (#${result.commentId}).` : `Comment posted (#${result.commentId}).`);
           setComposerOpen(false);
           setTarget(null);
           // 0.4.1 — push the just-submitted comment into the local pin
@@ -501,22 +523,15 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           url: window.location.href,
           pathname: window.location.pathname,
           routeQuery: window.location.search,
+          routeStory: readCurrentStory(),
           prose,
           viewport,
           userAgent: navigator.userAgent,
           // No selector + no bbox → general comment.
         });
-        const body = formatReviewComment({ payload });
-        const result = await submitComment({
-          owner: repoCoord.owner,
-          repo: repoCoord.repo,
-          pr: prNumber,
-          pat,
-          body,
-          apiBase: getProxyApiBase() ?? undefined,
-        });
+        const { res: result, kind } = await postPayload(payload, pat);
         if (result.ok) {
-          setFeedback(`Note posted (#${result.commentId}).`);
+          setFeedback(kind === "issue" ? `LCR issue filed (#${result.commentId}).` : `Note posted (#${result.commentId}).`);
           setGeneralComposerOpen(false);
           const optimisticRecord = {
             commentId: result.commentId,

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1877,6 +1877,9 @@ function CommentsListPanel(props: {
   isApproved: boolean;
 }): JSX.Element {
   const { records, showApplied, onToggleApplied, onClose, onOpenComment, onAddGeneral, onApprove, isApproved } = props;
+  // 0.6.14 — expand/collapse a row in place to read the full prose + reply,
+  // open the GitHub issue, or (for anchored comments) locate the pin on the page.
+  const [expandedId, setExpandedId] = useState<number | null>(null);
   // 0.6.0 — resolved comments (applied/declined/noop) hide by default so the
   // list shows what still needs attention; needs-clarification + unresolved
   // always show. The toggle reveals the resolved ones.
@@ -1999,68 +2002,47 @@ function CommentsListPanel(props: {
               : hidden
               ? { text: "hidden", color: "#94a3b8", bg: "rgba(148,163,184,0.18)" }
               : { text: "anchored", color: "#22c55e", bg: "rgba(34,197,94,0.18)" };
+            const expanded = expandedId === r.commentId;
+            const clamp = (lines: number) => expanded ? {} : { display: "-webkit-box", WebkitLineClamp: lines, WebkitBoxOrient: "vertical" as const, overflow: "hidden" };
             return (
-              <button
+              <div
                 key={r.commentId}
-                type="button"
-                onClick={() => onOpenComment(r.commentId)}
                 style={{
-                  display: "block",
-                  width: "100%",
-                  textAlign: "left",
                   background: "rgba(255,255,255,0.03)",
-                  border: "1px solid rgba(255,255,255,0.08)",
-                  borderRadius: 8,
-                  padding: 10,
-                  marginBottom: 6,
-                  cursor: "pointer",
-                  color: "white",
-                  font: "inherit",
+                  border: `1px solid ${expanded ? "rgba(255,255,255,0.18)" : "rgba(255,255,255,0.08)"}`,
+                  borderRadius: 8, padding: 10, marginBottom: 6, color: "white",
                 }}
               >
-                <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
-                  <span style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: 18,
-                    height: 18,
-                    borderRadius: 999,
-                    background: palette.bg,
-                    color: palette.fg,
-                    fontSize: 10,
-                    fontWeight: 700,
-                  }}>{palette.glyph}</span>
-                  <span style={{
-                    fontSize: 10,
-                    fontWeight: 700,
-                    textTransform: "uppercase",
-                    letterSpacing: 0.4,
-                    padding: "1px 6px",
-                    borderRadius: 999,
-                    background: anchorLabel.bg,
-                    color: anchorLabel.color,
-                  }}>{anchorLabel.text}</span>
-                  <span style={{ fontSize: 10, opacity: 0.55, marginLeft: "auto" }}>
-                    @{r.author} · {formatTimeAgo(r.createdAt)}
-                  </span>
-                </div>
-                <div style={{ fontSize: 12, opacity: 0.85, lineHeight: 1.4, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
-                  {r.payload.prose}
-                </div>
-                {/* 0.6.7 — show the latest reply inline so the answer is visible
-                    in the list, not only the pin popover. */}
+                {/* Header — click toggles expand. */}
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(expanded ? null : r.commentId)}
+                  style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", textAlign: "left", color: "white", font: "inherit", cursor: "pointer" }}
+                >
+                  <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 18, height: 18, borderRadius: 999, background: palette.bg, color: palette.fg, fontSize: 10, fontWeight: 700 }}>{palette.glyph}</span>
+                  <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4, padding: "1px 6px", borderRadius: 999, background: anchorLabel.bg, color: anchorLabel.color }}>{anchorLabel.text}</span>
+                  <span style={{ fontSize: 10, opacity: 0.55, marginLeft: "auto" }}>@{r.author} · {formatTimeAgo(r.createdAt)}</span>
+                  <span aria-hidden style={{ fontSize: 10, opacity: 0.55, transform: expanded ? "rotate(90deg)" : "none", transition: "transform .15s" }}>▶</span>
+                </button>
+                <div style={{ fontSize: 12, opacity: 0.85, lineHeight: 1.4, marginTop: 4, ...clamp(3) }}>{r.payload.prose}</div>
                 {r.plateReply?.summary && (
-                  <div style={{
-                    marginTop: 6, paddingTop: 6, borderTop: "1px solid rgba(255,255,255,0.08)",
-                    fontSize: 11.5, lineHeight: 1.45, color: "rgba(255,255,255,0.82)",
-                    display: "-webkit-box", WebkitLineClamp: 4, WebkitBoxOrient: "vertical", overflow: "hidden",
-                  }}>
-                    <span style={{ color: palette.bg, fontWeight: 700 }}>↳ reply: </span>
-                    {r.plateReply.summary}
+                  <div style={{ marginTop: 6, paddingTop: 6, borderTop: "1px solid rgba(255,255,255,0.08)", fontSize: 11.5, lineHeight: 1.45, color: "rgba(255,255,255,0.82)", whiteSpace: "pre-wrap", ...clamp(4) }}>
+                    <span style={{ color: palette.bg, fontWeight: 700 }}>↳ reply: </span>{r.plateReply.summary}
                   </div>
                 )}
-              </button>
+                {/* Actions — always offer GitHub; locate only when anchored. */}
+                <div style={{ display: "flex", gap: 12, marginTop: 8, fontSize: 11.5 }}>
+                  <a href={r.htmlUrl} target="_blank" rel="noreferrer" style={{ color: "#7cc7ff", textDecoration: "none" }}>↗ Open issue on GitHub</a>
+                  {anchored && (
+                    <button type="button" onClick={() => onOpenComment(r.commentId)} style={{ color: "#22c55e", font: "inherit", fontSize: 11.5, cursor: "pointer" }}>
+                      📍 {live ? "Locate on page" : "Anchor drifted"}
+                    </button>
+                  )}
+                  {!expanded && (r.payload.prose.length > 120 || (r.plateReply?.summary?.length ?? 0) > 180) && (
+                    <button type="button" onClick={() => setExpandedId(r.commentId)} style={{ color: "rgba(255,255,255,0.6)", font: "inherit", fontSize: 11.5, cursor: "pointer", marginLeft: "auto" }}>Expand</button>
+                  )}
+                </div>
+              </div>
             );
           })
         )}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -145,6 +145,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // are declared. Bails early during SSR via the typeof window check.
   const [mode, setMode] = useState<Mode>("nav");
   const [target, setTarget] = useState<Element | null>(null);
+  // 0.6.5 — element under the cursor in comment mode (green hover preview).
+  const [hoverEl, setHoverEl] = useState<Element | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   // 0.5.0 — comments-list panel state. Opened by the "📋" button in
   // the pill OR by clicking the count badge on the Comment toggle.
@@ -355,24 +357,38 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // Capture clicks at the document level when in comment/approve mode.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (mode === "nav") return;
+    if (mode === "nav") { setHoverEl(null); return; }
+    const isOwnUi = (el: Element | null) =>
+      !el ||
+      (composerRef.current && composerRef.current.contains(el)) ||
+      !!(el as HTMLElement).closest('[data-slowcook-overlay-ui="1"]');
     function onClick(e: MouseEvent) {
       const el = e.target as Element | null;
-      if (!el) return;
-      // Don't capture clicks on the overlay's own UI.
-      if (composerRef.current && composerRef.current.contains(el)) return;
-      if ((el as HTMLElement).closest('[data-slowcook-overlay-ui="1"]')) return;
+      if (!el || isOwnUi(el)) return;
       e.preventDefault();
       e.stopPropagation();
       if (mode === "comment") {
         setTarget(el);
+        setHoverEl(null);
         setComposerOpen(true);
       } else if (mode === "approve") {
         void submitApproval();
       }
     }
+    // 0.6.5 — live hover preview in comment mode: green-outline the element that
+    // would be selected on click, so the reviewer isn't minesweeping. (The red
+    // outline marks the element already chosen for the open composer.)
+    function onMove(e: MouseEvent) {
+      if (mode !== "comment") return;
+      const el = e.target as Element | null;
+      setHoverEl(el && !isOwnUi(el) ? el : null);
+    }
     document.addEventListener("click", onClick, { capture: true });
-    return () => document.removeEventListener("click", onClick, { capture: true });
+    document.addEventListener("mouseover", onMove, { capture: true });
+    return () => {
+      document.removeEventListener("click", onClick, { capture: true });
+      document.removeEventListener("mouseover", onMove, { capture: true });
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
@@ -621,6 +637,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           aria-hidden="true"
         />
       )}
+      {/* 0.6.5 — green hover preview of the click target in comment mode. */}
+      {mode === "comment" && !composerOpen && hoverEl && <HoverHighlight el={hoverEl} />}
       <ModeToggle
         mode={mode}
         onChange={(m) => (m === "approve" ? onApproveClicked() : setMode(m))}
@@ -713,6 +731,32 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
 }
 
 /**
+/**
+ * 0.6.5 — green hover preview in comment mode. Outlines the element the cursor
+ * is over (the one a click would attach the comment to) so the reviewer can see
+ * the target before committing — no minesweeping. Distinct from the red outline,
+ * which marks the element already chosen for the open composer.
+ */
+function HoverHighlight({ el }: { el: Element }): JSX.Element {
+  const r = el.getBoundingClientRect();
+  return (
+    <div
+      data-slowcook-overlay-ui="1"
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        top: r.top, left: r.left, width: r.width, height: r.height,
+        border: "2px solid #22c55e",
+        background: "rgba(34, 197, 94, 0.12)",
+        borderRadius: 4,
+        boxShadow: "0 0 0 1px rgba(34,197,94,0.35)",
+        pointerEvents: "none",
+        zIndex: 2147483200,
+      }}
+    />
+  );
+}
+
 /** 0.6.0 — device-flow login dialog: shows the user code + verification link. */
 function ReviewerLoginDialog({
   userCode, verificationUri, status, onClose,

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -56,10 +56,11 @@ import {
   clearReviewerSession,
   runDeviceLogin,
   identifyReviewer,
+  checkRepoWriteAccess,
+  type StoredReviewerIdentity,
 } from "../reviewer-session.js";
 import { isResolvedStatus } from "../comment-format.js";
 import { readCurrentStory } from "./use-story-marker.js";
-import type { ReviewerIdentity } from "@slowcook-ai/core";
 
 export interface SlowcookReviewOverlayProps {
   /**
@@ -163,7 +164,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const [approveConfirmOpen, setApproveConfirmOpen] = useState(false);
   // 0.6.0 — LCR multi-person review: who's signed in (this browser) + the
   // device-flow login dialog state. Comments post as this reviewer.
-  const [reviewerIdentity, setReviewerIdentity] = useState<ReviewerIdentity | null>(null);
+  const [reviewerIdentity, setReviewerIdentity] = useState<StoredReviewerIdentity | null>(null);
   const [login, setLogin] = useState<{ open: boolean; userCode?: string; verificationUri?: string; status: string }>({ open: false, status: "" });
   const loginAbort = useRef(false);
   // 0.6.0 — "show already-applied" toggle for the comments list. Resolved
@@ -313,12 +314,17 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     });
     if (!token) return;
     try {
-      const id = await identifyReviewer(token);
+      const base = await identifyReviewer(token);
+      // Derive the apply tier from repo write access (push/maintain/admin).
+      const canApply = await checkRepoWriteAccess(token, { owner, repo });
+      const id = { ...base, canApply };
       saveReviewerToken(window.localStorage, { owner, repo }, token);
       saveReviewerIdentity(window.localStorage, { owner, repo }, id);
       setReviewerIdentity(id);
       setLogin({ open: false, status: "" });
-      setFeedback(`Signed in as @${id.login}.`);
+      setFeedback(canApply
+        ? `Signed in as @${id.login} — your comments are applied.`
+        : `Signed in as @${id.login} — your feedback goes to the team for review.`);
     } catch (e) {
       setLogin({ open: true, status: `Could not read your GitHub identity: ${e instanceof Error ? e.message : String(e)}` });
     }
@@ -337,7 +343,9 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const postPayload = useCallback(
     async (payload: ReviewCommentPayload, pat: string) => {
       if (reviewMode === "lcr") {
-        const issue = formatLcrIssue({ payload });
+        // Only write-access reviewers get the `vibe` (auto-apply) label; others
+        // are labelled `community-review` and held for the team to triage.
+        const issue = formatLcrIssue({ payload, canApply: reviewerIdentity?.canApply === true });
         const res = await createIssue({
           owner: repoCoord.owner, repo: repoCoord.repo, pat,
           title: issue.title, body: issue.body, labels: issue.labels,
@@ -352,7 +360,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       });
       return { res, kind: "comment" as const };
     },
-    [reviewMode, repoCoord, prNumber],
+    [reviewMode, repoCoord, prNumber, reviewerIdentity],
   );
 
   useEffect(() => {
@@ -924,7 +932,7 @@ function ModeToggle(props: {
   // 0.6.2 — LCR sign-in lives IN the floating disk (self-styled, theme-proof),
   // not a separate fixed badge.
   reviewMode: "scenarios" | "lcr";
-  identity: ReviewerIdentity | null;
+  identity: StoredReviewerIdentity | null;
   onSignIn: () => void;
   onSignOut: () => void;
 }): JSX.Element {
@@ -1123,7 +1131,11 @@ function ModeToggle(props: {
       {reviewMode === "lcr" && mode === "comment" && (
         identity ? (
           <span
-            title={confirmLogout ? "Click again to sign out (or click anything else to cancel)" : `Signed in as @${identity.login}`}
+            title={confirmLogout
+              ? "Click again to sign out (or click anything else to cancel)"
+              : identity.canApply
+              ? `Signed in as @${identity.login} — you have write access, so your comments are applied`
+              : `Signed in as @${identity.login} — no write access, so your feedback is gathered for the team to review (not auto-applied)`}
             onClick={() => { if (confirmLogout) { setConfirmLogout(false); onSignOut(); } else { setConfirmLogout(true); } }}
             style={{
               marginLeft: 4, display: "inline-flex", alignItems: "center", gap: 6,
@@ -1141,6 +1153,13 @@ function ModeToggle(props: {
                   ? <img src={identity.avatarUrl} alt="" width={20} height={20} style={{ borderRadius: "50%" }} />
                   : <span aria-hidden style={{ width: 20, height: 20, borderRadius: "50%", background: "rgba(255,255,255,0.2)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 11 }}>👤</span>}
                 @{identity.login}
+                {/* tier chip — write access applies; otherwise feedback to team */}
+                <span style={{
+                  fontSize: 9.5, fontWeight: 800, letterSpacing: 0.3, textTransform: "uppercase",
+                  padding: "1px 6px", borderRadius: 999,
+                  background: identity.canApply ? "rgba(34,197,94,0.22)" : "rgba(148,163,184,0.25)",
+                  color: identity.canApply ? "#4ade80" : "#cbd5e1",
+                }}>{identity.canApply ? "applies" : "review"}</span>
               </>
             )}
           </span>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -187,6 +187,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!enabled) return;
+    // 0.6.1 — the pin layer reads PR comments; lcr mode (no PR) skips it and
+    // relies on the GitHub issues it files instead.
     if (!owner || !repo || !prNumber) return;
     const cached = loadCachedComments(window.localStorage, { owner, repo }, prNumber);
     if (cached) setComments(cached);
@@ -563,9 +565,12 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   if (typeof window === "undefined") return null;
   if (isPickerRoute) return null;
   // 0.5.1 — auto-detect path: skip when env vars + props together
-  // don't supply a real owner/repo/pr. Avoids "submit comment"
-  // failing silently because the API call goes nowhere.
-  if (!owner || !repo || !prNumber) return null;
+  // don't supply a real owner/repo. Avoids "submit comment" failing
+  // silently because the API call goes nowhere.
+  // 0.6.1 — lcr mode files ISSUES (not PR comments), so it needs no PR;
+  // only scenarios mode requires a prNumber.
+  if (!owner || !repo) return null;
+  if (reviewMode !== "lcr" && !prNumber) return null;
 
   return (
     <div

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -180,6 +180,23 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // refresh; background-refresh on focus.
   const [comments, setComments] = useState<OverlayCommentRecord[]>([]);
   const [openCommentId, setOpenCommentId] = useState<number | null>(null);
+  // 0.6.8 — "new activity" badge: track which comment states the reviewer has
+  // already seen, so new replies / newly-applied resolutions ping the Comment
+  // button with a green count. Signature = id + reply status + reply length.
+  const seenKey = `slowcook.review-overlay.seen.${owner}/${repo}`;
+  const [seenSigs, setSeenSigs] = useState<Set<string>>(() => {
+    try { return new Set(JSON.parse(window.localStorage.getItem(seenKey) ?? "[]") as string[]); }
+    catch { return new Set(); }
+  });
+  const sigOf = (r: OverlayCommentRecord) =>
+    `${r.commentId}:${r.plateReply?.status ?? ""}:${(r.plateReply?.summary ?? "").length}`;
+  const newCount = comments.filter((r) => !seenSigs.has(sigOf(r))).length;
+  const markAllSeen = useCallback(() => {
+    const sigs = comments.map(sigOf);
+    setSeenSigs(new Set(sigs));
+    try { window.localStorage.setItem(seenKey, JSON.stringify(sigs)); } catch { /* ignore */ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comments]);
   // 0.4.2 — approved state. True when the PR carries the
   // slowcook-mockup-approved label; pill renders green-tinted +
   // hides the Approve button. Nav + Comment still work for follow-up
@@ -660,7 +677,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         isMobile={isMobile}
         isApproved={isApproved}
         commentCount={comments.length}
-        onListClick={() => setListPanelOpen(true)}
+        newCount={newCount}
+        onListClick={() => { setListPanelOpen(true); markAllSeen(); }}
         reviewMode={reviewMode}
         identity={reviewerIdentity}
         onSignIn={() => void signIn()}
@@ -697,6 +715,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
             setListPanelOpen(false);
             setGeneralComposerOpen(true);
           }}
+          onApprove={() => { setListPanelOpen(false); onApproveClicked(); }}
+          isApproved={isApproved}
         />
       )}
       {generalComposerOpen && (
@@ -851,6 +871,7 @@ function ModeToggle(props: {
   isMobile: boolean;
   isApproved: boolean;
   commentCount: number;
+  newCount: number;
   onListClick: () => void;
   // 0.6.2 — LCR sign-in lives IN the floating disk (self-styled, theme-proof),
   // not a separate fixed badge.
@@ -859,7 +880,7 @@ function ModeToggle(props: {
   onSignIn: () => void;
   onSignOut: () => void;
 }): JSX.Element {
-  const { mode, onChange, disabled, isMobile, isApproved, commentCount, onListClick, reviewMode, identity, onSignIn, onSignOut } = props;
+  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, reviewMode, identity, onSignIn, onSignOut } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -988,36 +1009,24 @@ function ModeToggle(props: {
         onClick={() => onChangeSafe("comment")}
         disabled={disabled}
         label={isMobile ? "💬" : "💬 Comment"}
-        title="Comment on an element"
+        title={newCount ? `Comment — ${newCount} new update(s)` : "Comment on an element"}
         accent
+        badge={newCount}
       />
-      {isApproved ? (
+      {/* 0.6.8 — Approve moved into the Comments panel (under "+ Add note").
+          The disk only shows the approved state now, never the action. */}
+      {isApproved && (
         <span
           data-slowcook-overlay-ui="1"
           title="Mockup approved — comment thread stays open for follow-up; plate refuses to amend"
           style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 4,
-            padding: "6px 12px",
-            borderRadius: 999,
-            background: APPROVED_GREEN,
-            color: "white",
-            fontWeight: 700,
-            fontSize: 13,
+            display: "inline-flex", alignItems: "center", gap: 4,
+            padding: "6px 12px", borderRadius: 999, background: APPROVED_GREEN,
+            color: "white", fontWeight: 700, fontSize: 13,
           }}
         >
           ✓ Approved
         </span>
-      ) : (
-        <ToggleButton
-          active={mode === "approve"}
-          onClick={() => onChangeSafe("approve")}
-          disabled={disabled}
-          label={isMobile ? "✅" : "✅ Approve"}
-          title="Approve the mockup (asks for confirmation)"
-          approve
-        />
       )}
       {/* 0.5.0 — list-panel toggle. Always reachable; shows ALL
           comments (incl. hidden-element + general). Count badge. */}
@@ -1227,7 +1236,7 @@ function SlowcookLogo(): JSX.Element {
   );
 }
 
-function ToggleButton(props: { active: boolean; onClick: () => void; disabled: boolean; label: string; title?: string; accent?: boolean; approve?: boolean }): JSX.Element {
+function ToggleButton(props: { active: boolean; onClick: () => void; disabled: boolean; label: string; title?: string; accent?: boolean; approve?: boolean; badge?: number }): JSX.Element {
   const bg = props.active
     ? props.approve
       ? "#22c55e"
@@ -1242,6 +1251,7 @@ function ToggleButton(props: { active: boolean; onClick: () => void; disabled: b
       disabled={props.disabled}
       title={props.title}
       style={{
+        position: "relative",
         background: bg,
         color: "white",
         border: "none",
@@ -1253,6 +1263,15 @@ function ToggleButton(props: { active: boolean; onClick: () => void; disabled: b
       }}
     >
       {props.label}
+      {/* 0.6.8 — green "new activity" badge (new replies / newly-applied). */}
+      {props.badge ? (
+        <span style={{
+          position: "absolute", top: -5, right: -5, minWidth: 16, height: 16,
+          padding: "0 4px", borderRadius: 999, background: "#22c55e", color: "white",
+          fontSize: 10, fontWeight: 800, display: "inline-flex", alignItems: "center",
+          justifyContent: "center", boxShadow: "0 0 0 2px rgba(15,15,24,0.92)",
+        }}>{props.badge}</span>
+      ) : null}
     </button>
   );
 }
@@ -1819,8 +1838,10 @@ function CommentsListPanel(props: {
   onClose: () => void;
   onOpenComment: (id: number) => void;
   onAddGeneral: () => void;
+  onApprove: () => void;
+  isApproved: boolean;
 }): JSX.Element {
-  const { records, showApplied, onToggleApplied, onClose, onOpenComment, onAddGeneral } = props;
+  const { records, showApplied, onToggleApplied, onClose, onOpenComment, onAddGeneral, onApprove, isApproved } = props;
   // 0.6.0 — resolved comments (applied/declined/noop) hide by default so the
   // list shows what still needs attention; needs-clarification + unresolved
   // always show. The toggle reveals the resolved ones.
@@ -1889,6 +1910,23 @@ function CommentsListPanel(props: {
           }}
         >
           + Add note (about the page, not an element)
+        </button>
+        {/* 0.6.8 — Approve lives here now (out of the floating disk, where it was
+            too easy to hit). It asks for confirmation before approving. */}
+        <button
+          type="button"
+          onClick={isApproved ? undefined : onApprove}
+          disabled={isApproved}
+          title={isApproved ? "Mockup already approved" : "Approve the whole mockup (asks to confirm)"}
+          style={{
+            width: "100%", marginTop: 8, padding: "10px 12px",
+            background: isApproved ? "rgba(34,197,94,0.15)" : "rgba(34,197,94,0.10)",
+            color: APPROVED_GREEN, border: `1px solid ${APPROVED_GREEN}`,
+            borderRadius: 8, cursor: isApproved ? "default" : "pointer",
+            font: "inherit", fontWeight: 700, fontSize: 13,
+          }}
+        >
+          {isApproved ? "✓ Mockup approved" : "✅ Approve mockup"}
         </button>
       </div>
       {hiddenCount > 0 && (

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -44,10 +44,14 @@ import {
   fetchPrLabels,
   addLabelsToPr,
   submitPrApproval,
+  fetchDocFile,
+  commitDocFile,
   APPROVED_LABEL,
   type RepoCoord,
   type OverlayCommentRecord,
+  type DocFile,
 } from "../github.js";
+import { renderMarkdown } from "./markdown.js";
 import {
   loadReviewerToken,
   loadReviewerIdentity,
@@ -104,6 +108,17 @@ export interface SlowcookReviewOverlayProps {
   authBase?: string;
   /** Overlay package version, included in the JSON payload. */
   overlayVersion?: string;
+  /**
+   * 0.7.0 — docs studio: the spine markdown docs a reviewer can read + edit as
+   * the "textual" half of review. Falls back to `NEXT_PUBLIC_SLOWCOOK_DOC_PATHS`
+   * (comma-separated). Default: the common GUCDI docs. Empty disables Docs mode.
+   */
+  docPaths?: string[];
+  /**
+   * 0.7.0 — the working branch a doc "scope change" commits to (where the PR
+   * lives). Falls back to `NEXT_PUBLIC_SLOWCOOK_BRANCH`, then the repo default.
+   */
+  branch?: string;
 }
 
 type Mode = "nav" | "comment" | "approve";
@@ -129,6 +144,11 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const authBase = props.authBase ?? process.env["NEXT_PUBLIC_SLOWCOOK_AUTH_BASE"] ?? "";
   const overlayVersion = props.overlayVersion ?? "0.6.0";
   const repoCoord: RepoCoord = { owner, repo };
+  // 0.7.0 — docs studio config.
+  const docPaths: string[] = props.docPaths ??
+    (process.env["NEXT_PUBLIC_SLOWCOOK_DOC_PATHS"]?.split(",").map((s) => s.trim()).filter(Boolean)) ??
+    ["docs/PRD.md", "docs/ROADMAP.md", "docs/USER_STORIES.md", "docs/ARCHITECTURE.md"];
+  const branchProp = props.branch ?? process.env["NEXT_PUBLIC_SLOWCOOK_BRANCH"] ?? "";
 
   // 0.5.1 — hydration-mismatch fix. The overlay can't render during
   // SSR (no localStorage, no window.matchMedia, no DOM), so it returns
@@ -171,6 +191,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // comments (applied/declined/noop) hide by default; needs-clarification +
   // unresolved always show.
   const [showApplied, setShowApplied] = useState<boolean>(false);
+  // 0.7.0 — docs studio (textual review): panel open + the resolved working
+  // branch a scope-change commits to.
+  const [docsPanelOpen, setDocsPanelOpen] = useState<boolean>(false);
+  const [resolvedBranch, setResolvedBranch] = useState<string>(branchProp);
   // 0.2.0 — track viewport width for the icon-only mobile collapse + the
   // picker-route hide. Updates on resize + initial mount.
   const [isMobile, setIsMobile] = useState<boolean>(false);
@@ -223,6 +247,22 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     body.style.touchAction = "none";
     return () => { body.style.overflow = prevOverflow; body.style.touchAction = prevTouch; };
   }, [composerOpen, generalComposerOpen, openCommentId]);
+
+  // 0.7.0 — resolve the working branch for doc scope-changes. Prefer the
+  // configured branch; else the head branch of the open mockup PR; else the
+  // repo default. Runs once in lcr mode when no branch was provided.
+  useEffect(() => {
+    if (typeof window === "undefined" || reviewMode !== "lcr" || branchProp || !owner || !repo) return;
+    let alive = true;
+    (async () => {
+      const base = getProxyApiBase() ?? "https://api.github.com";
+      try {
+        const r = await fetch(`${base}/repos/${owner}/${repo}`, { headers: { Accept: "application/vnd.github+json" } });
+        if (r.ok && alive) { const j = (await r.json()) as { default_branch?: string }; if (j.default_branch) setResolvedBranch(j.default_branch); }
+      } catch { /* offline / rate-limited — Docs read falls back to default ref */ }
+    })();
+    return () => { alive = false; };
+  }, [reviewMode, branchProp, owner, repo]);
 
   // Mount-time + on-focus fetch of overlay comments / LCR issues.
   useEffect(() => {
@@ -734,6 +774,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         commentCount={comments.length}
         newCount={newCount}
         onListClick={() => { setListPanelOpen(true); markAllSeen(); }}
+        docsEnabled={reviewMode === "lcr" && docPaths.length > 0}
+        onDocsClick={() => setDocsPanelOpen(true)}
         reviewMode={reviewMode}
         identity={reviewerIdentity}
         onSignIn={() => void signIn()}
@@ -773,6 +815,20 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           }}
           onApprove={() => { setListPanelOpen(false); onApproveClicked(); }}
           isApproved={isApproved}
+        />
+      )}
+      {/* 0.7.0 — docs studio: the textual half of review. */}
+      {docsPanelOpen && (
+        <DocsPanel
+          repo={repoCoord}
+          docPaths={docPaths}
+          branch={resolvedBranch}
+          identity={reviewerIdentity}
+          getToken={() => (typeof window !== "undefined" ? loadReviewerToken(window.localStorage, repoCoord) : null)}
+          onSignIn={() => void signIn()}
+          apiBase={getProxyApiBase() ?? undefined}
+          onClose={() => setDocsPanelOpen(false)}
+          onFeedback={(t) => setFeedback(t)}
         />
       )}
       {generalComposerOpen && (
@@ -929,6 +985,8 @@ function ModeToggle(props: {
   commentCount: number;
   newCount: number;
   onListClick: () => void;
+  docsEnabled: boolean;
+  onDocsClick: () => void;
   // 0.6.2 — LCR sign-in lives IN the floating disk (self-styled, theme-proof),
   // not a separate fixed badge.
   reviewMode: "scenarios" | "lcr";
@@ -936,7 +994,7 @@ function ModeToggle(props: {
   onSignIn: () => void;
   onSignOut: () => void;
 }): JSX.Element {
-  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, reviewMode, identity, onSignIn, onSignOut } = props;
+  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, reviewMode, identity, onSignIn, onSignOut } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -1124,6 +1182,24 @@ function ModeToggle(props: {
           }}>{commentCount}</span>
         )}
       </button>
+      )}
+      {/* 0.7.0 — Docs (textual review): read + edit the spec docs. Available in
+          both Nav and Comment modes — it's a parallel review surface. */}
+      {docsEnabled && (
+        <button
+          type="button"
+          onClick={() => { setConfirmLogout(false); onDocsClick(); }}
+          disabled={disabled}
+          title="Review & edit the spec docs (textual review)"
+          style={{
+            marginLeft: 4, background: "rgba(255,255,255,0.06)", color: "white",
+            border: "none", padding: "6px 10px", borderRadius: 999,
+            cursor: disabled ? "not-allowed" : "pointer", opacity: disabled ? 0.6 : 1,
+            font: "inherit", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 5,
+          }}
+        >
+          📄 Docs
+        </button>
       )}
       {/* 0.6.2 — LCR per-reviewer sign-in, inside the disk. All colours are
           explicit (white-on-dark) so the app's dark/light theme can't touch it.
@@ -2286,6 +2362,181 @@ function GeneralComposer(props: {
           {props.submitting ? "Posting…" : "Post note"}
         </button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * 0.7.0 — Docs studio: the textual half of review. Reads the spine markdown docs
+ * on the working branch, lets a reviewer edit them with an edit/preview toggle,
+ * and (write-access only) commits the edit to the branch as a "scope change"
+ * that `refine` reconciles. Non-write reviewers get read + preview.
+ */
+function DocsPanel(props: {
+  repo: RepoCoord;
+  docPaths: string[];
+  branch: string;
+  identity: StoredReviewerIdentity | null;
+  getToken: () => string | null;
+  onSignIn: () => void;
+  apiBase?: string;
+  onClose: () => void;
+  onFeedback: (t: string) => void;
+}): JSX.Element {
+  const { repo, docPaths, branch, identity, getToken, onSignIn, apiBase, onClose, onFeedback } = props;
+  const [path, setPath] = useState<string>(docPaths[0] ?? "");
+  const [file, setFile] = useState<DocFile | null>(null);
+  const [draft, setDraft] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<"edit" | "preview">("preview");
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const canApply = identity?.canApply === true;
+  const dirty = file != null && draft !== file.content;
+  const ref = branch || "HEAD";
+
+  const load = useCallback(async (p: string) => {
+    setLoading(true); setError(null); setFile(null);
+    const token = getToken();
+    const res = await fetchDocFile({ owner: repo.owner, repo: repo.repo, path: p, ref, pat: token ?? undefined, apiBase });
+    if (res.ok) { setFile(res.file); setDraft(res.file.content); setView("preview"); }
+    else if (!token && (res.status === 404 || res.status === 401)) {
+      setError(`Sign in with GitHub to read ${p.split("/").pop()} — this repo is private.`);
+    } else {
+      setError(`Couldn't load ${p}: ${res.message} (${res.status})`);
+    }
+    setLoading(false);
+  }, [repo.owner, repo.repo, ref, apiBase, getToken]);
+
+  useEffect(() => { if (path) void load(path); }, [path, load]);
+
+  async function submit() {
+    if (!file || !dirty) return;
+    const token = getToken();
+    if (!canApply || !token) return;
+    setSubmitting(true);
+    const res = await commitDocFile({
+      owner: repo.owner, repo: repo.repo, path, content: draft, sha: file.sha,
+      branch: ref, message: `docs(scope): ${path} edited via review (PM scope change)`,
+      pat: token, apiBase,
+    });
+    setSubmitting(false);
+    if (res.ok) {
+      onFeedback(`Scope change committed to ${ref} — refine will reconcile ${path.split("/").pop()}.`);
+      await load(path); // refresh sha + content
+    } else {
+      setError(`Commit failed: ${res.message} (${res.status})`);
+    }
+  }
+
+  const name = (p: string) => p.split("/").pop() ?? p;
+
+  return (
+    <div
+      data-slowcook-overlay-ui="1"
+      role="dialog"
+      aria-label="Docs studio"
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: "fixed", inset: 0, zIndex: 2147483602,
+        background: "rgba(15,15,24,0.97)", color: "white", pointerEvents: "auto",
+        fontFamily: "system-ui, -apple-system, sans-serif", fontSize: 13,
+        display: "flex", flexDirection: "column",
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 16px", borderBottom: "1px solid rgba(255,255,255,0.1)" }}>
+        <span style={{ fontWeight: 700, fontSize: 14 }}>📄 Docs · textual review</span>
+        <span style={{ fontSize: 11, opacity: 0.6 }}>branch <code style={{ background: "rgba(255,255,255,0.1)", padding: "1px 6px", borderRadius: 5 }}>{ref}</code></span>
+        <span style={{ marginLeft: "auto" }} />
+        <button type="button" onClick={onClose} aria-label="Close docs" style={{ background: "transparent", border: "none", color: "rgba(255,255,255,0.6)", cursor: "pointer", fontSize: 22, lineHeight: 1 }}>×</button>
+      </div>
+
+      {/* Doc tabs */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, padding: "10px 16px", borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+        {docPaths.map((p) => (
+          <button key={p} type="button" onClick={() => setPath(p)} title={p}
+            style={{
+              fontSize: 12, fontWeight: p === path ? 800 : 600, padding: "5px 11px", borderRadius: 999,
+              cursor: "pointer", border: "1px solid " + (p === path ? "rgba(255,107,107,0.7)" : "rgba(255,255,255,0.15)"),
+              background: p === path ? "rgba(255,107,107,0.18)" : "transparent", color: p === path ? "#ffb4b4" : "rgba(255,255,255,0.75)",
+            }}>{name(p)}{dirty && p === path ? " •" : ""}</button>
+        ))}
+      </div>
+
+      {/* Toolbar */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 16px", borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+        <div style={{ display: "inline-flex", background: "rgba(255,255,255,0.06)", borderRadius: 999, padding: 2 }}>
+          {(["preview", "edit"] as const).map((v) => (
+            <button key={v} type="button" onClick={() => setView(v)}
+              style={{ fontSize: 12, fontWeight: 700, padding: "4px 12px", borderRadius: 999, border: "none", cursor: "pointer",
+                background: view === v ? "white" : "transparent", color: view === v ? "#111" : "rgba(255,255,255,0.7)" }}>
+              {v === "preview" ? "Preview" : "Edit"}
+            </button>
+          ))}
+        </div>
+        <span style={{ marginLeft: "auto" }} />
+        {identity ? (
+          canApply ? (
+            <button type="button" disabled={!dirty || submitting} onClick={() => void submit()}
+              title={dirty ? "Commit this edit to the branch as a scope change" : "No changes yet"}
+              style={{ fontSize: 12.5, fontWeight: 800, padding: "7px 14px", borderRadius: 8, border: "none",
+                cursor: !dirty || submitting ? "not-allowed" : "pointer", opacity: !dirty || submitting ? 0.5 : 1,
+                background: "#22c55e", color: "white" }}>
+              {submitting ? "Submitting…" : "Submit scope change"}
+            </button>
+          ) : (
+            <span style={{ fontSize: 11.5, opacity: 0.7, maxWidth: 280 }}>Read-only — write access is required to submit a scope change; your notes can go via a review comment.</span>
+          )
+        ) : (
+          <button type="button" onClick={onSignIn}
+            style={{ fontSize: 12.5, fontWeight: 700, padding: "7px 14px", borderRadius: 8, border: "none", cursor: "pointer", background: "white", color: "#111" }}>
+            Sign in to edit
+          </button>
+        )}
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflow: "auto", padding: 0 }}>
+        {loading ? (
+          <div style={{ padding: 24, opacity: 0.6 }}>Loading {name(path)}…</div>
+        ) : error ? (
+          <div style={{ padding: 24, color: "#ffb4b4" }}>{error}</div>
+        ) : view === "edit" ? (
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            style={{
+              width: "100%", height: "100%", minHeight: 400, boxSizing: "border-box",
+              padding: "16px 20px", border: "none", outline: "none", resize: "none",
+              background: "#11111b", color: "#e8e8f0", fontSize: 16, lineHeight: 1.55,
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            }}
+          />
+        ) : (
+          <div
+            className="sc-doc-prose"
+            style={{ padding: "16px 24px", maxWidth: 860, margin: "0 auto", lineHeight: 1.6 }}
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(draft) }}
+          />
+        )}
+      </div>
+
+      {/* Prose styling (scoped) */}
+      <style dangerouslySetInnerHTML={{ __html:
+        `.sc-doc-prose h1,.sc-doc-prose h2,.sc-doc-prose h3{color:#fff;margin:1.1em 0 .4em;line-height:1.25}` +
+        `.sc-doc-prose h1{font-size:24px}.sc-doc-prose h2{font-size:19px;border-bottom:1px solid rgba(255,255,255,0.12);padding-bottom:4px}.sc-doc-prose h3{font-size:16px}` +
+        `.sc-doc-prose p,.sc-doc-prose li{color:rgba(255,255,255,0.85)}` +
+        `.sc-doc-prose code{background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:5px;font-size:0.9em}` +
+        `.sc-doc-prose pre{background:#11111b;padding:12px 14px;border-radius:8px;overflow:auto}.sc-doc-prose pre code{background:none;padding:0}` +
+        `.sc-doc-prose a{color:#7cc7ff}` +
+        `.sc-doc-prose blockquote{border-left:3px solid rgba(255,107,107,0.6);margin:.6em 0;padding:.2em 0 .2em 14px;color:rgba(255,255,255,0.7)}` +
+        `.sc-doc-prose hr{border:none;border-top:1px solid rgba(255,255,255,0.12);margin:1.2em 0}` +
+        `.sc-doc-prose table{border-collapse:collapse;width:100%;margin:.8em 0;font-size:12.5px}` +
+        `.sc-doc-prose th,.sc-doc-prose td{border:1px solid rgba(255,255,255,0.15);padding:6px 10px;text-align:left}` +
+        `.sc-doc-prose th{background:rgba(255,255,255,0.06)}`
+      }} />
     </div>
   );
 }

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -2,9 +2,10 @@
  * <SlowcookReviewOverlay /> — 0.16.0-α.6.
  *
  * Mounted into the consumer's mock-app root layout. Renders a floating
- * mode toggle (nav / comment / approve). In comment mode, clicks on
- * elements capture a selector + bbox + viewport metadata; the user
- * types prose and submits to the mockup PR via PAT.
+ * mode toggle (review / approve). 0.8.0 — in a review session the page
+ * navigates freely; the reviewer arms a single element-pick ("📍 Pin a
+ * comment") and the next click captures a selector + bbox + viewport
+ * metadata; the user types prose and submits to the mockup PR via PAT.
  *
  * Bundle weight is paid only when consumers mount it. The mock app
  * scaffolded by `slowcook init mock` includes a code-comment placeholder
@@ -229,6 +230,12 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // 0.6.5 — element under the cursor in comment mode (green hover preview).
   const [hoverEl, setHoverEl] = useState<Element | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
+  // 0.8.0 — free-nav: in comment mode the page navigates normally. The reviewer
+  // ARMS a single element-pick ("📍 Pin a comment"); only while armed does the
+  // overlay intercept the next click. After the pick (or cancel) it disarms, so
+  // navigation is never trapped — and there's an on-screen cancel for mobile
+  // (no Escape key). See the capture effect below.
+  const [armed, setArmed] = useState<boolean>(false);
   // 0.5.0 — comments-list panel state. Opened by the "📋" button in
   // the pill OR by clicking the count badge on the Comment toggle.
   // Surfaces ALL comments — including ones whose anchor element is
@@ -485,24 +492,31 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     };
   }, [reviewMode]);
 
-  // ESC exits comment/approve mode + closes composer.
+  // ESC steps back one layer at a time (graduated, 0.8.0): an open composer
+  // closes first, then an armed pick disarms, then comment/approve mode exits to
+  // nav. Mobile has no Escape — each of these layers also has an on-screen exit
+  // (composer Cancel, the armed banner, the toolbar toggle).
   useEffect(() => {
     if (typeof window === "undefined") return;
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        setMode("nav");
-        setComposerOpen(false);
-        setTarget(null);
-      }
+      if (e.key !== "Escape") return;
+      if (composerOpen) { setComposerOpen(false); setTarget(null); setArmed(false); return; }
+      if (armed) { setArmed(false); return; }
+      if (mode !== "nav") setMode("nav");
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [composerOpen, armed, mode]);
 
-  // Capture clicks at the document level when in comment/approve mode.
+  // Capture clicks at the document level ONLY while a pick is live:
+  //  - comment mode → only when the reviewer armed a pick (else clicks navigate);
+  //  - approve mode → the next click confirms approval (one-shot).
+  // 0.8.0 — this gate is the whole free-nav feature: when not capturing, page
+  // links/buttons work normally and the reviewer is never trapped.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (mode === "nav") { setHoverEl(null); return; }
+    const capturing = mode === "approve" || (mode === "comment" && armed);
+    if (!capturing) { setHoverEl(null); return; }
     const isOwnUi = (el: Element | null) =>
       !el ||
       (composerRef.current && composerRef.current.contains(el)) ||
@@ -516,6 +530,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         setTarget(el);
         setHoverEl(null);
         setComposerOpen(true);
+        setArmed(false); // one-shot — disarm so the page is navigable again
       } else if (mode === "approve") {
         void submitApproval();
       }
@@ -550,7 +565,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       document.removeEventListener("pointerdown", onDown, { capture: true });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode]);
+  }, [mode, armed]);
 
   // 0.6.6 — entering Nav clears the whole comment surface: any open composer,
   // the comments-list panel, a general-note composer, an open pin popover, the
@@ -559,6 +574,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     if (mode !== "nav") return;
     setComposerOpen(false);
     setTarget(null);
+    setArmed(false);
     setGeneralComposerOpen(false);
     setListPanelOpen(false);
     setOpenCommentId(null);
@@ -818,24 +834,62 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         `font-size:11px !important;padding:4px 7px !important;line-height:1.15 !important;` +
         `color:#1a1a1a !important;background-color:#fff !important;font-weight:700 !important;}`
       }} />
-      {mode !== "nav" && (
+      {/* 0.8.0 — tint the page only while a pick is live (armed comment, or
+          approve). Free-nav comment mode with no armed pick stays untinted —
+          you're just navigating. */}
+      {(armed || mode === "approve") && (
         <div
           style={{
             position: "absolute",
             inset: 0,
             backgroundColor:
-              mode === "comment"
-                ? "rgba(255, 107, 107, 0.05)"
-                : "rgba(74, 222, 128, 0.05)",
+              mode === "approve"
+                ? "rgba(74, 222, 128, 0.05)"
+                : "rgba(255, 107, 107, 0.05)",
             pointerEvents: "none",
           }}
           aria-hidden="true"
         />
       )}
       {/* 0.6.5 — green hover preview of the click target in comment mode. */}
-      {mode === "comment" && !composerOpen && hoverEl && <HoverHighlight el={hoverEl} />}
+      {mode === "comment" && armed && !composerOpen && hoverEl && <HoverHighlight el={hoverEl} />}
+      {/* 0.8.0 — armed banner: the on-screen, mobile-safe cancel for a live pick.
+          Tap it (or Esc) to disarm and go back to navigating. */}
+      {mode === "comment" && armed && !composerOpen && (
+        <button
+          type="button"
+          data-slowcook-overlay-ui="1"
+          onClick={() => setArmed(false)}
+          style={{
+            position: "fixed",
+            top: 12,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 2147483647,
+            pointerEvents: "auto",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            maxWidth: "92vw",
+            padding: "8px 14px",
+            border: "1px solid rgba(255,255,255,0.16)",
+            borderRadius: 999,
+            background: "rgba(15, 15, 24, 0.94)",
+            color: "white",
+            font: "600 13px system-ui, -apple-system, sans-serif",
+            cursor: "pointer",
+            boxShadow: "0 4px 14px rgba(0,0,0,0.35)",
+          }}
+        >
+          📍 Tap an element to comment on it
+          <span style={{ opacity: 0.7, fontWeight: 400 }}>· tap here / Esc to cancel</span>
+        </button>
+      )}
       <ModeToggle
         mode={mode}
+        armed={armed}
+        onArm={() => setArmed(true)}
+        onCancelArm={() => setArmed(false)}
         onChange={(m) => (m === "approve" ? onApproveClicked() : setMode(m))}
         disabled={submitting}
         isMobile={isMobile}
@@ -1056,6 +1110,9 @@ function saveTogglePosition(p: TogglePosition): void {
 
 function ModeToggle(props: {
   mode: Mode;
+  armed: boolean;
+  onArm: () => void;
+  onCancelArm: () => void;
   onChange: (m: Mode) => void;
   disabled: boolean;
   isMobile: boolean;
@@ -1074,7 +1131,7 @@ function ModeToggle(props: {
   onSignIn: () => void;
   onSignOut: () => void;
 }): JSX.Element {
-  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, surfaces, onNavigate, reviewMode, identity, onSignIn, onSignOut } = props;
+  const { mode, armed, onArm, onCancelArm, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, surfaces, onNavigate, reviewMode, identity, onSignIn, onSignOut } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -1200,25 +1257,55 @@ function ModeToggle(props: {
           <circle cx="4.5" cy="12" r="1.1" fill="currentColor" />
         </svg>
       </div>
-      {/* 0.6.9 — single Nav/Comment toggle (was two buttons): off = navigate,
-          on (accent) = comment mode. */}
+      {/* 0.8.0 — single Review/exit toggle. Off = overlay idle. On (accent) =
+          a review session: the page still navigates freely; you arm a pick with
+          the "📍 Pin a comment" button below. (Was "Commenting" — but comment
+          mode no longer traps clicks, so it now reads "Reviewing".) */}
       <ToggleButton
         active={mode === "comment"}
         onClick={() => onChangeSafe(mode === "comment" ? "nav" : "comment")}
         disabled={disabled}
         label={
           mode === "comment"
-            ? (isMobile ? "💬" : "💬 Commenting")
-            : (isMobile ? "🧭" : "🧭 Navigating")
+            ? (isMobile ? "🧭" : "🧭 Reviewing")
+            : (isMobile ? "💬" : "💬 Review")
         }
         title={
           mode === "comment"
-            ? "Comment mode on — click to go back to navigating"
-            : (newCount ? `Click to comment — ${newCount} new update(s)` : "Click to comment on an element")
+            ? "Reviewing — navigate freely; click to end the review"
+            : (newCount ? `Start reviewing — ${newCount} new update(s)` : "Start reviewing — navigate freely and pin comments")
         }
         accent
         badge={newCount}
       />
+      {/* 0.8.0 — arm a single element-pick. While armed the next page tap selects
+          an element to comment on (then auto-disarms); tap again to cancel. */}
+      {mode === "comment" && (
+        <button
+          type="button"
+          onClick={() => (armed ? onCancelArm() : onArm())}
+          disabled={disabled}
+          title={armed ? "Cancel — tap an element, or cancel the pick" : "Pin a comment on an element"}
+          style={{
+            marginLeft: 4,
+            background: armed ? ACCENT : "rgba(255,255,255,0.06)",
+            color: "white",
+            border: armed ? `1px solid ${ACCENT}` : "1px solid transparent",
+            padding: "6px 10px",
+            borderRadius: 999,
+            cursor: disabled ? "not-allowed" : "pointer",
+            opacity: disabled ? 0.6 : 1,
+            font: "inherit",
+            fontSize: 12,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {armed ? "✕ Cancel pick" : (isMobile ? "📍" : "📍 Pin a comment")}
+        </button>
+      )}
       {/* 0.6.8 — Approve moved into the Comments panel (under "+ Add note").
           The disk only shows the approved state now, never the action. */}
       {isApproved && (

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -767,7 +767,13 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         `color:#1a1a1a !important;background-color:#fff !important;` +
         `-webkit-text-fill-color:#1a1a1a !important;border-color:rgba(0,0,0,0.15) !important;caret-color:#1a1a1a !important;}` +
         `[data-slowcook-overlay-ui] textarea::placeholder,[data-slowcook-overlay-ui] input::placeholder{` +
-        `color:rgba(0,0,0,0.4) !important;-webkit-text-fill-color:rgba(0,0,0,0.4) !important;}`
+        `color:rgba(0,0,0,0.4) !important;-webkit-text-fill-color:rgba(0,0,0,0.4) !important;}` +
+        // 0.7.2 — the compact pane select. Higher specificity (attr + class +
+        // element) so the host's `select{font-size:16px !important}` (iOS-zoom
+        // guard) can't bloat it; keep it small + dark to match the pane.
+        `[data-slowcook-overlay-ui] select.sc-ovl-pane-select{` +
+        `font-size:11px !important;padding:4px 7px !important;line-height:1.15 !important;` +
+        `color:#1a1a1a !important;background-color:#fff !important;font-weight:700 !important;}`
       }} />
       {mode !== "nav" && (
         <div
@@ -1090,13 +1096,22 @@ function ModeToggle(props: {
         pointerEvents: "auto",
         display: "flex",
         alignItems: "center",
+        // 0.7.1 — wrap to multiple rows when crowded (Nav/Comment + 📋 + Docs +
+        // persona switcher + sign-in don't fit one row on portrait mobile).
+        flexWrap: "wrap",
+        justifyContent: "flex-end",
+        // 0.7.2 — cap to the viewport (not a fixed px) so it stays one row on
+        // desktop but wraps to two on portrait mobile when crowded (Comment mode
+        // adds 📋 + Sign-in on top of Docs + the persona switcher).
+        maxWidth: "94vw",
         gap: 4,
+        rowGap: 5,
         // 0.4.2 — green-tinted background + green border when approved.
         background: isApproved
           ? "rgba(20, 83, 45, 0.92)"      // dark-green pill
           : "rgba(15, 15, 24, 0.92)",     // default dark
-        padding: "4px 4px 4px 6px",
-        borderRadius: 999,
+        padding: "5px 6px",
+        borderRadius: 16,
         border: isApproved
           ? `1px solid rgba(34, 197, 94, 0.55)`   // brighter green border
           : "1px solid rgba(255, 255, 255, 0.16)",
@@ -2595,16 +2610,16 @@ function SurfaceSwitcher(props: { surfaces: ReviewSurface[]; onNavigate: (home: 
     .sort((a, b) => b.home.length - a.home.length)[0] ?? surfaces[0];
   return (
     <select
+      className="sc-ovl-pane-select"
       aria-label="Viewing as (review surface)"
       title="Viewing as — jump between persona surfaces (review only; not a real control)"
       value={current?.home ?? ""}
       disabled={disabled}
       onChange={(e) => onNavigate(e.target.value)}
       style={{
-        marginLeft: 4, maxWidth: 170, background: "rgba(255,255,255,0.08)", color: "white",
-        border: "1px solid rgba(255,255,255,0.18)", borderRadius: 999, padding: "6px 10px",
+        marginLeft: 2, maxWidth: 150,
+        border: "1px solid rgba(0,0,0,0.15)", borderRadius: 999,
         cursor: disabled ? "not-allowed" : "pointer", opacity: disabled ? 0.6 : 1,
-        font: "inherit", fontSize: 12, fontWeight: 700,
       }}
     >
       {surfaces.map((s) => (

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1975,6 +1975,18 @@ function CommentsListPanel(props: {
                 <div style={{ fontSize: 12, opacity: 0.85, lineHeight: 1.4, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
                   {r.payload.prose}
                 </div>
+                {/* 0.6.7 — show the latest reply inline so the answer is visible
+                    in the list, not only the pin popover. */}
+                {r.plateReply?.summary && (
+                  <div style={{
+                    marginTop: 6, paddingTop: 6, borderTop: "1px solid rgba(255,255,255,0.08)",
+                    fontSize: 11.5, lineHeight: 1.45, color: "rgba(255,255,255,0.82)",
+                    display: "-webkit-box", WebkitLineClamp: 4, WebkitBoxOrient: "vertical", overflow: "hidden",
+                  }}>
+                    <span style={{ color: palette.bg, fontWeight: 700 }}>↳ reply: </span>
+                    {r.plateReply.summary}
+                  </div>
+                )}
               </button>
             );
           })

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1287,6 +1287,28 @@ function ToggleButton(props: { active: boolean; onClick: () => void; disabled: b
   );
 }
 
+/**
+ * 0.6.13 — page-context badge in the composer so the reviewer sees which page
+ * the comment is on (route + the story it declares, if any) before submitting.
+ */
+function PageBadge(): JSX.Element | null {
+  if (typeof window === "undefined") return null;
+  const route = window.location.pathname + window.location.search;
+  const story = readCurrentStory();
+  return (
+    <div style={{
+      display: "inline-flex", alignItems: "center", gap: 6, maxWidth: "100%",
+      fontSize: 11.5, color: "#3a3a3a", background: "rgba(255,107,107,0.10)",
+      border: "1px solid rgba(255,107,107,0.30)", borderRadius: 6,
+      padding: "3px 9px", marginBottom: 8,
+    }}>
+      <span aria-hidden>📄</span>
+      <span style={{ fontFamily: "ui-monospace, monospace", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{route}</span>
+      {story && <span style={{ fontWeight: 700, color: "#d6336c" }}>· story-{story}</span>}
+    </div>
+  );
+}
+
 function Composer(props: {
   target: Element;
   onCancel: () => void;
@@ -1367,7 +1389,8 @@ function Composer(props: {
           zIndex: 2147483647,
         }}
       >
-        <div style={{ fontWeight: 600, marginBottom: 8 }}>Review comment</div>
+        <div style={{ fontWeight: 600, marginBottom: 6 }}>Review comment</div>
+        <PageBadge />
         <div style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace", fontSize: 11, opacity: 0.7, marginBottom: 8, wordBreak: "break-all" }}>
           {sel.selector}
         </div>
@@ -2080,7 +2103,8 @@ function GeneralComposer(props: {
         fontSize: 13,
       }}
     >
-      <div style={{ fontWeight: 600, marginBottom: 4, fontSize: 14 }}>Add page note</div>
+      <div style={{ fontWeight: 600, marginBottom: 6, fontSize: 14 }}>Add page note</div>
+      <PageBadge />
       <div style={{ fontSize: 12, opacity: 0.65, marginBottom: 10 }}>
         Comment about overall behavior — not anchored to a specific element.
       </div>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -784,9 +784,24 @@ function ModeToggle(props: {
   useEffect(() => { setPos(loadTogglePosition()); }, []);
   const dragRef = useRef<{ startX: number; startY: number; startTop: number; startRight: number } | null>(null);
 
+  // 0.6.3 — sign-out is a two-step confirm: the disk floats, so a single
+  // mis-click shouldn't log you out. First click/tap on the identity chip arms
+  // confirmation (the chip turns into "Sign out?"); a second click/tap within a
+  // few seconds confirms. ANY other action (mode toggle, list, drag) cancels.
+  const [confirmLogout, setConfirmLogout] = useState(false);
+  const cancelLogout = useCallback(() => setConfirmLogout(false), []);
+  useEffect(() => {
+    if (!confirmLogout) return;
+    const t = setTimeout(() => setConfirmLogout(false), 3500);
+    return () => clearTimeout(t);
+  }, [confirmLogout]);
+  const onChangeSafe = useCallback((m: Mode) => { setConfirmLogout(false); onChange(m); }, [onChange]);
+  const onListSafe = useCallback(() => { setConfirmLogout(false); onListClick(); }, [onListClick]);
+
   // Drag handlers — pointer events for unified mouse + touch.
   const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     // Only drag from the grip itself; clicks on toggle buttons must stay clicks.
+    setConfirmLogout(false); // dragging cancels a pending sign-out confirm
     e.preventDefault();
     e.stopPropagation();
     const target = e.currentTarget;
@@ -880,14 +895,14 @@ function ModeToggle(props: {
       </div>
       <ToggleButton
         active={mode === "nav"}
-        onClick={() => onChange("nav")}
+        onClick={() => onChangeSafe("nav")}
         disabled={disabled}
         label={isMobile ? "🧭" : "Nav"}
         title="Navigate (default)"
       />
       <ToggleButton
         active={mode === "comment"}
-        onClick={() => onChange("comment")}
+        onClick={() => onChangeSafe("comment")}
         disabled={disabled}
         label={isMobile ? "💬" : "💬 Comment"}
         title="Comment on an element"
@@ -914,7 +929,7 @@ function ModeToggle(props: {
       ) : (
         <ToggleButton
           active={mode === "approve"}
-          onClick={() => onChange("approve")}
+          onClick={() => onChangeSafe("approve")}
           disabled={disabled}
           label={isMobile ? "✅" : "✅ Approve"}
           title="Approve the mockup (asks for confirmation)"
@@ -925,7 +940,7 @@ function ModeToggle(props: {
           comments (incl. hidden-element + general). Count badge. */}
       <button
         type="button"
-        onClick={onListClick}
+        onClick={onListSafe}
         disabled={disabled}
         title={`See all comments (${commentCount})`}
         style={{
@@ -962,18 +977,26 @@ function ModeToggle(props: {
       {reviewMode === "lcr" && (
         identity ? (
           <span
-            title={`Signed in as @${identity.login} — click to sign out`}
-            onClick={onSignOut}
+            title={confirmLogout ? "Click again to sign out (or click anything else to cancel)" : `Signed in as @${identity.login}`}
+            onClick={() => { if (confirmLogout) { setConfirmLogout(false); onSignOut(); } else { setConfirmLogout(true); } }}
             style={{
               marginLeft: 4, display: "inline-flex", alignItems: "center", gap: 6,
               padding: "4px 10px 4px 4px", borderRadius: 999, cursor: "pointer",
-              background: "rgba(255,255,255,0.10)", color: "white", fontSize: 12, fontWeight: 600,
+              background: confirmLogout ? "rgba(255,107,107,0.25)" : "rgba(255,255,255,0.10)",
+              border: confirmLogout ? "1px solid rgba(255,107,107,0.7)" : "1px solid transparent",
+              color: "white", fontSize: 12, fontWeight: 600,
             }}
           >
-            {identity.avatarUrl
-              ? <img src={identity.avatarUrl} alt="" width={20} height={20} style={{ borderRadius: "50%" }} />
-              : <span aria-hidden style={{ width: 20, height: 20, borderRadius: "50%", background: "rgba(255,255,255,0.2)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 11 }}>👤</span>}
-            @{identity.login}
+            {confirmLogout ? (
+              <><span aria-hidden>🚪</span> Sign out?</>
+            ) : (
+              <>
+                {identity.avatarUrl
+                  ? <img src={identity.avatarUrl} alt="" width={20} height={20} style={{ borderRadius: "50%" }} />
+                  : <span aria-hidden style={{ width: 20, height: 20, borderRadius: "50%", background: "rgba(255,255,255,0.2)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 11 }}>👤</span>}
+                @{identity.login}
+              </>
+            )}
           </span>
         ) : (
           <button

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -208,6 +208,21 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // discussion (plate refuses to amend either way).
   const [isApproved, setIsApproved] = useState<boolean>(false);
 
+  // Lock page scroll while a composer or thread popover is open. Those boxes
+  // (and the element highlight) are positioned once at open time, so a scroll
+  // would leave them behind — easy to lose on mobile. Freezing the page keeps
+  // the box and its highlight together until the reviewer is done.
+  useEffect(() => {
+    const locked = composerOpen || generalComposerOpen || openCommentId !== null;
+    if (!locked || typeof document === "undefined") return;
+    const body = document.body;
+    const prevOverflow = body.style.overflow;
+    const prevTouch = body.style.touchAction;
+    body.style.overflow = "hidden";
+    body.style.touchAction = "none";
+    return () => { body.style.overflow = prevOverflow; body.style.touchAction = prevTouch; };
+  }, [composerOpen, generalComposerOpen, openCommentId]);
+
   // Mount-time + on-focus fetch of overlay comments / LCR issues.
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -674,6 +689,18 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         zIndex: 2147483000,
       }}
     >
+      {/* Style isolation — the overlay renders into the host's DOM, so the
+          host's global form rules (e.g. a `[data-theme="dark"] textarea {…}`
+          dark-mode override) bleed onto the overlay's own inputs and turn the
+          comment box dark. These scoped !important rules pin every overlay
+          form control to its intended light surface regardless of host theme. */}
+      <style dangerouslySetInnerHTML={{ __html:
+        `[data-slowcook-overlay-ui] textarea,[data-slowcook-overlay-ui] input,[data-slowcook-overlay-ui] select{` +
+        `color:#1a1a1a !important;background-color:#fff !important;` +
+        `-webkit-text-fill-color:#1a1a1a !important;border-color:rgba(0,0,0,0.15) !important;caret-color:#1a1a1a !important;}` +
+        `[data-slowcook-overlay-ui] textarea::placeholder,[data-slowcook-overlay-ui] input::placeholder{` +
+        `color:rgba(0,0,0,0.4) !important;-webkit-text-fill-color:rgba(0,0,0,0.4) !important;}`
+      }} />
       {mode !== "nav" && (
         <div
           style={{
@@ -1624,17 +1651,24 @@ function CommentPins(props: {
 
   return (
     <div data-slowcook-overlay-ui="1" style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
-      {placements.map(({ record, rect, drifted }) => (
-        <PinIcon
-          key={record.commentId}
-          record={record}
-          x={rect.x}
-          y={rect.y}
-          drifted={drifted}
-          flashing={flashCommentId === record.commentId}
-          onClick={() => onOpen(record.commentId)}
-        />
-      ))}
+      {/* Only render pins that track a live element. Drifted comments (selector
+          no longer resolves) used to render a frozen placeholder at the capture
+          bbox that didn't move on scroll — misleading. They now live only in the
+          sidebar list. A pin opened from the list (its id matches) still renders
+          so "Locate" has something to point at. */}
+      {placements
+        .filter(({ record, drifted }) => !drifted || record.commentId === openCommentId)
+        .map(({ record, rect, drifted }) => (
+          <PinIcon
+            key={record.commentId}
+            record={record}
+            x={rect.x}
+            y={rect.y}
+            drifted={drifted}
+            flashing={flashCommentId === record.commentId}
+            onClick={() => onOpen(record.commentId)}
+          />
+        ))}
       {openCommentId !== null && (() => {
         const placement = placements.find((p) => p.record.commentId === openCommentId);
         if (!placement) return null;
@@ -1999,7 +2033,16 @@ function CommentsListPanel(props: {
               : "Nothing needs attention — all comments are applied. Use the toggle above to see them."}
           </div>
         ) : (
-          visible.slice().reverse().map((r) => {
+          (() => {
+            // #198-overlay — separate page-level notes from element-anchored
+            // comments into labelled groups; element comments are the ones that
+            // get sticky pins, page notes live only here.
+            const rows = visible.slice().reverse();
+            const groups: Array<{ label: string; items: OverlayCommentRecord[] }> = [
+              { label: "📍 On an element", items: rows.filter((r) => r.payload.element !== null) },
+              { label: "📄 On the page", items: rows.filter((r) => r.payload.element === null) },
+            ];
+            const renderRow = (r: OverlayCommentRecord) => {
             const status = r.plateReply?.status ?? null;
             const palette = pinPalette(status as never, false);
             const anchored = r.payload.element !== null;
@@ -2059,7 +2102,18 @@ function CommentsListPanel(props: {
                 </div>
               </div>
             );
-          })
+            };
+            return groups
+              .filter((g) => g.items.length > 0)
+              .map((g) => (
+                <div key={g.label}>
+                  <div style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, color: "rgba(255,255,255,0.42)", padding: "10px 6px 4px" }}>
+                    {g.label} · {g.items.length}
+                  </div>
+                  {g.items.map(renderRow)}
+                </div>
+              ));
+          })()
         )}
       </div>
     </div>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -604,6 +604,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         isApproved={isApproved}
         commentCount={comments.length}
         onListClick={() => setListPanelOpen(true)}
+        reviewMode={reviewMode}
+        identity={reviewerIdentity}
+        onSignIn={() => void signIn()}
+        onSignOut={signOut}
       />
       {/* 0.3.0 — Figma-style pin layer for previously-left comments.
           Only visible in Comment mode (Nav stays clean). 0.5.0 —
@@ -670,14 +674,6 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           submitting={submitting}
         />
       )}
-      {/* 0.6.0 — LCR multi-person review: per-reviewer GitHub sign-in. */}
-      {reviewMode === "lcr" && (
-        <ReviewerSignInBadge
-          identity={reviewerIdentity}
-          onSignIn={() => void signIn()}
-          onSignOut={signOut}
-        />
-      )}
       {login.open && (
         <ReviewerLoginDialog
           userCode={login.userCode}
@@ -692,35 +688,6 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
 }
 
 /**
- * 0.6.0 — sign-in badge for LCR review (top-right). Shows "Sign in with
- * GitHub" until the reviewer authenticates, then their @login + sign-out.
- * Every comment then posts as that reviewer (real GitHub attribution).
- */
-function ReviewerSignInBadge({
-  identity, onSignIn, onSignOut,
-}: { identity: ReviewerIdentity | null; onSignIn: () => void; onSignOut: () => void }): JSX.Element {
-  return (
-    <div style={{ position: "fixed", top: 12, right: 12, pointerEvents: "auto", zIndex: 2147483600 }}>
-      {identity ? (
-        <div style={{ display: "flex", alignItems: "center", gap: 8, background: "#fff", border: "1px solid rgba(0,0,0,0.12)", borderRadius: 999, padding: "5px 10px 5px 6px", boxShadow: "0 2px 10px rgba(0,0,0,0.12)", fontSize: 13 }}>
-          {identity.avatarUrl
-            ? <img src={identity.avatarUrl} alt="" width={22} height={22} style={{ borderRadius: "50%" }} />
-            : <span aria-hidden style={{ width: 22, height: 22, borderRadius: "50%", background: "#eee", display: "inline-flex", alignItems: "center", justifyContent: "center" }}>👤</span>}
-          <span style={{ fontWeight: 600 }}>@{identity.login}</span>
-          <button onClick={onSignOut} title="Sign out" style={{ border: "none", background: "transparent", cursor: "pointer", color: "#888", fontSize: 12 }}>sign out</button>
-        </div>
-      ) : (
-        <button
-          onClick={onSignIn}
-          style={{ display: "flex", alignItems: "center", gap: 8, background: "#24292f", color: "#fff", border: "none", borderRadius: 999, padding: "8px 14px", cursor: "pointer", boxShadow: "0 2px 10px rgba(0,0,0,0.18)", fontSize: 13, fontWeight: 600 }}
-        >
-          <span aria-hidden>⧉</span> Sign in with GitHub
-        </button>
-      )}
-    </div>
-  );
-}
-
 /** 0.6.0 — device-flow login dialog: shows the user code + verification link. */
 function ReviewerLoginDialog({
   userCode, verificationUri, status, onClose,
@@ -802,8 +769,14 @@ function ModeToggle(props: {
   isApproved: boolean;
   commentCount: number;
   onListClick: () => void;
+  // 0.6.2 — LCR sign-in lives IN the floating disk (self-styled, theme-proof),
+  // not a separate fixed badge.
+  reviewMode: "scenarios" | "lcr";
+  identity: ReviewerIdentity | null;
+  onSignIn: () => void;
+  onSignOut: () => void;
 }): JSX.Element {
-  const { mode, onChange, disabled, isMobile, isApproved, commentCount, onListClick } = props;
+  const { mode, onChange, disabled, isMobile, isApproved, commentCount, onListClick, reviewMode, identity, onSignIn, onSignOut } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -984,6 +957,44 @@ function ModeToggle(props: {
           }}>{commentCount}</span>
         )}
       </button>
+      {/* 0.6.2 — LCR per-reviewer sign-in, inside the disk. All colours are
+          explicit (white-on-dark) so the app's dark/light theme can't touch it. */}
+      {reviewMode === "lcr" && (
+        identity ? (
+          <span
+            title={`Signed in as @${identity.login} — click to sign out`}
+            onClick={onSignOut}
+            style={{
+              marginLeft: 4, display: "inline-flex", alignItems: "center", gap: 6,
+              padding: "4px 10px 4px 4px", borderRadius: 999, cursor: "pointer",
+              background: "rgba(255,255,255,0.10)", color: "white", fontSize: 12, fontWeight: 600,
+            }}
+          >
+            {identity.avatarUrl
+              ? <img src={identity.avatarUrl} alt="" width={20} height={20} style={{ borderRadius: "50%" }} />
+              : <span aria-hidden style={{ width: 20, height: 20, borderRadius: "50%", background: "rgba(255,255,255,0.2)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 11 }}>👤</span>}
+            @{identity.login}
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={onSignIn}
+            disabled={disabled}
+            title="Sign in with GitHub to comment as yourself"
+            style={{
+              marginLeft: 4, display: "inline-flex", alignItems: "center", gap: 6,
+              padding: "6px 12px", borderRadius: 999, border: "none",
+              background: "white", color: "#24292f", cursor: disabled ? "not-allowed" : "pointer",
+              font: "inherit", fontSize: 12, fontWeight: 700,
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="#24292f" aria-hidden="true">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+            </svg>
+            Sign in
+          </button>
+        )
+      )}
     </div>
   );
 }

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -405,11 +405,26 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       const el = e.target as Element | null;
       setHoverEl(el && !isOwnUi(el) ? el : null);
     }
+    // 0.6.15 — native controls (a <select>, <input>, link, button) activate on
+    // mousedown/pointerdown, BEFORE click — so without this they'd open their
+    // dropdown / focus / navigate instead of letting the click attach a comment.
+    // Swallow the down-press on the page (not the overlay's own UI) in
+    // comment/approve mode; the click still fires and opens the composer.
+    function onDown(e: Event) {
+      const el = e.target as Element | null;
+      if (!el || isOwnUi(el)) return;
+      e.preventDefault();
+      e.stopPropagation();
+    }
     document.addEventListener("click", onClick, { capture: true });
     document.addEventListener("mouseover", onMove, { capture: true });
+    document.addEventListener("mousedown", onDown, { capture: true });
+    document.addEventListener("pointerdown", onDown, { capture: true });
     return () => {
       document.removeEventListener("click", onClick, { capture: true });
       document.removeEventListener("mouseover", onMove, { capture: true });
+      document.removeEventListener("mousedown", onDown, { capture: true });
+      document.removeEventListener("pointerdown", onDown, { capture: true });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -44,6 +44,17 @@ import {
   type RepoCoord,
   type OverlayCommentRecord,
 } from "../github.js";
+import {
+  loadReviewerToken,
+  loadReviewerIdentity,
+  saveReviewerToken,
+  saveReviewerIdentity,
+  clearReviewerSession,
+  runDeviceLogin,
+  identifyReviewer,
+} from "../reviewer-session.js";
+import { isResolvedStatus } from "../comment-format.js";
+import type { ReviewerIdentity } from "@slowcook-ai/core";
 
 export interface SlowcookReviewOverlayProps {
   /**
@@ -79,6 +90,12 @@ export interface SlowcookReviewOverlayProps {
    *    comment captures its route so plate can amend per-page.
    */
   reviewMode?: "scenarios" | "lcr";
+  /**
+   * 0.6.0 — base URL of the box-hosted reviewer auth-helper (run-mock's
+   * device-flow endpoints). Falls back to `NEXT_PUBLIC_SLOWCOOK_AUTH_BASE`.
+   * Only used in `lcr` mode; enables per-reviewer "Sign in with GitHub".
+   */
+  authBase?: string;
   /** Overlay package version, included in the JSON payload. */
   overlayVersion?: string;
 }
@@ -102,6 +119,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const reviewMode: "scenarios" | "lcr" =
     props.reviewMode ??
     (process.env["NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE"] === "lcr" ? "lcr" : "scenarios");
+  // 0.6.0 — LCR multi-person review: box-hosted device-flow helper base URL.
+  const authBase = props.authBase ?? process.env["NEXT_PUBLIC_SLOWCOOK_AUTH_BASE"] ?? "";
   const overlayVersion = props.overlayVersion ?? "0.6.0";
   const repoCoord: RepoCoord = { owner, repo };
 
@@ -135,6 +154,15 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [approveConfirmOpen, setApproveConfirmOpen] = useState(false);
+  // 0.6.0 — LCR multi-person review: who's signed in (this browser) + the
+  // device-flow login dialog state. Comments post as this reviewer.
+  const [reviewerIdentity, setReviewerIdentity] = useState<ReviewerIdentity | null>(null);
+  const [login, setLogin] = useState<{ open: boolean; userCode?: string; verificationUri?: string; status: string }>({ open: false, status: "" });
+  const loginAbort = useRef(false);
+  // 0.6.0 — "show already-applied" toggle for the comments list. Resolved
+  // comments (applied/declined/noop) hide by default; needs-clarification +
+  // unresolved always show.
+  const [showApplied, setShowApplied] = useState<boolean>(false);
   // 0.2.0 — track viewport width for the icon-only mobile collapse + the
   // picker-route hide. Updates on resize + initial mount.
   const [isMobile, setIsMobile] = useState<boolean>(false);
@@ -188,6 +216,49 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     mql.addEventListener("change", apply);
     return () => mql.removeEventListener("change", apply);
   }, []);
+
+  // 0.6.0 — restore a prior reviewer session (lcr mode).
+  useEffect(() => {
+    if (typeof window === "undefined" || reviewMode !== "lcr") return;
+    setReviewerIdentity(loadReviewerIdentity(window.localStorage, { owner, repo }));
+  }, [reviewMode, owner, repo]);
+
+  const signIn = useCallback(async () => {
+    if (!authBase) {
+      setLogin({ open: true, status: "Sign-in helper not configured (no AUTH_BASE). Run via `slowcook run-mock`." });
+      return;
+    }
+    loginAbort.current = false;
+    setLogin({ open: true, status: "Requesting a code…" });
+    const token = await runDeviceLogin({
+      authBase,
+      shouldStop: () => loginAbort.current,
+      onEvent: (e) => {
+        if (e.type === "code") {
+          setLogin({ open: true, userCode: e.grant.userCode, verificationUri: e.grant.verificationUri, status: "Waiting for you to authorize on GitHub…" });
+        } else if (e.type === "denied") setLogin({ open: true, status: "Authorization was denied." });
+        else if (e.type === "expired") setLogin({ open: true, status: "The code expired — try again." });
+        else if (e.type === "error") setLogin({ open: true, status: `Sign-in error: ${e.message}` });
+      },
+    });
+    if (!token) return;
+    try {
+      const id = await identifyReviewer(token);
+      saveReviewerToken(window.localStorage, { owner, repo }, token);
+      saveReviewerIdentity(window.localStorage, { owner, repo }, id);
+      setReviewerIdentity(id);
+      setLogin({ open: false, status: "" });
+      setFeedback(`Signed in as @${id.login}.`);
+    } catch (e) {
+      setLogin({ open: true, status: `Could not read your GitHub identity: ${e instanceof Error ? e.message : String(e)}` });
+    }
+  }, [authBase, owner, repo]);
+
+  const signOut = useCallback(() => {
+    if (typeof window !== "undefined") clearReviewerSession(window.localStorage, { owner, repo });
+    setReviewerIdentity(null);
+    setFeedback("Signed out.");
+  }, [owner, repo]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -259,9 +330,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     setSubmitting(true);
     setFeedback(null);
     try {
-      const pat = ensurePat(repoCoord);
+      const pat = ensurePat(repoCoord, reviewMode === "lcr");
       if (!pat) {
-        setFeedback("Approval cancelled — no PAT.");
+        if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to approve as yourself."); }
+        else setFeedback("Approval cancelled — no PAT.");
         return;
       }
       // 0.5.2 — three things land on approve, in order:
@@ -330,9 +402,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       setSubmitting(true);
       setFeedback(null);
       try {
-        const pat = ensurePat(repoCoord);
+        const pat = ensurePat(repoCoord, reviewMode === "lcr");
         if (!pat) {
-          setFeedback("Cancelled — no PAT.");
+          if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to comment as yourself."); }
+          else setFeedback("Cancelled — no PAT.");
           return;
         }
         const sel = extractSelector(target);
@@ -408,9 +481,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       setSubmitting(true);
       setFeedback(null);
       try {
-        const pat = ensurePat(repoCoord);
+        const pat = ensurePat(repoCoord, reviewMode === "lcr");
         if (!pat) {
-          setFeedback("Cancelled — no PAT.");
+          if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to comment as yourself."); }
+          else setFeedback("Cancelled — no PAT.");
           return;
         }
         const viewport: ViewportInfo = {
@@ -528,6 +602,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       {listPanelOpen && (
         <CommentsListPanel
           records={comments}
+          showApplied={showApplied}
+          onToggleApplied={() => setShowApplied((v) => !v)}
           onClose={() => setListPanelOpen(false)}
           onOpenComment={(id) => {
             setListPanelOpen(false);
@@ -574,7 +650,86 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           submitting={submitting}
         />
       )}
+      {/* 0.6.0 — LCR multi-person review: per-reviewer GitHub sign-in. */}
+      {reviewMode === "lcr" && (
+        <ReviewerSignInBadge
+          identity={reviewerIdentity}
+          onSignIn={() => void signIn()}
+          onSignOut={signOut}
+        />
+      )}
+      {login.open && (
+        <ReviewerLoginDialog
+          userCode={login.userCode}
+          verificationUri={login.verificationUri}
+          status={login.status}
+          onClose={() => { loginAbort.current = true; setLogin({ open: false, status: "" }); }}
+        />
+      )}
       {feedback && <FeedbackToast text={feedback} onDismiss={() => setFeedback(null)} />}
+    </div>
+  );
+}
+
+/**
+ * 0.6.0 — sign-in badge for LCR review (top-right). Shows "Sign in with
+ * GitHub" until the reviewer authenticates, then their @login + sign-out.
+ * Every comment then posts as that reviewer (real GitHub attribution).
+ */
+function ReviewerSignInBadge({
+  identity, onSignIn, onSignOut,
+}: { identity: ReviewerIdentity | null; onSignIn: () => void; onSignOut: () => void }): JSX.Element {
+  return (
+    <div style={{ position: "fixed", top: 12, right: 12, pointerEvents: "auto", zIndex: 2147483600 }}>
+      {identity ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, background: "#fff", border: "1px solid rgba(0,0,0,0.12)", borderRadius: 999, padding: "5px 10px 5px 6px", boxShadow: "0 2px 10px rgba(0,0,0,0.12)", fontSize: 13 }}>
+          {identity.avatarUrl
+            ? <img src={identity.avatarUrl} alt="" width={22} height={22} style={{ borderRadius: "50%" }} />
+            : <span aria-hidden style={{ width: 22, height: 22, borderRadius: "50%", background: "#eee", display: "inline-flex", alignItems: "center", justifyContent: "center" }}>👤</span>}
+          <span style={{ fontWeight: 600 }}>@{identity.login}</span>
+          <button onClick={onSignOut} title="Sign out" style={{ border: "none", background: "transparent", cursor: "pointer", color: "#888", fontSize: 12 }}>sign out</button>
+        </div>
+      ) : (
+        <button
+          onClick={onSignIn}
+          style={{ display: "flex", alignItems: "center", gap: 8, background: "#24292f", color: "#fff", border: "none", borderRadius: 999, padding: "8px 14px", cursor: "pointer", boxShadow: "0 2px 10px rgba(0,0,0,0.18)", fontSize: 13, fontWeight: 600 }}
+        >
+          <span aria-hidden>⧉</span> Sign in with GitHub
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** 0.6.0 — device-flow login dialog: shows the user code + verification link. */
+function ReviewerLoginDialog({
+  userCode, verificationUri, status, onClose,
+}: { userCode?: string; verificationUri?: string; status: string; onClose: () => void }): JSX.Element {
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: 2147483601 }}>
+      <div style={{ background: "#fff", borderRadius: 14, padding: 24, width: 360, maxWidth: "90vw", boxShadow: "0 12px 40px rgba(0,0,0,0.3)", fontFamily: "system-ui, sans-serif" }}>
+        <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 6, color: "#111" }}>Sign in with GitHub</div>
+        {userCode ? (
+          <>
+            <p style={{ fontSize: 13.5, color: "#555", margin: "0 0 14px" }}>
+              Open GitHub and enter this code to review as yourself:
+            </p>
+            <div style={{ fontSize: 30, fontWeight: 800, letterSpacing: "0.18em", textAlign: "center", background: "#f3f4f6", borderRadius: 10, padding: "12px 0", color: "#111", fontFamily: "ui-monospace, monospace" }}>
+              {userCode}
+            </div>
+            <a href={verificationUri} target="_blank" rel="noreferrer"
+               style={{ display: "block", textAlign: "center", marginTop: 14, background: "#2da44e", color: "#fff", borderRadius: 999, padding: "9px 0", textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
+              Open {verificationUri?.replace(/^https?:\/\//, "")}
+            </a>
+          </>
+        ) : (
+          <p style={{ fontSize: 14, color: "#555", margin: "8px 0 14px" }}>{status || "Starting…"}</p>
+        )}
+        {userCode && <p style={{ fontSize: 12, color: "#888", marginTop: 12 }}>{status}</p>}
+        <button onClick={onClose} style={{ marginTop: 16, width: "100%", border: "1px solid rgba(0,0,0,0.12)", background: "#fff", borderRadius: 999, padding: "8px 0", cursor: "pointer", fontSize: 13, color: "#444" }}>
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }
@@ -1148,7 +1303,14 @@ function getProxyApiBase(): string | null {
 
 const PROXY_PAT_SENTINEL = "__slowcook_proxy__";
 
-function ensurePat(repo: RepoCoord): string | null {
+function ensurePat(repo: RepoCoord, lcr = false): string | null {
+  // 0.6.0 — LCR multi-person review: post as the signed-in reviewer using
+  // their own device-flow token. No prompt — the "Sign in with GitHub" UI
+  // drives acquisition; null here means "not signed in yet".
+  if (lcr) {
+    if (typeof window === "undefined") return null;
+    return loadReviewerToken(window.localStorage, repo);
+  }
   // Proxy mode: skip prompt + storage; the proxy ignores the
   // Authorization header and signs upstream with `gh auth token`.
   if (getProxyApiBase()) return PROXY_PAT_SENTINEL;
@@ -1514,11 +1676,19 @@ function formatTimeAgo(iso: string): string {
  */
 function CommentsListPanel(props: {
   records: OverlayCommentRecord[];
+  showApplied: boolean;
+  onToggleApplied: () => void;
   onClose: () => void;
   onOpenComment: (id: number) => void;
   onAddGeneral: () => void;
 }): JSX.Element {
-  const { records, onClose, onOpenComment, onAddGeneral } = props;
+  const { records, showApplied, onToggleApplied, onClose, onOpenComment, onAddGeneral } = props;
+  // 0.6.0 — resolved comments (applied/declined/noop) hide by default so the
+  // list shows what still needs attention; needs-clarification + unresolved
+  // always show. The toggle reveals the resolved ones.
+  const isResolved = (r: OverlayCommentRecord) => r.plateReply != null && isResolvedStatus(r.plateReply.status);
+  const hiddenCount = records.filter(isResolved).length;
+  const visible = showApplied ? records : records.filter((r) => !isResolved(r));
   return (
     <div
       data-slowcook-overlay-ui="1"
@@ -1544,7 +1714,7 @@ function CommentsListPanel(props: {
       }}
     >
       <div style={{ padding: "14px 16px", borderBottom: "1px solid rgba(255,255,255,0.08)", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
-        <div style={{ fontWeight: 600 }}>Comments ({records.length})</div>
+        <div style={{ fontWeight: 600 }}>Comments ({visible.length})</div>
         <button
           type="button"
           onClick={onClose}
@@ -1583,13 +1753,24 @@ function CommentsListPanel(props: {
           + Add note (about the page, not an element)
         </button>
       </div>
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={onToggleApplied}
+          style={{ margin: "0 12px 8px", padding: "7px 10px", background: "transparent", color: "rgba(255,255,255,0.6)", border: "1px solid rgba(255,255,255,0.12)", borderRadius: 8, cursor: "pointer", font: "inherit", fontSize: 12 }}
+        >
+          {showApplied ? `Hide ${hiddenCount} already-applied` : `Show ${hiddenCount} already-applied`}
+        </button>
+      )}
       <div style={{ overflow: "auto", flex: 1, padding: 8 }}>
-        {records.length === 0 ? (
+        {visible.length === 0 ? (
           <div style={{ padding: 16, opacity: 0.55, textAlign: "center", fontSize: 12 }}>
-            No comments yet. Toggle 💬 Comment + click an element to anchor a comment, or use the button above for a page-level note.
+            {records.length === 0
+              ? "No comments yet. Toggle 💬 Comment + click an element to anchor a comment, or use the button above for a page-level note."
+              : "Nothing needs attention — all comments are applied. Use the toggle above to see them."}
           </div>
         ) : (
-          records.slice().reverse().map((r) => {
+          visible.slice().reverse().map((r) => {
             const status = r.plateReply?.status ?? null;
             const palette = pinPalette(status as never, false);
             const anchored = r.payload.element !== null;

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1036,8 +1036,9 @@ function ModeToggle(props: {
           ✓ Approved
         </span>
       )}
-      {/* 0.5.0 — list-panel toggle. Always reachable; shows ALL
-          comments (incl. hidden-element + general). Count badge. */}
+      {/* 0.6.11 — comments-list toggle + sign-in only show in Comment mode;
+          Nav mode stays minimal (just the toggle). */}
+      {mode === "comment" && (
       <button
         type="button"
         onClick={onListSafe}
@@ -1072,9 +1073,11 @@ function ModeToggle(props: {
           }}>{commentCount}</span>
         )}
       </button>
+      )}
       {/* 0.6.2 — LCR per-reviewer sign-in, inside the disk. All colours are
-          explicit (white-on-dark) so the app's dark/light theme can't touch it. */}
-      {reviewMode === "lcr" && (
+          explicit (white-on-dark) so the app's dark/light theme can't touch it.
+          0.6.11 — only in Comment mode. */}
+      {reviewMode === "lcr" && mode === "comment" && (
         identity ? (
           <span
             title={confirmLogout ? "Click again to sign out (or click anything else to cancel)" : `Signed in as @${identity.login}`}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1590,6 +1590,7 @@ function pinPalette(status: OverlayCommentRecord["plateReply"] extends infer R ?
     case "declined":      return { bg: "#94a3b8", fg: "white",   glyph: "⊘", ring: "rgba(148, 163, 184, 0.35)" };
     case "spec-altering": return { bg: "#facc15", fg: "#1a1a1a", glyph: "!", ring: "rgba(250, 204, 21, 0.35)" };
     case "noop":          return { bg: "#94a3b8", fg: "white",   glyph: "•", ring: "rgba(148, 163, 184, 0.35)" };
+    case "needs-clarification": return { bg: "#4D96FF", fg: "white", glyph: "?", ring: "rgba(77, 150, 255, 0.35)" };
     default:              return { bg: ACCENT,    fg: "white",   glyph: "💬", ring: "rgba(255, 107, 107, 0.35)" };
   }
 }
@@ -1777,7 +1778,7 @@ function CommentThreadPopover(props: {
         </a>
         {record.plateCommentUrl && (
           <a href={record.plateCommentUrl} target="_blank" rel="noreferrer" style={{ color: "#22c55e", textDecoration: "none" }}>
-            ↗ Plate reply on GitHub
+            ↗ Reply on GitHub
           </a>
         )}
       </div>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -24,6 +24,7 @@
 "use client";
 
 import { useEffect, useState, useRef, useCallback, type JSX } from "react";
+import { createPortal } from "react-dom";
 import { extractSelector, resolveStoredSelector } from "../selector.js";
 import {
   buildPayload,
@@ -141,6 +142,20 @@ type Mode = "nav" | "comment" | "approve";
 const ACCENT = "#FF6B6B";
 const APPROVED_GREEN = "#22c55e";
 
+// 0.7.3 — the in-shadow-root CSS firewall. `all: initial` on :host severs
+// every inherited property the host page would otherwise leak in (font,
+// color, letter-spacing, text-transform…), then we re-establish a neutral
+// base. `direction`/`unicode-bidi` are the two properties `all` deliberately
+// skips, so they're set explicitly — this is what un-mirrors the toolbar on
+// RTL hosts. Selector-based host rules (the `*{}` reset, `button{}` styles)
+// can't cross the shadow boundary at all, so box-sizing/margin/padding are
+// already safe without listing them here.
+const SHADOW_RESET_CSS =
+  `:host{all:initial;direction:ltr;unicode-bidi:isolate;` +
+  `font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;` +
+  `font-size:14px;line-height:1.4;color:#1a1a1a;}` +
+  `:host *,:host *::before,:host *::after{box-sizing:border-box;}`;
+
 export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.Element | null {
   // 0.5.1 — auto-detect props from process.env.NEXT_PUBLIC_SLOWCOOK_*.
   // Next inlines NEXT_PUBLIC_* at consumer build time, so this works
@@ -181,6 +196,31 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // "1 issue" warning consumers were seeing.
   const [mounted, setMounted] = useState<boolean>(false);
   useEffect(() => { setMounted(true); }, []);
+
+  // 0.7.3 — Shadow-DOM style firewall. The overlay used to render straight
+  // into the host's DOM, so the host's *global* CSS bled in: a universal
+  // reset (`*{box-sizing;margin:0;padding:0}`) collapsed the disk's geometry,
+  // and an RTL host (`body{direction:rtl}`, e.g. a Persian app) mirrored the
+  // toolbar + inverted the grip's right-anchored drag math — the disk "lost
+  // its shape" and couldn't be grabbed. We now mount the whole UI inside a
+  // shadow root on a body-level host element, so selector-based host CSS
+  // (resets, button styles) physically can't reach in. Inherited properties
+  // (direction/font/color) still cross the boundary, so the in-root reset
+  // (SHADOW_RESET_CSS) re-establishes them — note `all: initial` does NOT
+  // cover `direction`/`unicode-bidi`, hence the explicit `direction: ltr`.
+  // The host element carries no transform/filter, so position:fixed children
+  // still resolve to the viewport. Comment-mode still queries the host
+  // document directly — the shadow only encapsulates the overlay's own UI.
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const host = document.createElement("div");
+    host.setAttribute("data-slowcook-overlay-host", "");
+    document.body.appendChild(host);
+    const root = host.attachShadow({ mode: "open" });
+    setShadowRoot(root);
+    return () => { host.remove(); };
+  }, []);
 
   // Hooks must run unconditionally — render the null AFTER all hooks
   // are declared. Bails early during SSR via the typeof window check.
@@ -746,8 +786,11 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // only scenarios mode requires a prNumber.
   if (!owner || !repo) return null;
   if (reviewMode !== "lcr" && !prNumber) return null;
+  if (!shadowRoot) return null; // 0.7.3 — wait for the shadow host to mount
 
-  return (
+  return createPortal(
+    <>
+      <style dangerouslySetInnerHTML={{ __html: SHADOW_RESET_CSS }} />
     <div
       data-slowcook-overlay-ui="1"
       style={{
@@ -907,10 +950,11 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       )}
       {feedback && <FeedbackToast text={feedback} onDismiss={() => setFeedback(null)} />}
     </div>
+    </>,
+    shadowRoot
   );
 }
 
-/**
 /**
  * 0.6.5 — green hover preview in comment mode. Outlines the element the cursor
  * is over (the one a click would attach the comment to) so the reviewer can see

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -38,6 +38,7 @@ import {
   submitComment,
   createIssue,
   fetchOverlayComments,
+  fetchLcrIssues,
   loadCachedComments,
   saveCachedComments,
   fetchPrLabels,
@@ -183,13 +184,37 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // discussion (plate refuses to amend either way).
   const [isApproved, setIsApproved] = useState<boolean>(false);
 
-  // Mount-time + on-focus fetch of overlay comments.
+  // Mount-time + on-focus fetch of overlay comments / LCR issues.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (!enabled) return;
-    // 0.6.1 — the pin layer reads PR comments; lcr mode (no PR) skips it and
-    // relies on the GitHub issues it files instead.
-    if (!owner || !repo || !prNumber) return;
+    if (!enabled || !owner || !repo) return;
+
+    // 0.6.4 — lcr mode: comments are `lcr-review` ISSUES, retrieved with the
+    // signed-in reviewer's token. Closed issues = applied (hidden behind the
+    // "show already-applied" toggle); open = shown. Without a token (not signed
+    // in yet) there's nothing to read on a private repo — refetches after login
+    // via the reviewerIdentity dep.
+    if (reviewMode === "lcr") {
+      const cached = loadCachedComments(window.localStorage, { owner, repo }, 0);
+      if (cached) setComments(cached);
+      const refresh = () => {
+        const token = loadReviewerToken(window.localStorage, { owner, repo });
+        if (!token) return;
+        void fetchLcrIssues({ owner, repo, token })
+          .then((records) => {
+            setComments(records);
+            saveCachedComments(window.localStorage, { owner, repo }, 0, records);
+          })
+          .catch(() => { /* silent — cached state still renders */ });
+      };
+      refresh();
+      const onFocus = () => refresh();
+      window.addEventListener("focus", onFocus);
+      return () => window.removeEventListener("focus", onFocus);
+    }
+
+    // scenarios mode — the pin layer reads PR comments (needs a PR).
+    if (!prNumber) return;
     const cached = loadCachedComments(window.localStorage, { owner, repo }, prNumber);
     if (cached) setComments(cached);
     const refresh = () => {
@@ -212,7 +237,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     const onFocus = () => refresh();
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
-  }, [enabled, owner, repo, prNumber]);
+  }, [enabled, owner, repo, prNumber, reviewMode, reviewerIdentity]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -190,7 +190,12 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   });
   const sigOf = (r: OverlayCommentRecord) =>
     `${r.commentId}:${r.plateReply?.status ?? ""}:${(r.plateReply?.summary ?? "").length}`;
-  const newCount = comments.filter((r) => !seenSigs.has(sigOf(r))).length;
+  // 0.6.10 — only an AGENT action is an "event": a reply comment (plateCommentUrl)
+  // or a resolution (applied). A reviewer's own freshly-filed comment (open issue,
+  // no reply) is NOT an event — it shouldn't ping their own badge.
+  const isAgentEvent = (r: OverlayCommentRecord) =>
+    r.plateReply != null && (r.plateReply.status === "applied" || !!r.plateCommentUrl);
+  const newCount = comments.filter((r) => isAgentEvent(r) && !seenSigs.has(sigOf(r))).length;
   const markAllSeen = useCallback(() => {
     const sigs = comments.map(sigOf);
     setSeenSigs(new Set(sigs));

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -119,6 +119,21 @@ export interface SlowcookReviewOverlayProps {
    * lives). Falls back to `NEXT_PUBLIC_SLOWCOOK_BRANCH`, then the repo default.
    */
   branch?: string;
+  /**
+   * 0.7.1 — review surfaces: named entry points (personas/sections) the mock
+   * exposes, so the floating pane can offer a "Viewing as" switcher to roam
+   * them. This is a REVIEW affordance — a real user is one role; only a reviewer
+   * hops between surfaces — so it lives here, not in the product mock. Falls back
+   * to `NEXT_PUBLIC_SLOWCOOK_SURFACES` (JSON). Empty hides the switcher.
+   */
+  surfaces?: ReviewSurface[];
+}
+
+export interface ReviewSurface {
+  label: string;
+  home: string; // route to navigate to
+  icon?: string;
+  blurb?: string;
 }
 
 type Mode = "nav" | "comment" | "approve";
@@ -149,6 +164,11 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     (process.env["NEXT_PUBLIC_SLOWCOOK_DOC_PATHS"]?.split(",").map((s) => s.trim()).filter(Boolean)) ??
     ["docs/PRD.md", "docs/ROADMAP.md", "docs/USER_STORIES.md", "docs/ARCHITECTURE.md"];
   const branchProp = props.branch ?? process.env["NEXT_PUBLIC_SLOWCOOK_BRANCH"] ?? "";
+  // 0.7.1 — review surfaces (persona switcher lives in the pane, not the mock).
+  const surfaces: ReviewSurface[] = props.surfaces ?? (() => {
+    try { const raw = process.env["NEXT_PUBLIC_SLOWCOOK_SURFACES"]; return raw ? (JSON.parse(raw) as ReviewSurface[]) : []; }
+    catch { return []; }
+  })();
 
   // 0.5.1 — hydration-mismatch fix. The overlay can't render during
   // SSR (no localStorage, no window.matchMedia, no DOM), so it returns
@@ -776,6 +796,14 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         onListClick={() => { setListPanelOpen(true); markAllSeen(); }}
         docsEnabled={reviewMode === "lcr" && docPaths.length > 0}
         onDocsClick={() => setDocsPanelOpen(true)}
+        surfaces={reviewMode === "lcr" ? surfaces : []}
+        onNavigate={(home) => {
+          if (typeof window === "undefined") return;
+          // Router-agnostic SPA nav: pushState + popstate so react-router (or any
+          // history listener) updates without a full reload.
+          window.history.pushState({}, "", home);
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        }}
         reviewMode={reviewMode}
         identity={reviewerIdentity}
         onSignIn={() => void signIn()}
@@ -908,7 +936,7 @@ function ReviewerLoginDialog({
   userCode, verificationUri, status, onClose,
 }: { userCode?: string; verificationUri?: string; status: string; onClose: () => void }): JSX.Element {
   return (
-    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: 2147483601 }}>
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: 2147483647 /* 0.7.1 — above the Docs panel (…602) so the sign-in popup isn't hidden behind it */ }}>
       <div style={{ background: "#fff", borderRadius: 14, padding: 24, width: 360, maxWidth: "90vw", boxShadow: "0 12px 40px rgba(0,0,0,0.3)", fontFamily: "system-ui, sans-serif" }}>
         <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 6, color: "#111" }}>Sign in with GitHub</div>
         {userCode ? (
@@ -987,6 +1015,8 @@ function ModeToggle(props: {
   onListClick: () => void;
   docsEnabled: boolean;
   onDocsClick: () => void;
+  surfaces: ReviewSurface[];
+  onNavigate: (home: string) => void;
   // 0.6.2 — LCR sign-in lives IN the floating disk (self-styled, theme-proof),
   // not a separate fixed badge.
   reviewMode: "scenarios" | "lcr";
@@ -994,7 +1024,7 @@ function ModeToggle(props: {
   onSignIn: () => void;
   onSignOut: () => void;
 }): JSX.Element {
-  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, reviewMode, identity, onSignIn, onSignOut } = props;
+  const { mode, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, surfaces, onNavigate, reviewMode, identity, onSignIn, onSignOut } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -1201,6 +1231,9 @@ function ModeToggle(props: {
           📄 Docs
         </button>
       )}
+      {/* 0.7.1 — "Viewing as" surface switcher. A REVIEW affordance (a real user
+          is one role), so it lives in the pane, not the mock. */}
+      {surfaces.length > 0 && <SurfaceSwitcher surfaces={surfaces} onNavigate={onNavigate} disabled={disabled} />}
       {/* 0.6.2 — LCR per-reviewer sign-in, inside the disk. All colours are
           explicit (white-on-dark) so the app's dark/light theme can't touch it.
           0.6.11 — only in Comment mode. */}
@@ -2538,5 +2571,47 @@ function DocsPanel(props: {
         `.sc-doc-prose th{background:rgba(255,255,255,0.06)}`
       }} />
     </div>
+  );
+}
+
+/**
+ * 0.7.1 — "Viewing as" surface switcher, in the review pane. Lets a reviewer
+ * jump between the mock's persona/section surfaces. This is review-only — a real
+ * user is one role — so it must NOT live in the product mock. Tracks the current
+ * route (longest matching surface home) and navigates via the parent's
+ * router-agnostic handler.
+ */
+function SurfaceSwitcher(props: { surfaces: ReviewSurface[]; onNavigate: (home: string) => void; disabled: boolean }): JSX.Element {
+  const { surfaces, onNavigate, disabled } = props;
+  const [path, setPath] = useState<string>(typeof window !== "undefined" ? window.location.pathname : "/");
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const on = () => setPath(window.location.pathname);
+    window.addEventListener("popstate", on);
+    return () => window.removeEventListener("popstate", on);
+  }, []);
+  const current = surfaces
+    .filter((s) => (s.home === "/" ? true : path === s.home || path.startsWith(s.home + "/") || path === s.home))
+    .sort((a, b) => b.home.length - a.home.length)[0] ?? surfaces[0];
+  return (
+    <select
+      aria-label="Viewing as (review surface)"
+      title="Viewing as — jump between persona surfaces (review only; not a real control)"
+      value={current?.home ?? ""}
+      disabled={disabled}
+      onChange={(e) => onNavigate(e.target.value)}
+      style={{
+        marginLeft: 4, maxWidth: 170, background: "rgba(255,255,255,0.08)", color: "white",
+        border: "1px solid rgba(255,255,255,0.18)", borderRadius: 999, padding: "6px 10px",
+        cursor: disabled ? "not-allowed" : "pointer", opacity: disabled ? 0.6 : 1,
+        font: "inherit", fontSize: 12, fontWeight: 700,
+      }}
+    >
+      {surfaces.map((s) => (
+        <option key={s.home} value={s.home} style={{ color: "#111" }}>
+          {(s.icon ? s.icon + " " : "") + "as " + s.label}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -252,7 +252,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // 0.6.0 — LCR multi-person review: who's signed in (this browser) + the
   // device-flow login dialog state. Comments post as this reviewer.
   const [reviewerIdentity, setReviewerIdentity] = useState<StoredReviewerIdentity | null>(null);
-  const [login, setLogin] = useState<{ open: boolean; userCode?: string; verificationUri?: string; status: string }>({ open: false, status: "" });
+  const [login, setLogin] = useState<{ open: boolean; userCode?: string; verificationUri?: string; status: string; error?: string }>({ open: false, status: "" });
   const loginAbort = useRef(false);
   // 0.6.0 — "show already-applied" toggle for the comments list. Resolved
   // comments (applied/declined/noop) hide by default; needs-clarification +
@@ -401,11 +401,50 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     setReviewerIdentity(loadReviewerIdentity(window.localStorage, { owner, repo }));
   }, [reviewMode, owner, repo]);
 
-  const signIn = useCallback(async () => {
-    if (!authBase) {
-      setLogin({ open: true, status: "Sign-in helper not configured (no AUTH_BASE). Run via `slowcook run-mock`." });
-      return;
+  // 0.8.1 — open the sign-in dialog. It always offers the classic-PAT path
+  // (deterministic auth instructions live there), plus device-flow when an
+  // authBase helper is configured. `error` shows a contextual reason (e.g. a
+  // 403 from an org's OAuth-App restriction) above the instructions.
+  const openLogin = useCallback((error?: string) => {
+    setLogin({ open: true, status: "", error });
+  }, []);
+
+  // 0.8.1 — classic-PAT sign-in. The reliable path for PRIVATE repos and orgs
+  // that restrict OAuth Apps: a classic PAT is not an OAuth App, so the org's
+  // "OAuth App access restrictions" don't block it, and the `repo` scope covers
+  // private repos (the device-flow app only gets public_repo). Validates the
+  // token, derives identity + write-access tier, stores it like a device token.
+  const signInWithPat = useCallback(async (tokenRaw: string) => {
+    const token = tokenRaw.trim();
+    if (!token) return;
+    setLogin((l) => ({ ...l, status: "Checking token…", error: undefined }));
+    try {
+      const base = await identifyReviewer(token);
+      const canApply = await checkRepoWriteAccess(token, { owner, repo });
+      const id = { ...base, canApply };
+      saveReviewerToken(window.localStorage, { owner, repo }, token);
+      saveReviewerIdentity(window.localStorage, { owner, repo }, id);
+      setReviewerIdentity(id);
+      setLogin({ open: false, status: "" });
+      setFeedback(canApply
+        ? `Signed in as @${id.login} — your comments are applied.`
+        : `Signed in as @${id.login} — your feedback goes to the team for review.`);
+    } catch (e) {
+      setLogin((l) => ({ ...l, status: "", error: `That token didn't work (${e instanceof Error ? e.message : String(e)}). Use a CLASSIC token with the \`repo\` scope.` }));
     }
+  }, [owner, repo]);
+
+  // 0.8.1 — a write failure that's really an auth problem (401/403/404 — bad
+  // token, org OAuth-App restriction, or a private repo the token can't see)
+  // routes to the sign-in dialog with a deterministic explanation, instead of a
+  // dead-end toast. Other failures still toast.
+  const reportFailure = useCallback((status: number | undefined, message: string | undefined, prefix: string) => {
+    if (status === 401 || status === 403 || status === 404) openLogin(describeAuthError(status, message, { owner, repo }));
+    else setFeedback(`${prefix}: ${status ?? "?"} ${message ?? ""}`);
+  }, [openLogin, owner, repo]);
+
+  const startDeviceLogin = useCallback(async () => {
+    if (!authBase) return;
     loginAbort.current = false;
     setLogin({ open: true, status: "Requesting a code…" });
     const token = await runDeviceLogin({
@@ -594,7 +633,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     try {
       const pat = ensurePat(repoCoord, reviewMode === "lcr");
       if (!pat) {
-        if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to approve as yourself."); }
+        if (reviewMode === "lcr") { openLogin(); }
         else setFeedback("Approval cancelled — no PAT.");
         return;
       }
@@ -651,7 +690,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         setMode("nav");
         if (labelOk) setIsApproved(true); // optimistic; focus-refresh confirms
       } else {
-        setFeedback(`Approval failed: ${result.status} ${result.message}`);
+        reportFailure(result.status, result.message, "Approval failed");
       }
     } finally {
       setSubmitting(false);
@@ -666,7 +705,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       try {
         const pat = ensurePat(repoCoord, reviewMode === "lcr");
         if (!pat) {
-          if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to comment as yourself."); }
+          if (reviewMode === "lcr") { openLogin(); }
           else setFeedback("Cancelled — no PAT.");
           return;
         }
@@ -718,7 +757,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
             return next;
           });
         } else {
-          setFeedback(`Failed: ${result.status} ${result.message}`);
+          reportFailure(result.status, result.message, "Failed");
         }
       } finally {
         setSubmitting(false);
@@ -738,7 +777,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       try {
         const pat = ensurePat(repoCoord, reviewMode === "lcr");
         if (!pat) {
-          if (reviewMode === "lcr") { void signIn(); setFeedback("Sign in with GitHub to comment as yourself."); }
+          if (reviewMode === "lcr") { openLogin(); }
           else setFeedback("Cancelled — no PAT.");
           return;
         }
@@ -782,7 +821,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
             return next;
           });
         } else {
-          setFeedback(`Failed: ${result.status} ${result.message}`);
+          reportFailure(result.status, result.message, "Failed");
         }
       } finally {
         setSubmitting(false);
@@ -909,7 +948,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         }}
         reviewMode={reviewMode}
         identity={reviewerIdentity}
-        onSignIn={() => void signIn()}
+        onSignIn={() => openLogin()}
         onSignOut={signOut}
       />
       {/* 0.3.0 — Figma-style pin layer for previously-left comments.
@@ -956,7 +995,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           branch={resolvedBranch}
           identity={reviewerIdentity}
           getToken={() => (typeof window !== "undefined" ? loadReviewerToken(window.localStorage, repoCoord) : null)}
-          onSignIn={() => void signIn()}
+          onSignIn={() => openLogin()}
           apiBase={getProxyApiBase() ?? undefined}
           onClose={() => setDocsPanelOpen(false)}
           onFeedback={(t) => setFeedback(t)}
@@ -996,9 +1035,15 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       )}
       {login.open && (
         <ReviewerLoginDialog
+          owner={repoCoord.owner}
+          repo={repoCoord.repo}
           userCode={login.userCode}
           verificationUri={login.verificationUri}
           status={login.status}
+          error={login.error}
+          hasAuthBase={Boolean(authBase)}
+          onSubmitPat={(tok) => void signInWithPat(tok)}
+          onStartDevice={() => void startDeviceLogin()}
           onClose={() => { loginAbort.current = true; setLogin({ open: false, status: "" }); }}
         />
       )}
@@ -1035,31 +1080,116 @@ function HoverHighlight({ el }: { el: Element }): JSX.Element {
   );
 }
 
-/** 0.6.0 — device-flow login dialog: shows the user code + verification link. */
+/**
+ * 0.8.1 — deterministic, in-code explanation of a write/auth failure. No LLM,
+ * no agent: the overlay itself tells the reviewer exactly why GitHub rejected
+ * the post and what to do (use a classic PAT with the `repo` scope), keyed off
+ * the HTTP status + GitHub's own message. Surfaced on every repo the overlay is
+ * mounted on.
+ */
+function describeAuthError(status: number | undefined, message: string | undefined, repo: RepoCoord): string {
+  const m = (message ?? "").toLowerCase();
+  if (status === 403 && m.includes("oauth app access restrictions")) {
+    return `Your "${repo.owner}" organization restricts third-party OAuth Apps, so the GitHub sign-in app is blocked from posting here — even though you're signed in. Use a classic personal access token with the \`repo\` scope instead: a PAT isn't an OAuth App, so the restriction doesn't apply.`;
+  }
+  if (status === 403) {
+    return `GitHub returned 403 (forbidden) for ${repo.owner}/${repo.repo}. If it's a private repo, or your org restricts OAuth Apps, sign in with a classic token that has the \`repo\` scope.`;
+  }
+  if (status === 401) {
+    return `GitHub rejected the token (401) — it's likely expired or missing scope. Sign in again with a classic token that has the \`repo\` scope.`;
+  }
+  if (status === 404) {
+    return `${repo.owner}/${repo.repo} wasn't found for this token — it's probably private and your token lacks the \`repo\` scope. Sign in with a classic token that has \`repo\`.`;
+  }
+  return message ?? "Sign-in needed to post your comment.";
+}
+
+/**
+ * 0.6.0 → 0.8.1 — sign-in dialog. Always offers a classic-PAT path with baked-in
+ * instructions (the reliable route for private repos + orgs that restrict OAuth
+ * Apps), plus device-flow login when an authBase helper is configured. `error`
+ * shows the deterministic reason a write was just rejected.
+ */
 function ReviewerLoginDialog({
-  userCode, verificationUri, status, onClose,
-}: { userCode?: string; verificationUri?: string; status: string; onClose: () => void }): JSX.Element {
+  owner, repo, userCode, verificationUri, status, error, hasAuthBase, onSubmitPat, onStartDevice, onClose,
+}: {
+  owner: string; repo: string;
+  userCode?: string; verificationUri?: string; status: string; error?: string;
+  hasAuthBase: boolean;
+  onSubmitPat: (token: string) => void;
+  onStartDevice: () => void;
+  onClose: () => void;
+}): JSX.Element {
+  const [pat, setPat] = useState("");
+  const tokenUrl = `https://github.com/settings/tokens/new?scopes=repo&description=${encodeURIComponent(`slowcook review ${owner}/${repo}`)}`;
   return (
-    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: 2147483647 /* 0.7.1 — above the Docs panel (…602) so the sign-in popup isn't hidden behind it */ }}>
-      <div style={{ background: "#fff", borderRadius: 14, padding: 24, width: 360, maxWidth: "90vw", boxShadow: "0 12px 40px rgba(0,0,0,0.3)", fontFamily: "system-ui, sans-serif" }}>
-        <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 6, color: "#111" }}>Sign in with GitHub</div>
-        {userCode ? (
-          <>
-            <p style={{ fontSize: 13.5, color: "#555", margin: "0 0 14px" }}>
-              Open GitHub and enter this code to review as yourself:
-            </p>
-            <div style={{ fontSize: 30, fontWeight: 800, letterSpacing: "0.18em", textAlign: "center", background: "#f3f4f6", borderRadius: 10, padding: "12px 0", color: "#111", fontFamily: "ui-monospace, monospace" }}>
-              {userCode}
-            </div>
-            <a href={verificationUri} target="_blank" rel="noreferrer"
-               style={{ display: "block", textAlign: "center", marginTop: 14, background: "#2da44e", color: "#fff", borderRadius: 999, padding: "9px 0", textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
-              Open {verificationUri?.replace(/^https?:\/\//, "")}
-            </a>
-          </>
-        ) : (
-          <p style={{ fontSize: 14, color: "#555", margin: "8px 0 14px" }}>{status || "Starting…"}</p>
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: 2147483647, fontFamily: "system-ui, -apple-system, sans-serif" }}>
+      <div style={{ background: "#fff", borderRadius: 14, padding: 22, width: 400, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto", boxShadow: "0 12px 40px rgba(0,0,0,0.3)" }}>
+        <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 2, color: "#111" }}>Sign in to review</div>
+        <div style={{ fontSize: 12, color: "#666", marginBottom: 12, fontFamily: "ui-monospace, monospace" }}>{owner}/{repo}</div>
+
+        {error && (
+          <div style={{ background: "#fff1f0", border: "1px solid #ffccc7", color: "#a8071a", borderRadius: 8, padding: "10px 12px", fontSize: 12.5, lineHeight: 1.5, marginBottom: 14 }}>
+            {error}
+          </div>
         )}
-        {userCode && <p style={{ fontSize: 12, color: "#888", marginTop: 12 }}>{status}</p>}
+
+        {/* Classic-PAT path — the reliable route (deterministic instructions). */}
+        <div style={{ fontSize: 13.5, fontWeight: 700, color: "#111", marginBottom: 4 }}>Personal access token{!hasAuthBase && " (recommended)"}</div>
+        <p style={{ fontSize: 12.5, color: "#555", margin: "0 0 10px", lineHeight: 1.5 }}>
+          Works for <strong>private repos</strong> and orgs that restrict OAuth Apps. Create a <strong>classic</strong> token with the <code style={{ background: "#f3f4f6", padding: "1px 4px", borderRadius: 4 }}>repo</code> scope, then paste it below.
+        </p>
+        <a href={tokenUrl} target="_blank" rel="noreferrer"
+           style={{ display: "block", textAlign: "center", background: "#1f2328", color: "#fff", borderRadius: 8, padding: "8px 0", textDecoration: "none", fontWeight: 600, fontSize: 13, marginBottom: 10 }}>
+          ① Create a classic token (repo scope) ↗
+        </a>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            type="password"
+            value={pat}
+            onChange={(e) => setPat(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter" && pat.trim()) onSubmitPat(pat); }}
+            placeholder="② Paste token (ghp_… / github_pat_…)"
+            autoComplete="off"
+            style={{ flex: 1, minWidth: 0, padding: "8px 10px", border: "1px solid #d0d7de", borderRadius: 8, fontSize: 14, color: "#111", background: "#fff" }}
+          />
+          <button
+            type="button"
+            disabled={pat.trim() === ""}
+            onClick={() => onSubmitPat(pat)}
+            style={{ background: pat.trim() ? "#2da44e" : "#94d3a2", color: "#fff", border: "none", borderRadius: 8, padding: "8px 14px", fontWeight: 700, fontSize: 13, cursor: pat.trim() ? "pointer" : "not-allowed", whiteSpace: "nowrap" }}
+          >
+            Save
+          </button>
+        </div>
+        <p style={{ fontSize: 11, color: "#888", margin: "8px 0 0", lineHeight: 1.5 }}>
+          Stored only in this browser, scoped to {owner}/{repo}. {status && <span style={{ color: "#555", fontWeight: 600 }}>· {status}</span>}
+        </p>
+
+        {/* Device-flow path — only when an auth helper (authBase) is configured. */}
+        {hasAuthBase && (
+          <>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, margin: "16px 0 12px", color: "#999", fontSize: 11 }}>
+              <span style={{ flex: 1, height: 1, background: "#eaeaea" }} /> OR <span style={{ flex: 1, height: 1, background: "#eaeaea" }} />
+            </div>
+            {userCode ? (
+              <>
+                <p style={{ fontSize: 12.5, color: "#555", margin: "0 0 10px" }}>Open GitHub and enter this code:</p>
+                <div style={{ fontSize: 28, fontWeight: 800, letterSpacing: "0.18em", textAlign: "center", background: "#f3f4f6", borderRadius: 10, padding: "10px 0", color: "#111", fontFamily: "ui-monospace, monospace" }}>{userCode}</div>
+                <a href={verificationUri} target="_blank" rel="noreferrer"
+                   style={{ display: "block", textAlign: "center", marginTop: 12, background: "#2da44e", color: "#fff", borderRadius: 999, padding: "9px 0", textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
+                  Open {verificationUri?.replace(/^https?:\/\//, "")}
+                </a>
+              </>
+            ) : (
+              <button type="button" onClick={onStartDevice}
+                style={{ width: "100%", background: "#fff", color: "#1f2328", border: "1px solid #d0d7de", borderRadius: 8, padding: "9px 0", fontWeight: 600, fontSize: 13, cursor: "pointer" }}>
+                Sign in with GitHub device login
+              </button>
+            )}
+          </>
+        )}
+
         <button onClick={onClose} style={{ marginTop: 16, width: "100%", border: "1px solid rgba(0,0,0,0.12)", background: "#fff", borderRadius: 999, padding: "8px 0", cursor: "pointer", fontSize: 13, color: "#444" }}>
           Cancel
         </button>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -738,6 +738,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       {mode === "comment" && comments.length > 0 && (
         <CommentPins
           records={comments.filter((c) => c.payload.element !== null)}
+          showApplied={showApplied}
           openCommentId={openCommentId}
           onOpen={(id) => setOpenCommentId(id)}
           onClose={() => setOpenCommentId(null)}
@@ -1588,12 +1589,22 @@ function ensurePat(repo: RepoCoord, lcr = false): string | null {
  */
 function CommentPins(props: {
   records: OverlayCommentRecord[];
+  showApplied: boolean;
   openCommentId: number | null;
   onOpen: (id: number) => void;
   onClose: () => void;
   flashCommentId?: number | null;
 }): JSX.Element {
-  const { records, openCommentId, onOpen, onClose, flashCommentId } = props;
+  const { records: allRecords, showApplied, openCommentId, onOpen, onClose, flashCommentId } = props;
+  // Hide pins for resolved/applied comments unless the reviewer has asked to
+  // see them (the same "show applied" toggle that governs the list). An open
+  // pin stays visible so "Locate from list" still works.
+  const records = allRecords.filter(
+    (r) =>
+      showApplied ||
+      r.commentId === openCommentId ||
+      !(r.plateReply != null && isResolvedStatus(r.plateReply.status)),
+  );
   // tick forces a re-render on every animation frame so pins follow
   // the underlying DOM as the page scrolls / reflows.
   const [tick, setTick] = useState(0);
@@ -1698,6 +1709,20 @@ function pinPalette(status: OverlayCommentRecord["plateReply"] extends infer R ?
   }
 }
 
+/** Per-author colour — Figma-style. Hashes the FULL author handle to a hue, so
+ *  two reviewers with the same initial still get distinct colours. */
+function authorColor(author: string): { bg: string; ring: string } {
+  let h = 0;
+  for (let i = 0; i < author.length; i++) h = (h * 31 + author.charCodeAt(i)) >>> 0;
+  const hue = h % 360;
+  return { bg: `hsl(${hue}, 58%, 42%)`, ring: `hsla(${hue}, 58%, 42%, 0.35)` };
+}
+/** First alphanumeric character of the author handle, uppercased. */
+function authorInitial(author: string): string {
+  const m = author.replace(/[^a-zA-Z0-9]/g, "");
+  return (m[0] ?? "?").toUpperCase();
+}
+
 function PinIcon(props: {
   record: OverlayCommentRecord;
   x: number;
@@ -1706,11 +1731,18 @@ function PinIcon(props: {
   flashing?: boolean;
   onClick: () => void;
 }): JSX.Element {
+  const author = props.record.author || "unknown";
   const status = props.record.plateReply?.status ?? null;
-  const palette = pinPalette(status as never, props.drifted);
-  const title = props.drifted
-    ? `Selector drifted (anchored at original bbox); click to view`
-    : `${status ?? "unresolved"} · click to view`;
+  const col = authorColor(author);
+  // Status is shown as a small corner badge (not the whole pin) so the pin's
+  // body can carry the author's identity instead. No badge for a plain
+  // unresolved comment; drifted/resolved states get one.
+  const statusBadge = props.drifted
+    ? pinPalette(null as never, true)
+    : status
+    ? pinPalette(status as never, false)
+    : null;
+  const title = `@${author}${props.drifted ? " · selector drifted" : status ? ` · ${status}` : ""} · click to view`;
   return (
     <button
       type="button"
@@ -1725,18 +1757,18 @@ function PinIcon(props: {
         width: 22,
         height: 22,
         borderRadius: 999,
-        background: palette.bg,
-        color: palette.fg,
+        background: col.bg,
+        color: "#fff",
         border: `2px solid white`,
         boxShadow: props.flashing
-          ? `0 2px 6px rgba(0,0,0,0.25), 0 0 0 12px ${palette.ring}`
-          : `0 2px 6px rgba(0,0,0,0.25), 0 0 0 4px ${palette.ring}`,
+          ? `0 2px 6px rgba(0,0,0,0.25), 0 0 0 12px ${col.ring}`
+          : `0 2px 6px rgba(0,0,0,0.25), 0 0 0 4px ${col.ring}`,
         transform: props.flashing ? "scale(1.4)" : "scale(1)",
         transition: "transform 220ms ease, box-shadow 220ms ease",
         cursor: "pointer",
         pointerEvents: "auto",
         fontSize: 11,
-        fontWeight: 700,
+        fontWeight: 800,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -1745,7 +1777,22 @@ function PinIcon(props: {
         lineHeight: 1,
       }}
     >
-      {palette.glyph}
+      {authorInitial(author)}
+      {statusBadge && (
+        <span
+          aria-hidden
+          style={{
+            position: "absolute", top: -5, right: -5,
+            width: 12, height: 12, borderRadius: 999,
+            background: statusBadge.bg, color: statusBadge.fg,
+            border: "1.5px solid white", fontSize: 8, fontWeight: 800,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            lineHeight: 1,
+          }}
+        >
+          {statusBadge.glyph}
+        </span>
+      )}
     </button>
   );
 }
@@ -2077,7 +2124,14 @@ function CommentsListPanel(props: {
                   onClick={() => setExpandedId(expanded ? null : r.commentId)}
                   style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", textAlign: "left", color: "white", font: "inherit", cursor: "pointer" }}
                 >
-                  <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 18, height: 18, borderRadius: 999, background: palette.bg, color: palette.fg, fontSize: 10, fontWeight: 700 }}>{palette.glyph}</span>
+                  {/* Per-author identity disk (colour + initial), with the plate
+                      status as a small corner badge — matches the on-page pins. */}
+                  <span style={{ position: "relative", display: "inline-flex", flexShrink: 0 }}>
+                    <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 18, height: 18, borderRadius: 999, background: authorColor(r.author || "unknown").bg, color: "#fff", fontSize: 9, fontWeight: 800 }}>{authorInitial(r.author || "unknown")}</span>
+                    {status && (
+                      <span aria-hidden style={{ position: "absolute", top: -4, right: -4, width: 10, height: 10, borderRadius: 999, background: palette.bg, color: palette.fg, border: "1.5px solid rgba(15,15,24,1)", fontSize: 7, fontWeight: 800, display: "flex", alignItems: "center", justifyContent: "center", lineHeight: 1 }}>{palette.glyph}</span>
+                    )}
+                  </span>
                   <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4, padding: "1px 6px", borderRadius: 999, background: anchorLabel.bg, color: anchorLabel.color }}>{anchorLabel.text}</span>
                   <span style={{ fontSize: 10, opacity: 0.55, marginLeft: "auto" }}>@{r.author} · {formatTimeAgo(r.createdAt)}</span>
                   <span aria-hidden style={{ fontSize: 10, opacity: 0.55, transform: expanded ? "rotate(90deg)" : "none", transition: "transform .15s" }}>▶</span>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -997,19 +997,22 @@ function ModeToggle(props: {
           <circle cx="4.5" cy="12" r="1.1" fill="currentColor" />
         </svg>
       </div>
-      <ToggleButton
-        active={mode === "nav"}
-        onClick={() => onChangeSafe("nav")}
-        disabled={disabled}
-        label={isMobile ? "🧭" : "Nav"}
-        title="Navigate (default)"
-      />
+      {/* 0.6.9 — single Nav/Comment toggle (was two buttons): off = navigate,
+          on (accent) = comment mode. */}
       <ToggleButton
         active={mode === "comment"}
-        onClick={() => onChangeSafe("comment")}
+        onClick={() => onChangeSafe(mode === "comment" ? "nav" : "comment")}
         disabled={disabled}
-        label={isMobile ? "💬" : "💬 Comment"}
-        title={newCount ? `Comment — ${newCount} new update(s)` : "Comment on an element"}
+        label={
+          mode === "comment"
+            ? (isMobile ? "💬" : "💬 Commenting")
+            : (isMobile ? "🧭" : "🧭 Navigating")
+        }
+        title={
+          mode === "comment"
+            ? "Comment mode on — click to go back to navigating"
+            : (newCount ? `Click to comment — ${newCount} new update(s)` : "Click to comment on an element")
+        }
         accent
         badge={newCount}
       />

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1087,7 +1087,7 @@ function HoverHighlight({ el }: { el: Element }): JSX.Element {
  * the HTTP status + GitHub's own message. Surfaced on every repo the overlay is
  * mounted on.
  */
-function describeAuthError(status: number | undefined, message: string | undefined, repo: RepoCoord): string {
+export function describeAuthError(status: number | undefined, message: string | undefined, repo: RepoCoord): string {
   const m = (message ?? "").toLowerCase();
   if (status === 403 && m.includes("oauth app access restrictions")) {
     return `Your "${repo.owner}" organization restricts third-party OAuth Apps, so the GitHub sign-in app is blocked from posting here — even though you're signed in. Use a classic personal access token with the \`repo\` scope instead: a PAT isn't an OAuth App, so the restriction doesn't apply.`;

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -67,6 +67,18 @@ export interface SlowcookReviewOverlayProps {
    * tree-shake the overlay out cleanly.
    */
   enabled?: boolean;
+  /**
+   * 0.6.0 — review surface shape. Falls back to
+   * `NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE` (default `"scenarios"`).
+   *
+   *  - `"scenarios"` (legacy): the mock is a scenario picker at `/`; the
+   *    overlay hides on the `/` route (commenting there is noise).
+   *  - `"lcr"`: the mock is a full navigable Living Coded Requirement
+   *    with its own router. The overlay shows on EVERY route (incl. `/`)
+   *    so the reviewer can roam the whole app and comment anywhere; each
+   *    comment captures its route so plate can amend per-page.
+   */
+  reviewMode?: "scenarios" | "lcr";
   /** Overlay package version, included in the JSON payload. */
   overlayVersion?: string;
 }
@@ -87,7 +99,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   const prNumber = props.prNumber ?? parseInt(process.env["NEXT_PUBLIC_SLOWCOOK_PR_NUMBER"] ?? "0", 10);
   const storyId = props.storyId ?? process.env["NEXT_PUBLIC_SLOWCOOK_STORY_ID"] ?? null;
   const enabled = props.enabled ?? (process.env["NEXT_PUBLIC_SLOWCOOK_REVIEW"] === "1");
-  const overlayVersion = props.overlayVersion ?? "0.5.1";
+  const reviewMode: "scenarios" | "lcr" =
+    props.reviewMode ??
+    (process.env["NEXT_PUBLIC_SLOWCOOK_REVIEW_MODE"] === "lcr" ? "lcr" : "scenarios");
+  const overlayVersion = props.overlayVersion ?? "0.6.0";
   const repoCoord: RepoCoord = { owner, repo };
 
   // 0.5.1 — hydration-mismatch fix. The overlay can't render during
@@ -178,6 +193,12 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
     if (typeof window === "undefined") return;
     // 0.2.0 — hide on the picker route (homepage). The picker is for
     // navigation, not for review; commenting affordances would be noise.
+    // 0.6.0 — only in scenarios mode. In LCR mode `/` is the app home, a
+    // first-class surface to review, so we never route-hide.
+    if (reviewMode === "lcr") {
+      setIsPickerRoute(false);
+      return;
+    }
     // Re-evaluate on pop/push via a polling tick (Next App Router doesn't
     // emit a usable event for this without a router hook).
     const apply = () => setIsPickerRoute(window.location.pathname === "/");
@@ -188,7 +209,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
       clearInterval(interval);
       window.removeEventListener("popstate", apply);
     };
-  }, []);
+  }, [reviewMode]);
 
   // ESC exits comment/approve mode + closes composer.
   useEffect(() => {
@@ -328,6 +349,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           overlayVersion,
           storyId,
           url: window.location.href,
+          pathname: window.location.pathname,
+          routeQuery: window.location.search,
           prose,
           selector: sel,
           bbox: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
@@ -402,6 +425,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           overlayVersion,
           storyId,
           url: window.location.href,
+          pathname: window.location.pathname,
+          routeQuery: window.location.search,
           prose,
           viewport,
           userAgent: navigator.userAgent,

--- a/packages/review-overlay/src/react/shadow-firewall.test.tsx
+++ b/packages/review-overlay/src/react/shadow-firewall.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// 0.7.3 — proves the Shadow-DOM style firewall. Reproduces the delgoosh
+// failure mode (an RTL host with a universal `*{}` reset) and asserts the
+// overlay mounts its UI inside a shadow root whose :host reset severs the
+// leaked inheritance — so the disk can't "lose its shape" or mirror.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+
+// React 19 wants this flag set before act() is used outside a test renderer.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { createRoot, type Root } from "react-dom/client";
+import { SlowcookReviewOverlay } from "./overlay.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  // Simulate a hostile host: RTL + a universal reset + a button reset,
+  // exactly the kind of global CSS that used to bleed into the overlay.
+  document.documentElement.setAttribute("dir", "rtl");
+  document.body.style.direction = "rtl";
+  const hostCss = document.createElement("style");
+  hostCss.textContent =
+    "*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}" +
+    "button{all:unset}";
+  document.head.appendChild(hostCss);
+
+  // The overlay fetches LCR issues + reads matchMedia on mount; stub both
+  // so the effects settle without network or a missing browser API.
+  vi.stubGlobal("fetch", vi.fn(async () => ({
+    ok: true, status: 200, headers: new Headers(), json: async () => [], text: async () => "[]",
+  })));
+  if (!window.matchMedia) {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: false, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+    })));
+  }
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+  document.querySelectorAll("[data-slowcook-overlay-host]").forEach((n) => n.remove());
+});
+
+function render() {
+  act(() => {
+    root.render(
+      <SlowcookReviewOverlay
+        enabled
+        reviewMode="lcr"
+        owner="acme"
+        repo="app"
+        prNumber={1}
+        branch="main"
+      />,
+    );
+  });
+}
+
+describe("shadow-DOM style firewall (0.7.3)", () => {
+  it("mounts the overlay UI inside a shadow root, not the light DOM", () => {
+    render();
+    const host = document.querySelector("[data-slowcook-overlay-host]") as HTMLElement | null;
+    expect(host, "a body-level shadow host is created").toBeTruthy();
+    expect(host!.shadowRoot, "host has an open shadow root").toBeTruthy();
+    // The overlay UI lives in the shadow tree...
+    expect(host!.shadowRoot!.querySelector("[data-slowcook-overlay-ui]")).toBeTruthy();
+    // ...and is therefore invisible to a light-DOM query (true encapsulation).
+    expect(document.querySelector("[data-slowcook-overlay-ui]")).toBeNull();
+  });
+
+  it("injects a :host reset that severs inherited host CSS (incl. the RTL exception)", () => {
+    render();
+    const host = document.querySelector("[data-slowcook-overlay-host]") as HTMLElement;
+    const css = Array.from(host.shadowRoot!.querySelectorAll("style"))
+      .map((s) => s.textContent ?? "")
+      .join("\n");
+    expect(css).toContain(":host{all:initial");
+    // `all` deliberately skips direction/unicode-bidi — the explicit reset is
+    // what actually un-mirrors the toolbar on an RTL host.
+    expect(css).toContain("direction:ltr");
+    expect(css).toContain("unicode-bidi:isolate");
+  });
+});

--- a/packages/review-overlay/src/react/use-story-marker.ts
+++ b/packages/review-overlay/src/react/use-story-marker.ts
@@ -1,0 +1,38 @@
+/**
+ * 0.6.0 — LCR runtime story marker.
+ *
+ * An LCR page renders the implementation of a story/requirement. Calling
+ * `useStoryMarker("104")` (or `<StoryMarker story="104">`) on that page sets
+ * `document.documentElement.dataset.slowcookStory` while it's mounted, so the
+ * review overlay can tag a comment left there with the exact requirement — the
+ * comment becomes a contextualised, `vibe`-labelled issue for that story.
+ *
+ * The @story SOURCE comments stay the provenance record; this is the runtime
+ * echo the browser can read. Absent marker → the overlay still files the route;
+ * vibe can derive the story from it.
+ */
+"use client";
+
+import { useEffect } from "react";
+
+const ATTR = "slowcookStory"; // document.documentElement.dataset.slowcookStory
+
+/** Read the story the current route declares, if any. */
+export function readCurrentStory(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+  const v = document.documentElement.dataset[ATTR];
+  return v && v.length > 0 ? v : undefined;
+}
+
+/** Declare the story for the route this component renders (while mounted). */
+export function useStoryMarker(story: string): void {
+  useEffect(() => {
+    if (typeof document === "undefined" || !story) return;
+    const prev = document.documentElement.dataset[ATTR];
+    document.documentElement.dataset[ATTR] = story.replace(/^story-/, "");
+    return () => {
+      if (prev === undefined) delete document.documentElement.dataset[ATTR];
+      else document.documentElement.dataset[ATTR] = prev;
+    };
+  }, [story]);
+}

--- a/packages/review-overlay/src/reviewer-session.test.ts
+++ b/packages/review-overlay/src/reviewer-session.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  loadReviewerToken, saveReviewerToken, loadReviewerIdentity, saveReviewerIdentity,
+  clearReviewerSession, runDeviceLogin, identifyReviewer, type LoginEvent,
+} from "./reviewer-session.js";
+import type { RepoCoord } from "./github.js";
+
+const repo: RepoCoord = { owner: "o", repo: "r" };
+
+function memStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    clear: () => m.clear(),
+    key: () => null,
+    get length() { return m.size; },
+  } as Storage;
+}
+
+describe("reviewer-session storage", () => {
+  it("round-trips token + identity, scoped per repo, and clears", () => {
+    const s = memStorage();
+    saveReviewerToken(s, repo, "tok");
+    saveReviewerIdentity(s, repo, { login: "ana", name: "Ana" });
+    expect(loadReviewerToken(s, repo)).toBe("tok");
+    expect(loadReviewerIdentity(s, repo)).toEqual({ login: "ana", name: "Ana" });
+    expect(loadReviewerToken(s, { owner: "x", repo: "y" })).toBeNull(); // per-repo scope
+    clearReviewerSession(s, repo);
+    expect(loadReviewerToken(s, repo)).toBeNull();
+    expect(loadReviewerIdentity(s, repo)).toBeNull();
+  });
+});
+
+/** Sequence a fetch stub across the device + poll endpoints. */
+function seqFetch(deviceJson: unknown, pollSequence: unknown[]): typeof fetch {
+  let pi = 0;
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/auth/device")) return { ok: true, json: async () => deviceJson } as Response;
+    if (u.includes("/auth/poll")) return { ok: true, json: async () => pollSequence[Math.min(pi++, pollSequence.length - 1)] } as Response;
+    if (u.includes("api.github.com/user")) return { ok: true, json: async () => ({ login: "ana", name: "Ana Q" }) } as Response;
+    throw new Error(`unexpected ${u}`);
+  }) as typeof fetch;
+}
+
+describe("runDeviceLogin", () => {
+  const grant = { deviceCode: "DC", userCode: "WXYZ-1234", verificationUri: "https://github.com/login/device", intervalSeconds: 1, expiresInSeconds: 900 };
+
+  it("surfaces the code, honours slow_down, then authorizes", async () => {
+    const events: LoginEvent[] = [];
+    const token = await runDeviceLogin({
+      authBase: "http://box:4200",
+      onEvent: (e) => events.push(e),
+      sleep: async () => {},
+      fetchImpl: seqFetch(grant, [
+        { status: "pending" },
+        { status: "slow_down", intervalSeconds: 2 },
+        { status: "authorized", token: "tok-xyz" },
+      ]),
+    });
+    expect(token).toBe("tok-xyz");
+    expect(events[0]).toEqual({ type: "code", grant });
+    expect(events.at(-1)).toEqual({ type: "authorized", token: "tok-xyz" });
+  });
+
+  it("returns null + emits denied", async () => {
+    const events: LoginEvent[] = [];
+    const token = await runDeviceLogin({
+      authBase: "http://box:4200", onEvent: (e) => events.push(e), sleep: async () => {},
+      fetchImpl: seqFetch(grant, [{ status: "denied" }]),
+    });
+    expect(token).toBeNull();
+    expect(events.at(-1)).toEqual({ type: "denied" });
+  });
+
+  it("stops when shouldStop fires", async () => {
+    const token = await runDeviceLogin({
+      authBase: "http://box:4200", onEvent: () => {}, sleep: async () => {}, shouldStop: () => true,
+      fetchImpl: seqFetch(grant, [{ status: "pending" }]),
+    });
+    expect(token).toBeNull();
+  });
+
+  it("identifyReviewer maps the user, name→login fallback", async () => {
+    const f = (async () => ({ ok: true, json: async () => ({ login: "ben", name: null }) } as Response)) as typeof fetch;
+    expect(await identifyReviewer("t", f)).toMatchObject({ login: "ben", name: "ben" });
+  });
+});

--- a/packages/review-overlay/src/reviewer-session.ts
+++ b/packages/review-overlay/src/reviewer-session.ts
@@ -26,17 +26,22 @@ export function loadReviewerToken(storage: Storage, repo: RepoCoord): string | n
 export function saveReviewerToken(storage: Storage, repo: RepoCoord, token: string): void {
   storage.setItem(tokenKey(repo), token);
 }
-export function loadReviewerIdentity(storage: Storage, repo: RepoCoord): ReviewerIdentity | null {
+/** Identity plus the access tier we derive from repo permissions. `canApply`
+ *  true → repo write access → comments get the `vibe` label (auto-applied);
+ *  false → comments are held for the team (`community-review`). */
+export type StoredReviewerIdentity = ReviewerIdentity & { canApply?: boolean };
+
+export function loadReviewerIdentity(storage: Storage, repo: RepoCoord): StoredReviewerIdentity | null {
   const raw = storage.getItem(identityKey(repo));
   if (!raw) return null;
   try {
-    const v = JSON.parse(raw) as ReviewerIdentity;
+    const v = JSON.parse(raw) as StoredReviewerIdentity;
     return typeof v?.login === "string" ? v : null;
   } catch {
     return null;
   }
 }
-export function saveReviewerIdentity(storage: Storage, repo: RepoCoord, id: ReviewerIdentity): void {
+export function saveReviewerIdentity(storage: Storage, repo: RepoCoord, id: StoredReviewerIdentity): void {
   storage.setItem(identityKey(repo), JSON.stringify(id));
 }
 export function clearReviewerSession(storage: Storage, repo: RepoCoord): void {
@@ -74,6 +79,30 @@ export async function identifyReviewer(token: string, f: typeof fetch = fetch): 
   if (!res.ok) throw new Error(`identify failed: ${res.status}`);
   const j = (await res.json()) as { login: string; name: string | null; avatar_url?: string };
   return { login: j.login, name: j.name ?? j.login, avatarUrl: j.avatar_url };
+}
+
+/**
+ * Does this reviewer have write access (push or higher) to the repo? Drives the
+ * apply tier: GET /repos/{owner}/{repo} returns `permissions` for the
+ * authenticated user. `push` (write), `maintain`, or `admin` → can apply.
+ * Anything else (read/none), or any error, → held for the team (fail closed).
+ */
+export async function checkRepoWriteAccess(token: string, repo: RepoCoord, f: typeof fetch = fetch): Promise<boolean> {
+  try {
+    const res = await f(`https://api.github.com/repos/${repo.owner}/${repo.repo}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) return false;
+    const j = (await res.json()) as { permissions?: { push?: boolean; maintain?: boolean; admin?: boolean } };
+    const p = j.permissions ?? {};
+    return !!(p.push || p.maintain || p.admin);
+  } catch {
+    return false; // fail closed — unknown access never auto-applies
+  }
 }
 
 export type LoginEvent =

--- a/packages/review-overlay/src/reviewer-session.ts
+++ b/packages/review-overlay/src/reviewer-session.ts
@@ -1,0 +1,145 @@
+/**
+ * Reviewer session (0.6.0) — multi-person LCR review identity, browser side.
+ *
+ * In LCR mode each reviewer signs in as THEMSELVES via GitHub device flow so
+ * their comments are attributed to their own account. The device dance's
+ * token-exchange hops aren't CORS-open to a browser, so they go through the
+ * box-hosted auth-helper (run-mock's reviewer-auth-server, env AUTH_BASE);
+ * identity + comment posting use the per-reviewer token directly against the
+ * CORS-OK api.github.com. Token + identity persist in localStorage per repo.
+ *
+ * Pure + injectable fetch — the React hook in ./react/use-reviewer-session.ts
+ * is a thin wrapper over these.
+ */
+import type { DeviceCodeGrant, PollResult, ReviewerIdentity } from "@slowcook-ai/core";
+import type { RepoCoord } from "./github.js";
+
+const TOKEN_KEY_PREFIX = "slowcook.review-overlay.reviewer-token.";
+const IDENTITY_KEY_PREFIX = "slowcook.review-overlay.reviewer-identity.";
+
+const tokenKey = (r: RepoCoord) => `${TOKEN_KEY_PREFIX}${r.owner}/${r.repo}`;
+const identityKey = (r: RepoCoord) => `${IDENTITY_KEY_PREFIX}${r.owner}/${r.repo}`;
+
+export function loadReviewerToken(storage: Storage, repo: RepoCoord): string | null {
+  return storage.getItem(tokenKey(repo));
+}
+export function saveReviewerToken(storage: Storage, repo: RepoCoord, token: string): void {
+  storage.setItem(tokenKey(repo), token);
+}
+export function loadReviewerIdentity(storage: Storage, repo: RepoCoord): ReviewerIdentity | null {
+  const raw = storage.getItem(identityKey(repo));
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as ReviewerIdentity;
+    return typeof v?.login === "string" ? v : null;
+  } catch {
+    return null;
+  }
+}
+export function saveReviewerIdentity(storage: Storage, repo: RepoCoord, id: ReviewerIdentity): void {
+  storage.setItem(identityKey(repo), JSON.stringify(id));
+}
+export function clearReviewerSession(storage: Storage, repo: RepoCoord): void {
+  storage.removeItem(tokenKey(repo));
+  storage.removeItem(identityKey(repo));
+}
+
+/** Begin a device-flow login via the box auth-helper. */
+export async function requestDeviceCode(authBase: string, f: typeof fetch = fetch): Promise<DeviceCodeGrant> {
+  const res = await f(`${authBase.replace(/\/$/, "")}/__slowcook/auth/device`, { method: "POST" });
+  if (!res.ok) throw new Error(`device code request failed: ${res.status}`);
+  return (await res.json()) as DeviceCodeGrant;
+}
+
+/** Poll the box auth-helper once for the access token. */
+export async function pollAccessToken(authBase: string, deviceCode: string, f: typeof fetch = fetch): Promise<PollResult> {
+  const res = await f(`${authBase.replace(/\/$/, "")}/__slowcook/auth/poll`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ deviceCode }),
+  });
+  if (!res.ok) throw new Error(`token poll failed: ${res.status}`);
+  return (await res.json()) as PollResult;
+}
+
+/** Resolve a reviewer token to identity (CORS-OK; runs in the browser). */
+export async function identifyReviewer(token: string, f: typeof fetch = fetch): Promise<ReviewerIdentity> {
+  const res = await f("https://api.github.com/user", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) throw new Error(`identify failed: ${res.status}`);
+  const j = (await res.json()) as { login: string; name: string | null; avatar_url?: string };
+  return { login: j.login, name: j.name ?? j.login, avatarUrl: j.avatar_url };
+}
+
+export type LoginEvent =
+  | { type: "code"; grant: DeviceCodeGrant }
+  | { type: "authorized"; token: string }
+  | { type: "denied" }
+  | { type: "expired" }
+  | { type: "error"; message: string };
+
+export interface LoginDriverOptions {
+  authBase: string;
+  /** Called with the user-code grant to show the reviewer, then on terminal events. */
+  onEvent: (e: LoginEvent) => void;
+  /** Abort polling (e.g. the reviewer closed the dialog). */
+  shouldStop?: () => boolean;
+  /** Injected sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run the full device-flow login: request a code, surface it via onEvent, then
+ * poll until authorized / denied / expired. Returns the token on success, null
+ * otherwise. Honors slow_down (backs off) and shouldStop (reviewer cancelled).
+ */
+export async function runDeviceLogin(opts: LoginDriverOptions): Promise<string | null> {
+  const f = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let grant: DeviceCodeGrant;
+  try {
+    grant = await requestDeviceCode(opts.authBase, f);
+  } catch (e) {
+    opts.onEvent({ type: "error", message: e instanceof Error ? e.message : String(e) });
+    return null;
+  }
+  opts.onEvent({ type: "code", grant });
+  let interval = grant.intervalSeconds;
+  const deadline = Date.now() + grant.expiresInSeconds * 1000;
+  // NOTE: Date.now() here is runtime-only (browser), not in a workflow script.
+  while (Date.now() < deadline) {
+    if (opts.shouldStop?.()) return null;
+    await sleep(interval * 1000);
+    let result: PollResult;
+    try {
+      result = await pollAccessToken(opts.authBase, grant.deviceCode, f);
+    } catch (e) {
+      opts.onEvent({ type: "error", message: e instanceof Error ? e.message : String(e) });
+      return null;
+    }
+    switch (result.status) {
+      case "authorized":
+        opts.onEvent({ type: "authorized", token: result.token });
+        return result.token;
+      case "pending":
+        break;
+      case "slow_down":
+        interval = result.intervalSeconds;
+        break;
+      case "denied":
+        opts.onEvent({ type: "denied" });
+        return null;
+      case "expired":
+        opts.onEvent({ type: "expired" });
+        return null;
+    }
+  }
+  opts.onEvent({ type: "expired" });
+  return null;
+}

--- a/packages/review-overlay/src/selector.test.ts
+++ b/packages/review-overlay/src/selector.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect } from "vitest";
-import { extractSelector } from "./selector.js";
+import { extractSelector, resolveStoredSelector } from "./selector.js";
 
 function root(html: string): HTMLElement {
   document.body.innerHTML = html;
@@ -96,6 +96,52 @@ describe("extractSelector — strategy order", () => {
     // span has no id/testid/role/classes — xpath fallback
     expect(r.strategy).toBe("xpath");
     expect(r.selector).toMatch(/^\/html\/body\//);
+  });
+
+  it("xpath has no double-body and round-trips back to the same element", () => {
+    const body = root('<div><section><span>x</span></section></div>');
+    const span = body.querySelector("span")!;
+    const r = extractSelector(span);
+    expect(r.strategy).toBe("xpath");
+    // regression: the prefix is `/html/body/`, never `/html/body/body/`
+    expect(r.selector).not.toMatch(/\/html\/body\/body\//);
+    const resolved = resolveStoredSelector(document, r.selector, r.fallbackSelector);
+    expect(resolved?.element).toBe(span);
+  });
+});
+
+describe("resolveStoredSelector — xpath + legacy tolerance", () => {
+  it("resolves a well-formed xpath via document.evaluate", () => {
+    const body = root('<div><p>a</p><p id="want">b</p></div>');
+    const target = body.querySelector("#want")!;
+    const resolved = resolveStoredSelector(document, "/html/body/div/p[2]", null);
+    expect(resolved?.element).toBe(target);
+  });
+
+  it("tolerates the legacy /html/body/body/… double-body", () => {
+    const body = root('<div><span>x</span></div>');
+    const span = body.querySelector("span")!;
+    // an old capture stored before the byXPath fix
+    const resolved = resolveStoredSelector(document, "/html/body/body/div/span", null);
+    expect(resolved?.element).toBe(span);
+  });
+
+  it("resolves CSS selectors unchanged", () => {
+    const body = root('<button data-testid="save">Save</button>');
+    const resolved = resolveStoredSelector(document, '[data-testid="save"]', null);
+    expect(resolved?.element).toBe(body.firstElementChild);
+  });
+
+  it("returns null when neither primary nor fallback resolve", () => {
+    root('<div>nothing</div>');
+    expect(resolveStoredSelector(document, "/html/body/div/span[9]", "#missing")).toBeNull();
+  });
+
+  it("falls back to the secondary selector when primary misses", () => {
+    const body = root('<button data-testid="real">x</button>');
+    const resolved = resolveStoredSelector(document, "/html/body/div/nope", '[data-testid="real"]');
+    expect(resolved?.element).toBe(body.firstElementChild);
+    expect(resolved?.usedFallback).toBe(true);
   });
 });
 

--- a/packages/review-overlay/src/selector.ts
+++ b/packages/review-overlay/src/selector.ts
@@ -132,7 +132,15 @@ function byTagClasses(el: Element): string | null {
 function byXPath(el: Element): string {
   const parts: string[] = [];
   let node: Element | null = el;
-  while (node && node.nodeType === 1 && node.tagName.toLowerCase() !== "html") {
+  // Stop at <body> (and <html>): the `/html/body/` prefix below already
+  // accounts for them. Including <body> here produced a `/html/body/body/…`
+  // double-body that no resolver could match.
+  while (
+    node &&
+    node.nodeType === 1 &&
+    node.tagName.toLowerCase() !== "html" &&
+    node.tagName.toLowerCase() !== "body"
+  ) {
     const parent: Element | null = node.parentElement;
     if (!parent) break;
     const tag = node.tagName.toLowerCase();
@@ -247,24 +255,55 @@ function cssEscapeAttr(s: string): string {
  * Wraps both querySelector calls in try/catch so a malformed stored
  * selector doesn't blow up the pin pass.
  */
+/** An XPath selector starts with `/` or `(/` — CSS selectors never do. */
+function looksLikeXPath(sel: string): boolean {
+  const s = sel.trimStart();
+  return s.startsWith("/") || s.startsWith("(/");
+}
+
+/**
+ * Resolve one stored selector — CSS via querySelector, XPath via
+ * document.evaluate. querySelector THROWS on an XPath string, which is why
+ * xpath-strategy comments never used to resolve (they all fell through to
+ * "drifted" and froze at their capture bbox).
+ *
+ * Also tolerates the legacy `/html/body/body/…` double-body that older
+ * captures emitted, so previously-filed comments resolve too.
+ */
+function resolveOne(doc: Document, sel: string): Element | null {
+  if (looksLikeXPath(sel)) {
+    const candidates = [sel];
+    if (sel.includes("/html/body/body/")) {
+      candidates.push(sel.replace("/html/body/body/", "/html/body/"));
+    }
+    for (const xp of candidates) {
+      try {
+        const r = doc.evaluate(xp, doc, null, /* FIRST_ORDERED_NODE_TYPE */ 9, null);
+        const node = r.singleNodeValue;
+        if (node && node.nodeType === 1) return node as Element;
+      } catch {
+        /* malformed xpath — try the next candidate */
+      }
+    }
+    return null;
+  }
+  try {
+    return doc.querySelector(sel);
+  } catch {
+    return null;
+  }
+}
+
 export function resolveStoredSelector(
   doc: Document,
   selector: string,
   fallbackSelector: string | null
 ): { element: Element; usedFallback: boolean } | null {
-  try {
-    const primary = doc.querySelector(selector);
-    if (primary) return { element: primary, usedFallback: false };
-  } catch {
-    /* malformed selector — try fallback */
-  }
+  const primary = resolveOne(doc, selector);
+  if (primary) return { element: primary, usedFallback: false };
   if (fallbackSelector) {
-    try {
-      const fb = doc.querySelector(fallbackSelector);
-      if (fb) return { element: fb, usedFallback: true };
-    } catch {
-      /* malformed fallback too */
-    }
+    const fb = resolveOne(doc, fallbackSelector);
+    if (fb) return { element: fb, usedFallback: true };
   }
   return null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   packages/review-overlay:
     devDependencies:
+      '@slowcook-ai/core':
+        specifier: workspace:^
+        version: link:../core
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,15 +141,18 @@ importers:
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.15)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.2.6
-        version: 19.2.6
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
         specifier: ^19.2.7
-        version: 19.2.7(react@19.2.6)
+        version: 19.2.7(react@19.2.7)
 
   packages/stack-ts:
     dependencies:
@@ -769,6 +772,11 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
@@ -1042,6 +1050,10 @@ packages:
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
@@ -1680,6 +1692,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
   '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
@@ -1960,7 +1976,14 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react@19.2.6: {}
+
+  react@19.2.7: {}
 
   require-from-string@2.0.2: {}
 


### PR DESCRIPTION
## Why
GUCDI mocks are full navigable apps (Living Coded Requirements) with their own router — not scenario pickers. Review must let a human roam **every route** and comment **anywhere**.

Two halves:
1. **Routing (0.6.0, original):** overlay shows on every route incl. `/`; each comment carries `pathname`/`route_query`; plate keys amendments to the comment's route.
2. **Click handling (0.8.0, this update):** comment mode used to trap *every* page click into a composer, exitable only with **Escape** — so mobile reviewers (no Esc key) were locked out of navigating. Reported live by a reviewer: *"anywhere I click I see a comment pop-up… on mobile I'd be forever locked out of navigating."*

## What (0.8.0 — arm-to-pick free nav)
**`@slowcook-ai/review-overlay`**
- A review session now **navigates the app freely**. Page links/buttons work; the overlay no longer captures clicks by default.
- To comment, the reviewer **arms a single element-pick** — the "📍 Pin a comment" button. Only while armed is the next click intercepted; after the pick (composer opens) it **auto-disarms** back to free navigation. One comment = one arm.
- **Mobile-safe exits at every layer** (no reliance on Escape): an on-screen **armed banner** ("tap an element… / tap here to cancel"), the composer **Cancel** button, and the toolbar **🧭 Reviewing** toggle.
- **Graduated Escape**: closes an open composer first, then disarms a live pick, then exits the review session — instead of nuking the whole mode at once.
- Page tint shows **only while a pick is live** (armed comment, or approve) — free-nav is untinted.
- Toolbar relabel: `💬 Review` ⇄ `🧭 Reviewing`, plus `📍 Pin a comment` / `✕ Cancel pick`.

## Tests
- review-overlay **65/65** green; `tsc -b` clean. (No behavioural regressions; interaction is DOM-event driven.)

## Remaining (follow-up, needs publish)
- Publish **review-overlay 0.8.0** so consumers (e.g. the delgoosh mock, currently pinned 0.7.3) can bump.
- Mount `<SlowcookReviewOverlay reviewMode="lcr" />` in the **Vite** mock template (today only the Next.js template mounts it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)