### PR TITLE
fix(menu): robust on large PRDs — stream, retry, normalize, no silent drops

### DIFF
--- a/packages/cli/src/commands/menu/index.ts
+++ b/packages/cli/src/commands/menu/index.ts
@@ -8,12 +8,12 @@
  *
  *   slowcook menu [--prd docs/PRD.md] [--cwd .] [--model <id>] [--dry-run]
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { AnthropicClient, MENU_SYSTEM, type MenuStoryDraft } from "@slowcook-ai/llm-anthropic";
 import { parsePrdInitiatives } from "./prd.js";
 import { assembleStories } from "./assemble.js";
-import { writeSpec, nextStoryId } from "../refine/spec-yaml.js";
+import { writeSpec, nextStoryId, normalizeScenarioArrays } from "../refine/spec-yaml.js";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 
@@ -29,8 +29,12 @@ export function extractStories(text: string): MenuStoryDraft[] {
   const start = body.indexOf("{");
   const end = body.lastIndexOf("}");
   if (start < 0 || end <= start) throw new Error("no JSON object found");
-  const parsed = JSON.parse(body.slice(start, end + 1)) as { stories?: MenuStoryDraft[] };
-  return parsed.stories ?? [];
+  const parsed = JSON.parse(body.slice(start, end + 1)) as { stories?: unknown[] };
+  // Normalise each story the same way refine does (e.g. {given,when,then} →
+  // string), so menu's specs conform to the Spec schema like refine's do.
+  return (parsed.stories ?? []).map(
+    (s) => normalizeScenarioArrays(s as Record<string, unknown>) as unknown as MenuStoryDraft,
+  );
 }
 
 export async function menu(argv: string[], cliVersion: string): Promise<void> {
@@ -66,19 +70,42 @@ export async function menu(argv: string[], cliVersion: string): Promise<void> {
   const userMsg =
     `PRD initiative anchors (cite exactly one per story as prd_anchor): ${initiatives.map((i) => i.anchor).join(", ")}\n\n` +
     `--- PRD ---\n${prdText}`;
-  const resp = await llm.complete({
-    system: MENU_SYSTEM,
-    messages: [{ role: "user", content: userMsg }],
-    model,
-    maxTokens: 16384,
-    cacheSystem: true,
-  });
-
-  let drafts: MenuStoryDraft[];
-  try {
-    drafts = extractStories(resp.text);
-  } catch (e) {
-    console.error(`menu: could not parse agent output as JSON — ${String(e instanceof Error ? e.message : e)}`);
+  // Retry on parse failure: the agent's large JSON is occasionally malformed
+  // (non-deterministic) — a fresh attempt usually succeeds. Stream so big
+  // outputs aren't truncated.
+  let drafts: MenuStoryDraft[] | undefined;
+  let lastErr: unknown;
+  let lastText = "";
+  const ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= ATTEMPTS && !drafts; attempt++) {
+    const resp = await llm.complete({
+      system: MENU_SYSTEM,
+      messages: [{ role: "user", content: userMsg }],
+      model,
+      maxTokens: 64000,
+      cacheSystem: true,
+      stream: true,
+    });
+    lastText = resp.text;
+    try {
+      drafts = extractStories(resp.text);
+    } catch (e) {
+      lastErr = e;
+      if (attempt < ATTEMPTS) {
+        console.warn(`menu: attempt ${attempt}/${ATTEMPTS} — JSON parse failed (${e instanceof Error ? e.message : e}); retrying...`);
+      }
+    }
+  }
+  if (!drafts) {
+    // Dump the raw output so the failure is debuggable, not a silent mystery.
+    let dumpPath = "";
+    try {
+      mkdirSync(resolve(cwd, ".brewing"), { recursive: true });
+      dumpPath = resolve(cwd, ".brewing", "menu-raw.txt");
+      writeFileSync(dumpPath, lastText, "utf8");
+    } catch { /* best-effort */ }
+    console.error(`menu: could not parse agent output as JSON after ${ATTEMPTS} attempts — ${String(lastErr instanceof Error ? lastErr.message : lastErr)}`);
+    if (dumpPath) console.error(`menu: raw agent output written to ${relative(cwd, dumpPath)} (${lastText.length} chars)`);
     process.exit(70);
   }
   if (drafts.length === 0) {

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -246,6 +246,33 @@ export function writeSpec(repoRoot: string, spec: Spec): string {
   return path;
 }
 
+/**
+ * Coerce "helpfully structured" array entries back to strings, matching the
+ * Spec schema (acceptance_scenarios et al. are `string[]`). Agents — menu AND
+ * refine — emit a {given,when,then} BDD object for an entry even when told to
+ * emit strings; normalise at ingestion. Shared so both producers agree.
+ * Non-breaking: well-formed string entries pass through unchanged.
+ */
+export function normalizeScenarioArrays<T extends Record<string, unknown>>(doc: T): T {
+  if (!doc || typeof doc !== "object") return doc;
+  const out = { ...doc } as Record<string, unknown>;
+  for (const key of ["acceptance_scenarios", "preconditions", "invariants", "non_goals"]) {
+    const val = out[key];
+    if (!Array.isArray(val)) continue;
+    out[key] = val.map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (entry && typeof entry === "object") {
+        const o = entry as Record<string, unknown>;
+        const given = o.given ?? o.Given, when = o.when ?? o.When, then = o.then ?? o.Then;
+        if (typeof given === "string" && typeof when === "string" && typeof then === "string")
+          return `Given ${given}, When ${when}, Then ${then}`;
+      }
+      return `[NORMALIZED_OBJECT] ${JSON.stringify(entry)}`;
+    });
+  }
+  return out as T;
+}
+
 export function listActiveSpecs(repoRoot: string): Spec[] {
   const dir = join(repoRoot, SPECS_DIR);
   if (!existsSync(dir)) return [];
@@ -258,8 +285,10 @@ export function listActiveSpecs(repoRoot: string): Spec[] {
     try {
       const s = readSpec(repoRoot, id);
       if (s.status === "active") specs.push(s);
-    } catch {
-      // ignore invalid specs; surface them elsewhere
+    } catch (e) {
+      // (c) Don't silently swallow — a dropped spec that looks like "0 stories"
+      // is a lie that costs hours. Surface it so the operator sees the real cause.
+      console.warn(`  ⚠ skipping invalid spec ${f}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
   return specs;

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -41,6 +41,12 @@ export interface LlmRequest {
   model: string;
   maxTokens?: number;
   temperature?: number;
+  /**
+   * Stream the response and assemble the final message. Required for large
+   * outputs: the SDK refuses a non-streaming request whose `maxTokens` could
+   * take >10 min. Rate-limit headers are not captured when streaming.
+   */
+  stream?: boolean;
 }
 
 export interface LlmUsage {

--- a/packages/llm-anthropic/src/client.ts
+++ b/packages/llm-anthropic/src/client.ts
@@ -108,16 +108,27 @@ export class AnthropicClient implements LlmClient {
     // 0.19.0-α.32 (sc#68) — wrap in try/catch so a 402 from the SDK is
     // re-thrown as the typed `LlmCreditExhaustedError`; other errors
     // pass through unchanged.
-    let result: Awaited<ReturnType<ReturnType<typeof this.client.messages.create>["withResponse"]>>;
+    const params =
+      args.temperature !== undefined
+        ? { ...base, temperature: args.temperature }
+        : base;
+    let response: Anthropic.Messages.Message;
+    let rateLimits: LlmRateLimits | undefined;
     try {
-      result = await this.client.messages
-        .create(
-          args.temperature !== undefined
-            ? { ...base, temperature: args.temperature }
-            : base
-        )
-        .withResponse();
+      if (args.stream) {
+        // Large outputs (e.g. menu over a big PRD) can exceed the SDK's
+        // non-streaming 10-min guard; stream + assemble the final message.
+        // Rate-limit headers aren't surfaced on the stream, so leave them unset.
+        response = await this.client.messages.stream(params).finalMessage();
+        rateLimits = undefined;
+      } else {
+        // 0.19.0-α.31 — withResponse() so we can read `anthropic-ratelimit-*`.
+        const result = await this.client.messages.create(params).withResponse();
+        response = result.data as Anthropic.Messages.Message;
+        rateLimits = extractRateLimits(result.response.headers);
+      }
     } catch (err) {
+      // 0.19.0-α.32 — re-throw a 402 as the typed LlmCreditExhaustedError.
       if (isAnthropicCreditExhausted(err)) {
         const e = err as { status?: number; message?: string };
         throw new LlmCreditExhaustedError({
@@ -129,11 +140,6 @@ export class AnthropicClient implements LlmClient {
       }
       throw err;
     }
-    // We never pass `stream: true`, so `.data` is always a Message, but
-    // the SDK's create() return type is a union with Stream<…>. Narrow
-    // explicitly so the rest of this function keeps the simpler types.
-    const response = result.data as Anthropic.Messages.Message;
-    const rateLimits = extractRateLimits(result.response.headers);
 
     const first = response.content[0];
     if (!first || first.type !== "text") {


### PR DESCRIPTION
The first real GUCDI run on a substantial PRD (15 initiatives, the slowcook Dashboard) surfaced a **chain of `menu` bugs**, each masking the next:

1. **Truncation** — `menu` used `maxTokens: 16384`, non-streaming. A big PRD's story-JSON exceeded it and was cut mid-array → opaque parse error. Added an `LlmRequest.stream` flag + a streaming path in `AnthropicClient` (`.stream().finalMessage()`); menu streams at 64000.
2. **Non-deterministic / oversized output** — **retry ×3**, and on final failure **dump the raw output** to `.brewing/menu-raw.txt` (was an unactionable error).
3. **Specs failed the `Spec` schema** — menu emitted `acceptance_scenarios` as `{given,when,then}` objects, but the schema wants strings (`brew`/`testgen`/`plate` rely on that). `refine` already normalizes via `normalizeEmittedSpec` — **menu didn't**. Extracted a shared `normalizeScenarioArrays` (in `spec-yaml`) used by menu.
4. **`listActiveSpecs` silently swallowed invalid specs** — so 26 real specs looked like **"0 stories"** (a lie that cost hours of debugging). Now warns with the file + reason.

**Validated end-to-end:** `menu` on the 15-initiative PRD → **23 conforming, anchored stories that `greenfield status` sees** (was 0). cli 1285 green.

Follow-up (not in this PR): for *arbitrarily* large PRDs even 64k could truncate — the scalable fix is to **batch the decomposition by initiative**. Filed as the next menu hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)