### PR TITLE
chore(deps): playwright ^1.61 consistently (supersedes #196)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@slowcook-ai/gates": "workspace:^",
     "@anthropic-ai/sdk": "^0.104.1",
     "@octokit/rest": "^22.0.1",
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.61.0",
     "ts-morph": "^28.0.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/gates/package.json
+++ b/packages/gates/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "tsc -b"
   },
   "peerDependencies": {
-    "@playwright/test": "^1.40.0"
+    "@playwright/test": "^1.61.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@playwright/test':
-        specifier: ^1.40.0
-        version: 1.59.1
+        specifier: ^1.61.0
+        version: 1.61.1
       '@slowcook-ai/core':
         specifier: workspace:^
         version: link:../core
@@ -86,8 +86,8 @@ importers:
   packages/gates:
     dependencies:
       '@playwright/test':
-        specifier: ^1.40.0
-        version: 1.59.1
+        specifier: ^1.61.0
+        version: 1.61.1
 
   packages/llm-anthropic:
     dependencies:
@@ -116,7 +116,7 @@ importers:
         version: 19.2.15
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@playwright/test@1.59.1)(react-dom@19.2.7(react@19.2.6))(react@19.2.6)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -627,8 +627,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1021,13 +1021,13 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1595,9 +1595,9 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.61.1
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -1910,7 +1910,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  next@16.2.9(@playwright/test@1.59.1)(react-dom@19.2.7(react@19.2.6))(react@19.2.6):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -1929,7 +1929,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
-      '@playwright/test': 1.59.1
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -1949,11 +1949,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.59.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
#196 bumped `@playwright/test` in one workspace package only → two `playwright-core` versions (1.59.1 + 1.61.0) → `cli/eye/run.ts` passed a 1.61 `Page` where 1.59 was expected (`ElementHandleWaitForSelectorOptions` 'detached' state mismatch) → build-test failed. This bumps the pin to `^1.61.0` in **both** `cli` and `gates` so the tree resolves a **single** playwright-core (1.61.1). Build + cli tests green. **Closes #196.**