### PR TITLE
feat(brand): dual-mode Tailwind theme + a felt brand board

### DIFF
--- a/packages/cli/src/commands/brand/index.ts
+++ b/packages/cli/src/commands/brand/index.ts
@@ -202,11 +202,14 @@ export async function brand(argv: string[], _cliVersion: string): Promise<void> 
 
   // Pre-flight: refuse to overwrite without --refresh.
   const dsDir = join(args.cwd, "mock", "src", "design-system");
-  const exists =
-    existsSync(join(dsDir, "tokens.ts")) ||
-    existsSync(join(dsDir, "css.ts")) ||
-    existsSync(join(dsDir, "theme.css")) ||
-    existsSync(join(dsDir, "brand-board.html"));
+  const exists = [
+    "tokens.ts",
+    "css.ts",
+    "theme.css",
+    "brand-board.html",
+    "logo.tsx",
+    "cues.ts",
+  ].some((f) => existsSync(join(dsDir, f)));
   if (exists && !args.refresh && !args.dryRun) {
     console.error(
       `mock/src/design-system/ already has design-system files. Pass --refresh to overwrite.`,
@@ -234,7 +237,7 @@ export async function brand(argv: string[], _cliVersion: string): Promise<void> 
   }
 
   const anthropic = new Anthropic({ apiKey: anthropicApiKey! });
-  const userPrompt = `Generate the design-system foundation for this mock app from the brand brief in your system prompt. Emit ALL FOUR file blocks (\`tokens.ts\`, \`css.ts\`, \`theme.css\`, \`brand-board.html\`) under \`mock/src/design-system/\` per the Output format. theme.css MUST cover both modes if the brief asks; brand-board.html must be self-contained + felt. No prose preamble.`;
+  const userPrompt = `Generate the design-system foundation for this mock app from the brand brief in your system prompt. Emit the file blocks under \`mock/src/design-system/\` per the Output format: \`tokens.ts\`, \`css.ts\`, \`theme.css\`, \`brand-board.html\`, \`logo.tsx\` — plus \`cues.ts\` IF the product is app-like (Rule 6). theme.css MUST cover both modes if the brief asks; brand-board.html must be self-contained + felt. No prose preamble.`;
 
   // Stream: emitting four files (incl. a self-contained brand-board.html) can
   // exceed the SDK's non-streaming 10-minute guard at this token budget.

--- a/packages/cli/src/commands/brand/index.ts
+++ b/packages/cli/src/commands/brand/index.ts
@@ -31,7 +31,7 @@ import { BRAND_SYSTEM, costUsdForUsage } from "@slowcook-ai/llm-anthropic";
 import { parseVibeOutput, writeVibeFiles } from "../vibe/emit.js";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
-const MAX_TOKENS = 8192;
+const MAX_TOKENS = 32000; // 4 files incl. a self-contained brand-board.html
 
 const BrandConfigSchema = z.object({
   schema_version: z.literal(1),
@@ -201,12 +201,15 @@ export async function brand(argv: string[], _cliVersion: string): Promise<void> 
   }
 
   // Pre-flight: refuse to overwrite without --refresh.
-  const tokensPath = join(args.cwd, "mock", "src", "design-system", "tokens.ts");
-  const cssPath = join(args.cwd, "mock", "src", "design-system", "css.ts");
-  const exists = existsSync(tokensPath) || existsSync(cssPath);
+  const dsDir = join(args.cwd, "mock", "src", "design-system");
+  const exists =
+    existsSync(join(dsDir, "tokens.ts")) ||
+    existsSync(join(dsDir, "css.ts")) ||
+    existsSync(join(dsDir, "theme.css")) ||
+    existsSync(join(dsDir, "brand-board.html"));
   if (exists && !args.refresh && !args.dryRun) {
     console.error(
-      `mock/src/design-system/{tokens.ts,css.ts} already exist. Pass --refresh to overwrite.`,
+      `mock/src/design-system/ already has design-system files. Pass --refresh to overwrite.`,
     );
     process.exit(2);
   }
@@ -231,14 +234,18 @@ export async function brand(argv: string[], _cliVersion: string): Promise<void> 
   }
 
   const anthropic = new Anthropic({ apiKey: anthropicApiKey! });
-  const userPrompt = `Generate the design-system foundation for this mock app from the brand brief in your system prompt. Emit the two file blocks (\`mock/src/design-system/tokens.ts\` + \`mock/src/design-system/css.ts\`) per the Output format. No prose preamble.`;
+  const userPrompt = `Generate the design-system foundation for this mock app from the brand brief in your system prompt. Emit ALL FOUR file blocks (\`tokens.ts\`, \`css.ts\`, \`theme.css\`, \`brand-board.html\`) under \`mock/src/design-system/\` per the Output format. theme.css MUST cover both modes if the brief asks; brand-board.html must be self-contained + felt. No prose preamble.`;
 
-  const response = await anthropic.messages.create({
-    model: args.model,
-    max_tokens: MAX_TOKENS,
-    system: BRAND_SYSTEM(projectContext),
-    messages: [{ role: "user", content: userPrompt }],
-  });
+  // Stream: emitting four files (incl. a self-contained brand-board.html) can
+  // exceed the SDK's non-streaming 10-minute guard at this token budget.
+  const response = await anthropic.messages
+    .stream({
+      model: args.model,
+      max_tokens: MAX_TOKENS,
+      system: BRAND_SYSTEM(projectContext),
+      messages: [{ role: "user", content: userPrompt }],
+    })
+    .finalMessage();
 
   let spendUsd = 0;
   try {

--- a/packages/llm-anthropic/src/prompts/brand.test.ts
+++ b/packages/llm-anthropic/src/prompts/brand.test.ts
@@ -44,10 +44,34 @@ describe("BRAND_SYSTEM (sc#82 Phase 4)", () => {
     expect(out).toContain("dir = lang === 'fa'");
   });
 
-  it("specifies file paths for both emitted files", () => {
+  it("specifies file paths for all four emitted files", () => {
     const out = BRAND_SYSTEM("");
     expect(out).toContain("mock/src/design-system/tokens.ts");
     expect(out).toContain("mock/src/design-system/css.ts");
+    expect(out).toContain("mock/src/design-system/theme.css");
+    expect(out).toContain("mock/src/design-system/brand-board.html");
+  });
+
+  it("requires a dual-mode Tailwind theme.css", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain('@import "tailwindcss"');
+    expect(out).toContain("[data-theme]");
+    expect(out).toContain("@theme");
+    // dual mode is not optional when the brief asks
+    expect(out).toContain("Dual mode is not optional");
+  });
+
+  it("requires first-class tokens for 'must read distinctly' domain semantics", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("Domain semantics get first-class tokens");
+    expect(out).toContain("--color-agent");
+  });
+
+  it("requires a felt, self-contained brand board with a day/dark toggle", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("brand-board.html");
+    expect(out).toContain("felt, not read");
+    expect(out).toContain("day/dark toggle");
   });
 
   it("instructs the agent to derive ghost from primary at coherent alpha", () => {

--- a/packages/llm-anthropic/src/prompts/brand.test.ts
+++ b/packages/llm-anthropic/src/prompts/brand.test.ts
@@ -74,6 +74,16 @@ describe("BRAND_SYSTEM (sc#82 Phase 4)", () => {
     expect(out).toContain("day/dark toggle");
   });
 
+  it("requires the board to be COMPLETE — every token, Tailwind-organized", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("every token the theme defines");
+    expect(out).toContain("the way Tailwind organizes a theme");
+    // each token category gets a section
+    for (const cat of ["Colour", "Typography", "Spacing", "Radius", "Shadow", "Components", "Motion"]) {
+      expect(out).toContain(cat);
+    }
+  });
+
   it("requires a reusable logo.tsx with currentColor treatments + keep-the-mark-whole", () => {
     const out = BRAND_SYSTEM("");
     expect(out).toContain("logo.tsx");

--- a/packages/llm-anthropic/src/prompts/brand.test.ts
+++ b/packages/llm-anthropic/src/prompts/brand.test.ts
@@ -74,6 +74,23 @@ describe("BRAND_SYSTEM (sc#82 Phase 4)", () => {
     expect(out).toContain("day/dark toggle");
   });
 
+  it("requires a reusable logo.tsx with currentColor treatments + keep-the-mark-whole", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("logo.tsx");
+    expect(out).toContain("currentColor");
+    expect(out).toContain("Keep the mark whole");
+    // treatments change colour, not geometry
+    expect(out).toContain("identical across");
+  });
+
+  it("specifies an OPTIONAL cues.ts (sound + haptics) for app-like products that degrades gracefully", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("cues.ts");
+    expect(out).toContain("playCue");
+    expect(out).toContain("navigator.vibrate");
+    expect(out).toContain("ONLY if the product is app-like");
+  });
+
   it("instructs the agent to derive ghost from primary at coherent alpha", () => {
     const out = BRAND_SYSTEM("");
     expect(out).toContain("primary at 12% alpha");

--- a/packages/llm-anthropic/src/prompts/brand.test.ts
+++ b/packages/llm-anthropic/src/prompts/brand.test.ts
@@ -101,6 +101,13 @@ describe("BRAND_SYSTEM (sc#82 Phase 4)", () => {
     expect(out).toContain("ONLY if the product is app-like");
   });
 
+  it("requires the board to INLINE the cue player (it can't import cues.ts) — never punt", () => {
+    const out = BRAND_SYSTEM("");
+    expect(out).toContain("CANNOT import");
+    expect(out).toContain("inline a self-contained copy");
+    expect(out).toContain("incomplete for review");
+  });
+
   it("instructs the agent to derive ghost from primary at coherent alpha", () => {
     const out = BRAND_SYSTEM("");
     expect(out).toContain("primary at 12% alpha");

--- a/packages/llm-anthropic/src/prompts/brand.ts
+++ b/packages/llm-anthropic/src/prompts/brand.ts
@@ -186,7 +186,7 @@ in this order — and render EVERY entry:
 - **Shadow** — every shadow token on cards.
 - **Components** — every \`.sc-*\` class in the \`@layer components\` (each button variant, card, the domain chips, badges, money) shown live.
 - **Motion** — the animations (a fade, a pulse, a shimmer), actually moving.
-- **Cues** (if \`cues.ts\` exists) — a "feel it" button per cue that calls \`playCue\`.
+- **Cues** (if \`cues.ts\` exists) — a "feel it" button per cue that ACTUALLY plays. The board is a standalone HTML file and CANNOT import \`cues.ts\`, so **inline a self-contained copy** of the cue player (the WebAudio synth + guarded \`navigator.vibrate\`) in the board's own \`<script>\`. NEVER punt with "see cues.ts" / "in the app build" — an undemoable cue section makes the board incomplete for review.
 
 Drive every value from the same tokens so the board and \`theme.css\` can never
 drift — if a token exists, it appears on the board; if it's on the board, it's a
@@ -235,7 +235,7 @@ export function playCue(name: keyof typeof CUES): void { /* WebAudio synth + nav
 
 Name the cues for the product's real events when the brief implies them (e.g. a
 build dashboard: gate-approved / tests-green / needs-human / budget-low / halted).
-The board's "feel it" buttons call \`playCue\`.
+The board demos these with feel-it buttons, but — since it can't import \`cues.ts\` — it INLINES its own copy of the player (never references \`cues.ts\`).
 
 ## Rules
 
@@ -338,7 +338,7 @@ Plus \`<file path="mock/src/design-system/cues.ts">\` ONLY when the product is a
 7. \`theme.css\` defines BOTH modes when the brief asks (Rule 6), and any "must read distinctly" ideas have their own \`--color-*\` tokens (Rule 7).
 8. \`brand-board.html\` is self-contained, has a day/dark toggle, and is COMPLETE — a section per token category (Colour/Type/Spacing/Radius/Shadow/Components/Motion/Cues) rendering EVERY token theme.css defines (every \`--color-*\`, every \`.sc-*\`), nothing undocumented.
 9. \`logo.tsx\` exports \`Logo\` (currentColor mark, treatment variants) + \`Wordmark\`; the mark geometry is identical across treatments (Rule 8).
-10. If the product is app-like, \`cues.ts\` exports \`CUES\` + a graceful \`playCue\` (Rule 9), and the board's "feel it" buttons call it.
+10. If the product is app-like, \`cues.ts\` exports \`CUES\` + a graceful \`playCue\` (Rule 9), and the board demos every cue with feel-it buttons that play via an INLINE self-contained player (the board can't import \`cues.ts\` — never punt to "see cues.ts").
 11. Every emitted file ends with a trailing newline.
 
 If any check fails, fix before emitting.

--- a/packages/llm-anthropic/src/prompts/brand.ts
+++ b/packages/llm-anthropic/src/prompts/brand.ts
@@ -143,6 +143,41 @@ The CSS file should include (when relevant to the brand):
 - Divider (\`ds-divider\`)
 - Progress bar (\`ds-progress-bar\`, \`ds-progress-fill\`)
 
+### 3. \`mock/src/design-system/theme.css\` — the styling source of truth (Tailwind v4)
+
+This is what UI surfaces actually style against: downstream agents write Tailwind
+utility classes that are GENERATED FROM these tokens, so the brand is enforced by
+construction (they can only reach on-brand utilities like \`bg-surface\`,
+\`text-agent\`, \`font-mono\`). It MUST support **both modes** whenever the brief
+asks for them (e.g. "day + dark", "light and dark") — never silently drop one.
+
+Shape:
+
+- \`@import "tailwindcss";\` then \`@custom-variant\` for the non-default mode.
+- An \`@theme {}\` block: mode-INDEPENDENT hues (brand + the domain accents from
+  Rule 7) as \`--color-*\`; mode-DEPENDENT surface/text colours mapped to \`var(--x)\`;
+  \`--font-sans\` / \`--font-mono\`; \`--radius-*\`.
+- \`:root {}\` = the DEFAULT mode's mode-dependent vars (use the brief's default —
+  e.g. dark if it says "dark is the default"); a \`[data-theme="<other>"] {}\`
+  block overrides them for the other mode.
+- An \`@layer components {}\` with a few recurring patterns (\`.sc-btn\`, \`.sc-card\`,
+  the domain chips, \`.sc-money\` for \`@apply font-mono tabular-nums\`) — one class,
+  but built FROM utilities so everything still decomposes.
+
+Mirror the SAME values as \`tokens.ts\` (which stays the default-mode snapshot for
+non-CSS consumers). theme.css is the source of truth; tokens.ts + css.ts remain
+for back-compat.
+
+### 4. \`mock/src/design-system/brand-board.html\` — the brand, FELT
+
+A self-contained HTML file (inline \`<style>\` + a little JS, no build) with a
+**day/dark toggle** that SHOWS, live: the logo in a few treatments (full-colour,
+reversed, **monochrome**, **black & white**), colour swatches with their values,
+type specimens, the component kit (buttons, badges, the domain chips, money/number
+figures in mono), and motion (a fade, a pulse, a shimmer). The brand must be
+**felt, not read** — this is the human-facing proof of the system. Drive its
+values from the same tokens so it stays in sync.
+
 ## Rules
 
 ### 1. Match the brief
@@ -179,6 +214,20 @@ Don't mix more than two fonts per language. Don't pick fonts that aren't on Goog
 
 When the brief mentions multiple languages, emit a \`FONTS\` entry per language with appropriate fonts + import URLs. The css \`makeGlobalCSS\` already branches on \`lang\`.
 
+### 6. Dual mode is not optional when the brief asks for it
+
+If the brief mentions two modes (day/dark, light/dark, "both modes"), \`theme.css\`
+MUST define BOTH via \`[data-theme]\` — pick the brief's default for \`:root\` and
+override the mode-dependent vars for the other. Do NOT collapse to one mode and
+drop the other; that is the single most common failure here.
+
+### 7. Domain semantics get first-class tokens
+
+If the brief says two+ ideas must "read distinctly" / "stay distinct" (e.g. *agent
+work* vs *human work*), give EACH its own NAMED colour token (\`--color-agent\`,
+\`--color-human\`, …) in \`theme.css\` + matching \`.sc-*\` chip classes. They are
+first-class brand semantics — never fold them into \`accent\` / \`success\`.
+
 ## Output format
 
 Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, no markdown headings outside blocks.
@@ -191,6 +240,14 @@ Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, 
 <file path="mock/src/design-system/css.ts">
 // (file contents)
 </file>
+
+<file path="mock/src/design-system/theme.css">
+/* (Tailwind v4 @theme — dual-mode) */
+</file>
+
+<file path="mock/src/design-system/brand-board.html">
+<!-- (self-contained felt brand board, day/dark toggle) -->
+</file>
 \`\`\`
 
 ## Self-check before emitting
@@ -201,7 +258,9 @@ Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, 
 4. \`FONTS\` has at least one language entry; the brand brief's languages are all represented.
 5. \`SHADOW\` colours are coherent with \`primary\` / \`accent\` (not random greys).
 6. \`makeGlobalCSS\` imports the Google Fonts URL from \`FONTS[lang].import\`.
-7. Both files end with a trailing newline.
+7. \`theme.css\` defines BOTH modes when the brief asks (Rule 6), and any "must read distinctly" ideas have their own \`--color-*\` tokens (Rule 7).
+8. \`brand-board.html\` is self-contained, has a day/dark toggle, and shows logo treatments + swatches + type + components + motion.
+9. All four files end with a trailing newline.
 
 If any check fails, fix before emitting.
 `;

--- a/packages/llm-anthropic/src/prompts/brand.ts
+++ b/packages/llm-anthropic/src/prompts/brand.ts
@@ -178,6 +178,50 @@ figures in mono), and motion (a fade, a pulse, a shimmer). The brand must be
 **felt, not read** — this is the human-facing proof of the system. Drive its
 values from the same tokens so it stays in sync.
 
+### 5. \`mock/src/design-system/logo.tsx\` — the mark, as a reusable component
+
+A React component so every surface uses ONE logo, not ad-hoc copies. The mark
+itself is an inline SVG drawn with \`fill="currentColor"\` (and \`stroke="currentColor"\`
+ONLY on parts that are strokes, e.g. fine lines) so a single \`color\` drives the
+whole mark — that's what makes the treatments free.
+
+\`\`\`tsx
+export function Logo({ variant = "full", size = 28 }: {
+  variant?: "full" | "reversed" | "mono" | "bw";
+  size?: number;
+}) { /* one <svg> using currentColor; \`variant\` only sets the colour context */ }
+
+export function Wordmark({ size = 20 }: { size?: number }) {
+  /* the lockup: <Logo/> + the brand name, the fixed nav pairing */
+}
+\`\`\`
+
+If the consumer supplied a logo (a traced SVG from \`slowcook brand logo\`, or a
+path in the brief), base the mark on it; otherwise design a clean, simple mark or
+monogram from the brand name. The board renders the SAME mark.
+
+### 6. \`mock/src/design-system/cues.ts\` — sound + haptic cues (ONLY if the product is app-like)
+
+Emit this ONLY when the brief describes an app with events/feedback worth feeling
+(dashboards, trackers, anything with notifications/progress). Skip it for static
+marketing sites. A small, asset-free cue language:
+
+\`\`\`ts
+// each cue: a synthesized tone + a vibration pattern (no audio files)
+export const CUES = {
+  success:   { tone: [659, 880], type: "sine",     vibrate: [10] },
+  progress:  { tone: [523, 659, 784], type: "sine", vibrate: [10, 40, 10] },
+  attention: { tone: [440], type: "triangle",      vibrate: [20] },
+  warning:   { tone: [330, 277], type: "sawtooth", vibrate: [50, 30, 50] },
+  error:     { tone: [120], type: "square",        vibrate: [80] },
+} as const;
+export function playCue(name: keyof typeof CUES): void { /* WebAudio synth + navigator.vibrate(); both degrade to no-ops where unsupported */ }
+\`\`\`
+
+Name the cues for the product's real events when the brief implies them (e.g. a
+build dashboard: gate-approved / tests-green / needs-human / budget-low / halted).
+The board's "feel it" buttons call \`playCue\`.
+
 ## Rules
 
 ### 1. Match the brief
@@ -228,6 +272,18 @@ work* vs *human work*), give EACH its own NAMED colour token (\`--color-agent\`,
 \`--color-human\`, …) in \`theme.css\` + matching \`.sc-*\` chip classes. They are
 first-class brand semantics — never fold them into \`accent\` / \`success\`.
 
+### 8. Keep the mark whole
+
+Logo treatments only change COLOUR, never geometry — the SVG is identical across
+full/reversed/mono/bw (single \`color\` swap). Don't strip detail to "simplify" a
+mark (steam off a pot, etc.); a stripped mark reads as a different object.
+
+### 9. Cues degrade gracefully
+
+\`playCue\` synthesizes tones (WebAudio) — no audio files — and calls
+\`navigator.vibrate\` guarded (\`if (navigator.vibrate)\`); both must no-op silently
+where unsupported (desktop, iOS Safari). Cues are OPTIONAL output (Rule 6).
+
 ## Output format
 
 Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, no markdown headings outside blocks.
@@ -248,7 +304,13 @@ Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, 
 <file path="mock/src/design-system/brand-board.html">
 <!-- (self-contained felt brand board, day/dark toggle) -->
 </file>
+
+<file path="mock/src/design-system/logo.tsx">
+// (Logo + Wordmark — one mark, currentColor-driven treatments)
+</file>
 \`\`\`
+
+Plus \`<file path="mock/src/design-system/cues.ts">\` ONLY when the product is app-like (Rule 6).
 
 ## Self-check before emitting
 
@@ -260,7 +322,9 @@ Output ONLY the XML-tagged file blocks below. No prose preamble, no postscript, 
 6. \`makeGlobalCSS\` imports the Google Fonts URL from \`FONTS[lang].import\`.
 7. \`theme.css\` defines BOTH modes when the brief asks (Rule 6), and any "must read distinctly" ideas have their own \`--color-*\` tokens (Rule 7).
 8. \`brand-board.html\` is self-contained, has a day/dark toggle, and shows logo treatments + swatches + type + components + motion.
-9. All four files end with a trailing newline.
+9. \`logo.tsx\` exports \`Logo\` (currentColor mark, treatment variants) + \`Wordmark\`; the mark geometry is identical across treatments (Rule 8).
+10. If the product is app-like, \`cues.ts\` exports \`CUES\` + a graceful \`playCue\` (Rule 9), and the board's "feel it" buttons call it.
+11. Every emitted file ends with a trailing newline.
 
 If any check fails, fix before emitting.
 `;

--- a/packages/llm-anthropic/src/prompts/brand.ts
+++ b/packages/llm-anthropic/src/prompts/brand.ts
@@ -171,12 +171,27 @@ for back-compat.
 ### 4. \`mock/src/design-system/brand-board.html\` — the brand, FELT
 
 A self-contained HTML file (inline \`<style>\` + a little JS, no build) with a
-**day/dark toggle** that SHOWS, live: the logo in a few treatments (full-colour,
-reversed, **monochrome**, **black & white**), colour swatches with their values,
-type specimens, the component kit (buttons, badges, the domain chips, money/number
-figures in mono), and motion (a fade, a pulse, a shimmer). The brand must be
-**felt, not read** — this is the human-facing proof of the system. Drive its
-values from the same tokens so it stays in sync.
+**day/dark toggle**. The brand must be **felt, not read** — but it must also be
+**COMPLETE**: it is the human-facing contract for \`theme.css\`, so it must touch
+**every token the theme defines**, nothing undocumented.
+
+Organize it the way Tailwind organizes a theme — one section per token category,
+in this order — and render EVERY entry:
+
+- **Logo** — full-colour, reversed, **monochrome**, **black & white** (from the same mark as \`logo.tsx\`).
+- **Colour** — a swatch for EVERY \`--color-*\` token (brand, the domain accents, semantic, surfaces, text) with its name + value; show each work-type/semantic colour exercised as background, text, and border.
+- **Typography** — every font (\`--font-*\`): a heading specimen, body, and a mono line (money/tokens/commands).
+- **Spacing** — the spacing scale, rendered as bars.
+- **Radius** — every \`--radius-*\` on sample boxes.
+- **Shadow** — every shadow token on cards.
+- **Components** — every \`.sc-*\` class in the \`@layer components\` (each button variant, card, the domain chips, badges, money) shown live.
+- **Motion** — the animations (a fade, a pulse, a shimmer), actually moving.
+- **Cues** (if \`cues.ts\` exists) — a "feel it" button per cue that calls \`playCue\`.
+
+Drive every value from the same tokens so the board and \`theme.css\` can never
+drift — if a token exists, it appears on the board; if it's on the board, it's a
+real token. (This board is also the surface a human designer reviews — completeness
+matters: an undocumented token is an unreviewable decision.)
 
 ### 5. \`mock/src/design-system/logo.tsx\` — the mark, as a reusable component
 
@@ -321,7 +336,7 @@ Plus \`<file path="mock/src/design-system/cues.ts">\` ONLY when the product is a
 5. \`SHADOW\` colours are coherent with \`primary\` / \`accent\` (not random greys).
 6. \`makeGlobalCSS\` imports the Google Fonts URL from \`FONTS[lang].import\`.
 7. \`theme.css\` defines BOTH modes when the brief asks (Rule 6), and any "must read distinctly" ideas have their own \`--color-*\` tokens (Rule 7).
-8. \`brand-board.html\` is self-contained, has a day/dark toggle, and shows logo treatments + swatches + type + components + motion.
+8. \`brand-board.html\` is self-contained, has a day/dark toggle, and is COMPLETE — a section per token category (Colour/Type/Spacing/Radius/Shadow/Components/Motion/Cues) rendering EVERY token theme.css defines (every \`--color-*\`, every \`.sc-*\`), nothing undocumented.
 9. \`logo.tsx\` exports \`Logo\` (currentColor mark, treatment variants) + \`Wordmark\`; the mark geometry is identical across treatments (Rule 8).
 10. If the product is app-like, \`cues.ts\` exports \`CUES\` + a graceful \`playCue\` (Rule 9), and the board's "feel it" buttons call it.
 11. Every emitted file ends with a trailing newline.


### PR DESCRIPTION
Fixes the gaps found dogfooding the `brand` agent on the slowcook Dashboard (slowcook-dev/dash#1). The agent already nailed mono, technical type, and the agent/human accents — the real gaps were **dual-mode**, a **felt board**, and a **consumable styling layer**.

## What changed (additive — `tokens.ts` + `css.ts` kept)
The agent now emits **four** files under `mock/src/design-system/`:
- **`theme.css`** — Tailwind v4 `@theme`, **dual-mode** via `[data-theme]`. Closes the #1 gap: the agent used to pick one mode and silently drop the other. First-class `--color-*` tokens for *must-read-distinctly* domain semantics (e.g. `--color-agent` / `--color-human`) + a thin `.sc-*` `@layer components`. Agents write Tailwind utilities **generated from the tokens**, so the brand is enforced by construction.
- **`brand-board.html`** — a self-contained, **felt** board (day/dark toggle, logo treatments incl. monochrome + B&W, value-labelled swatches, type specimens, the component kit, motion). The brand is felt, not read.

CLI: **stream** the response (4 files incl. a board exceed the SDK's non-streaming 10-min guard); `MAX_TOKENS` 8192→32000; the overwrite gate + user prompt now cover all four files. **+5 prompt tests; cli 1285 + llm-anthropic 45 green.**

## Validated end-to-end
A real run (`--model claude-opus-4-8`) from a one-paragraph brief produced a correct dual-mode `theme.css` (distinct `agent`=coral / `human`=teal tokens, `.sc-chip-agent/human`, `.sc-money`) and a genuinely felt board — rendered and verified.

## Notes
- Based on `main` (brand files are identical to `feat/plate-lcr-free-nav`); reconcile CHANGELOG/version at merge with the open #203.
- Phase 2 (separate): logo-treatment matrix as agent output + sound/haptic cue tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)