### PR TITLE
feat: PRD↔stories interdependency (trace stamp/impact + reconcile)

### DIFF
--- a/docs/plans/prd-stories-interdependency.md
+++ b/docs/plans/prd-stories-interdependency.md
@@ -1,0 +1,101 @@
+# PRD ↔ Stories interdependency (+ comment-driven reconcile)
+
+**Status:** building (deterministic engine first). **Owner:** GUCDI.
+
+## Problem
+
+The PRD is the source of truth; stories are derived (`menu`). The derivation link
+is **not maintained**: when the PRD changes, stories silently rot. `menu` is
+one-shot, so every PRD edit forces *regenerate-all* (churns stable specs, destroys
+hand-tweaks) or *hand-patch* (manual, lossy, no learning signal). Observed live on
+`slowcook-dev/dash`: 8 PRD decisions changed → 12 of 23 specs stale, nothing flagged
+it; the fix was a hand-edit that `garnish` couldn't even attribute.
+
+This is the same disease slowcook already solved one level down (issue→test:
+"side-effects audit", "supersedes is too coarse") — never lifted to **PRD↔spec**.
+
+## Feature (from the founder)
+
+Live, Google-Docs-style review of the PRD by the PM: highlight text → comment →
+the relevant agent replies in dialogue → the change is applied. Stories get the
+same, rendered as a structured table. **Bidirectional:** a comment on a story may
+affect the PRD (and vice-versa); the agent says so.
+
+## Critical evaluation — three corrections (load-bearing)
+
+1. **Propose, don't auto-apply.** The agent emits a *suggested* patch (a diff);
+   "applied" means **applied on human accept** (Google-Docs *suggesting mode*).
+   Auto-writing LLM edits into the source-of-truth violates "humans review
+   judgment" + the side-effects-audit contract.
+2. **One-hop propagation, human-gated.** A change proposes edits to *directly
+   linked* artifacts only. Second-order impact is **flagged as a note**
+   ("this also implies PRD §X"), never auto-chained — otherwise PRD→stories→PRD
+   ping-pongs and never converges.
+3. **One model for prose + structure.** A comment is `(artifact, anchor, body)`;
+   an *anchor* is a **text-range** (PRD prose) or a **YAML-path** (story field/row);
+   a *patch* is a **text edit** or a **structured edit**. Unify once in OSS so both
+   surfaces are lenses.
+
+Plus: **comments + patches are durable repo artifacts**, not dash state ("GitHub is
+the store; the dashboard is the lens"), so CI/headless agents act on the same data.
+
+## OSS ↔ Dash split
+
+| Capability | OSS (CLI) | Dash |
+|---|---|---|
+| PRD+stories model w/ provenance links (`prd_ref` + content-hash) | ✅ | — |
+| Bidirectional link graph (anchor ↔ stories) | ✅ | renders |
+| Deterministic staleness + impact (`trace check` stale, `trace impact`) | ✅ | badges |
+| Comment model `(artifact, anchor, body)` as durable artifact | ✅ | authoring UI |
+| Reconcile agent: comment/change → **proposed** patch + one-hop note | ✅ headless | streams it |
+| Apply = human accepts a patch | ✅ | accept UX |
+| Highlight-to-comment, realtime dialogue, suggesting diff, table view | — | ✅ |
+| Multi-user presence / realtime sync | — | ✅ |
+
+## OSS build — two layers
+
+### Layer 1 — deterministic interdependency engine (this slice, no LLM)
+
+The link is already there: every spec carries `prd_ref.anchor`. We add a
+**content fingerprint** so change is detectable, and expose the graph both ways.
+
+- **Schema:** `prd_ref.sha?` — fingerprint of the referenced PRD anchor's body at
+  stamp time. (`packages/cli/src/commands/refine/spec-yaml.ts`)
+- **Pure core** (`trace/check.ts`, dependency-free):
+  - `normalizeAnchorBody` + `contentHash` (FNV-1a) → `anchorHash(body)`.
+  - `checkFreshness({specs, anchors})` → `{stale, unstamped, fresh}`.
+  - `computeImpact({specs, changedAnchors})` → affected stories (forward: PRD→stories).
+    Reverse (story→PRD) is the same link read backward: the story's anchor is the
+    PRD candidate to review.
+- **Commands** (`trace/index.ts`):
+  - `trace stamp` — write current anchor hashes into specs.
+  - `trace check` — existing lints **+ advisory stale report** (recorded sha ≠
+    current). Advisory, not a hard fail (cosmetic PRD reflow shouldn't cry wolf);
+    `--strict` to fail.
+  - `trace impact [--since <gitref>] [--anchors a,b]` — list stories a PRD change
+    hits. With `--since`, diffs the PRD between revisions to find changed anchors.
+
+Granularity note: anchors today are **section-level** (`surfaces`, `personas-*`).
+Good enough as the deterministic floor (a candidate set); the LLM narrows within it.
+Finer `prd_ref` (decision-level) is a later `menu` enhancement.
+
+### Layer 2 — reconcile agent (next slice, LLM)
+
+`slowcook reconcile [--story <id>]` — for each impacted story, the side-effects
+audit lifted to PRD→spec: ingest the changed anchor (+ any review comment) → emit a
+**proposed patch** enumerating exactly which invariants / scenarios / actors / API
+entries contradict the new PRD, with the edit. Reviewable, one-hop, never
+auto-applied. This is the headless half of the dash conversational-review loop
+(dash Q13) — same investment.
+
+### Layer 3 — signal capture (small)
+
+`garnish` reads agent provenance from artifact front-matter (`refined_by:`), not
+just git history, so hand-fixes to agent-emitted specs always record
+`Tweaks-output-of:` → `reflect` can mine recurring corrections.
+
+## Dogfood
+
+On `slowcook-dev/dash`: `trace stamp` → change the PRD → `trace impact --since` +
+`trace check` show exactly which stories the change hit. (Layer 2 then proposes the
+edits once a key is available.)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,9 +53,9 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook recipe [--spec <id>] [--all] [--cwd <path>]
   ```
-- **`vibe`** — Design-first mockup generator. Emits a runnable React mockup PR from spec + brownfield context.
+- **`vibe`** — Design-first mockup generator. `vibe plan` (deterministic): compile all specs into the whole-app LCR plan — unified data model (entities merged + cross-story conflicts), persona/route map, coverage — to .brewing/lcr-plan.json. `vibe schema` (deterministic): generate the LCR data adaptor's @story-annotated Drizzle schema from that data model (data_contract types → columns; conflicts block). `vibe --spec <id>` (legacy per-story): emit a runnable React mockup PR.
   ```
-  slowcook vibe --spec <id> [--cwd <path>] [--owner <login>] [--repo <name>] [--dry-run]
+  slowcook vibe (plan | schema [--out <path>] [--stdout] | --spec <id> [--owner <login>] [--repo <name>] [--dry-run]) [--cwd <path>]
   ```
 - **`plate`** — Mockup amendment agent. Triggered by /plate PR comments on slowcook-mockup PRs; force-pushes amendments.
   ```
@@ -100,9 +100,13 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook recon [--story <id>] [--cwd <path>] [--reuse-scan] [--stub-scan] [--exclude <glob>]
   ```
-- **`trace`** — GUCDI provenance-completeness lint over the spine: every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Brownfield-safe (never demands a PRD).
+- **`trace`** — GUCDI traceability lint over the spine. check: provenance (forward — every spec/LCR node has a why; orphans/dangling fail), coverage (inverse — stories with no LCR surface; --coverage to fail), persona surfaces (declared routes resolve), and freshness (specs whose PRD section changed since stamping; --strict to fail). stamp: baseline each spec's PRD-anchor fingerprint (prd_ref.sha). impact: which stories a PRD change touches (--since <ref> diffs the PRD; or --anchors a,b). Brownfield-safe (never demands a PRD).
   ```
-  slowcook trace check [--prd <path>] [--cwd <dir>]
+  slowcook trace <check|stamp|impact> [--prd <path>] [--cwd <dir>] [--coverage] [--strict] [--since <ref>] [--anchors a,b]
+  ```
+- **`reconcile`** — PRD↔spec interdependency (LLM). When a PRD section a spec anchors to has changed (see `trace impact`/`trace check`), propose a minimum-diff corrected spec: enumerate which invariants/scenarios/actors/api now contradict the PRD, and report one-hop cross-impact as notes. Propose-not-apply by default (writes specs/story-<id>.reconcile.yaml); --apply accepts it (schema-validated) and re-stamps freshness.
+  ```
+  slowcook reconcile --story <id> [--prd <path>] [--cwd <dir>] [--apply] [--dry-run] [--model <id>]
   ```
 - **`eye`** — Fidelity eye (design #8). Renders mock + brewed URLs across the viewport×scheme matrix, grades visual drift, screenshots, exits 1 on drift.
   ```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,6 +42,7 @@ import { eye } from "./commands/eye/index.js";
 import { gate } from "./commands/gate/index.js";
 import { menu } from "./commands/menu/index.js";
 import { trace } from "./commands/trace/index.js";
+import { reconcile } from "./commands/reconcile/index.js";
 import { greenfield } from "./commands/greenfield/index.js";
 import { renderHelp, renderCommandHelp, renderReadmeBlock } from "./help.js";
 
@@ -294,7 +295,13 @@ async function main(): Promise<void> {
     case "trace":
       // GUCDI — provenance-completeness lint over the spine (the keystone):
       // every node has a why ∈ {requirement|convention|craft}; orphans fail.
+      // Also: check|stamp|impact for PRD↔spec freshness/interdependency.
       await trace(args.slice(1), VERSION);
+      return;
+    case "reconcile":
+      // GUCDI — PRD↔spec interdependency (LLM): propose a corrected spec when a
+      // PRD section it anchors to has changed. Propose-not-apply, one hop.
+      await reconcile(args.slice(1), VERSION);
       return;
     case "greenfield":
       // GUCDI — scope-completeness dashboard: PRD → stories → brand → LCR →

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -171,8 +171,14 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "trace",
-    usage: "slowcook trace check [--prd <path>] [--cwd <dir>] [--coverage]",
-    description: "GUCDI traceability lint over the spine. Provenance (forward): every spec/LCR node has a why (requirement/convention/craft); orphans + dangling refs fail; craft is reported. Coverage (inverse): reports stories with no LCR surface; --coverage makes them a hard failure (for UI milestones). Persona surfaces: each spec's declared persona surface route must resolve to a real mock router path (a promised surface the mock doesn't expose fails). Brownfield-safe (never demands a PRD).",
+    usage: "slowcook trace <check|stamp|impact> [--prd <path>] [--cwd <dir>] [--coverage] [--strict] [--since <ref>] [--anchors a,b]",
+    description: "GUCDI traceability lint over the spine. check: provenance (forward — every spec/LCR node has a why; orphans/dangling fail), coverage (inverse — stories with no LCR surface; --coverage to fail), persona surfaces (declared routes resolve), and freshness (specs whose PRD section changed since stamping; --strict to fail). stamp: baseline each spec's PRD-anchor fingerprint (prd_ref.sha). impact: which stories a PRD change touches (--since <ref> diffs the PRD; or --anchors a,b). Brownfield-safe (never demands a PRD).",
+    group: "checks",
+  },
+  {
+    name: "reconcile",
+    usage: "slowcook reconcile --story <id> [--prd <path>] [--cwd <dir>] [--apply] [--dry-run] [--model <id>]",
+    description: "PRD↔spec interdependency (LLM). When a PRD section a spec anchors to has changed (see `trace impact`/`trace check`), propose a minimum-diff corrected spec: enumerate which invariants/scenarios/actors/api now contradict the PRD, and report one-hop cross-impact as notes. Propose-not-apply by default (writes specs/story-<id>.reconcile.yaml); --apply accepts it (schema-validated) and re-stamps freshness.",
     group: "checks",
   },
   {

--- a/packages/cli/src/commands/reconcile/index.ts
+++ b/packages/cli/src/commands/reconcile/index.ts
@@ -1,0 +1,193 @@
+/**
+ * `slowcook reconcile` — the LLM half of PRD↔spec interdependency. When `trace
+ * impact` / `trace check` flags a spec as stale (its PRD section moved), reconcile
+ * takes that one spec + the changed PRD section and PROPOSES a corrected spec —
+ * the side-effects audit lifted from issue→test (refine) to PRD→spec.
+ *
+ *   slowcook reconcile --story 019 [--prd docs/PRD.md] [--apply] [--dry-run]
+ *
+ * Contract (docs/plans/prd-stories-interdependency.md):
+ *   - PROPOSE, don't apply. Default writes `specs/story-<id>.reconcile.yaml`
+ *     (a proposal) + prints the contradictions; `--apply` accepts it.
+ *   - ONE HOP. Reconciles this spec against its PRD section only; cross-impact
+ *     on the PRD / other stories is reported, never acted on.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import YAML from "yaml";
+import { AnthropicClient, RECONCILE_SYSTEM, formatCostFooter } from "@slowcook-ai/llm-anthropic";
+import { listActiveSpecs, SPECS_DIR, schemas, normalizeScenarioArrays } from "../refine/spec-yaml.js";
+import { parsePrdInitiatives } from "../menu/prd.js";
+import { anchorHash } from "../trace/check.js";
+import { setPrdSha } from "../trace/index.js";
+
+const DEFAULT_MODEL = "claude-opus-4-7";
+
+interface Contradiction {
+  path?: string;
+  current?: string | null;
+  issue?: string;
+  change?: string;
+}
+interface ReconcileOutput {
+  contradictions: Contradiction[];
+  cross_impact: string[];
+  updated_spec_yaml: string;
+}
+
+function val(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+const has = (args: string[], flag: string): boolean => args.includes(flag);
+
+function parseOutput(raw: string): ReconcileOutput {
+  const stripped = raw.replace(/```json\s*|\s*```/g, "");
+  const first = stripped.indexOf("{");
+  if (first === -1) throw new Error("reconcile: no JSON object in model response");
+  const parsed = JSON.parse(stripped.slice(first));
+  return {
+    contradictions: Array.isArray(parsed.contradictions) ? parsed.contradictions : [],
+    cross_impact: Array.isArray(parsed.cross_impact) ? parsed.cross_impact : [],
+    updated_spec_yaml: typeof parsed.updated_spec_yaml === "string" ? parsed.updated_spec_yaml : "",
+  };
+}
+
+export async function reconcile(argv: string[], _cliVersion: string): Promise<void> {
+  const cwd = resolve(val(argv, "--cwd") ?? ".");
+  const storyId = val(argv, "--story")?.replace(/^story-/, "");
+  const prdRel = val(argv, "--prd") ?? "docs/PRD.md";
+  const apply = has(argv, "--apply");
+  const dryRun = has(argv, "--dry-run");
+  const model = val(argv, "--model") ?? DEFAULT_MODEL;
+
+  if (!storyId) {
+    console.error("usage: slowcook reconcile --story <id> [--prd <path>] [--apply] [--dry-run]");
+    process.exit(64);
+  }
+
+  const spec = listActiveSpecs(cwd).find((s) => s.story_id === storyId);
+  if (!spec) {
+    console.error(`reconcile: no active spec story-${storyId} in ${SPECS_DIR}/`);
+    process.exit(1);
+  }
+  const anchor = spec.prd_ref?.anchor;
+  if (!anchor) {
+    console.error(`reconcile: story-${storyId} has no prd_ref.anchor — nothing to reconcile against.`);
+    process.exit(1);
+  }
+  const prdAbs = resolve(cwd, prdRel);
+  if (!existsSync(prdAbs)) {
+    console.error(`reconcile: no PRD at ${prdRel}.`);
+    process.exit(1);
+  }
+  const init = parsePrdInitiatives(readFileSync(prdAbs, "utf8")).find((i) => i.anchor === anchor);
+  if (!init) {
+    console.error(`reconcile: PRD has no section §${anchor} (dangling prd_ref).`);
+    process.exit(1);
+  }
+
+  const specPath = join(resolve(cwd, SPECS_DIR), `story-${storyId}.yaml`);
+  const specText = readFileSync(specPath, "utf8");
+
+  const userMessage = [
+    `## Changed PRD section`,
+    `anchor: ${anchor}`,
+    `title: ${init.title}`,
+    "",
+    init.body,
+    "",
+    `## Spec to reconcile (story-${storyId})`,
+    "```yaml",
+    specText,
+    "```",
+    "",
+    "Reconcile per the system prompt; emit a single JSON object.",
+  ].join("\n");
+
+  console.log(`reconcile: story-${storyId} ← §${anchor}  (model ${model})`);
+
+  if (dryRun) {
+    console.log("[dry-run] would call the model; skipping.");
+    return;
+  }
+
+  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  if (!apiKey) {
+    console.error("reconcile: ANTHROPIC_API_KEY not set (or pass --dry-run).");
+    process.exit(1);
+  }
+
+  const llm = new AnthropicClient(apiKey);
+  const res = await llm.complete({
+    system: RECONCILE_SYSTEM,
+    cacheSystem: false,
+    model,
+    messages: [{ role: "user", content: userMessage }],
+    maxTokens: 8192,
+  });
+
+  let out: ReconcileOutput;
+  try {
+    out = parseOutput(res.text);
+  } catch (e) {
+    console.error(`reconcile: couldn't parse model output — ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  // Report — the contradictions are the "what changed", reviewable before apply.
+  if (out.contradictions.length === 0) {
+    console.log("\n  no contradictions — the PRD change doesn't touch this spec's concerns.");
+  } else {
+    console.log(`\n  ${out.contradictions.length} contradiction(s):`);
+    for (const c of out.contradictions) {
+      console.log(`    [${c.change ?? "?"}] ${c.path ?? "(?)"} — ${c.issue ?? ""}`);
+      if (c.current) console.log(`        was: ${String(c.current).slice(0, 160)}`);
+    }
+  }
+  if (out.cross_impact.length) {
+    console.log(`\n  cross-impact (notes only — one hop, not acted on):`);
+    for (const n of out.cross_impact) console.log(`    → ${n}`);
+  }
+  console.log("\n" + formatCostFooter(res.costUsd, []));
+
+  if (!out.updated_spec_yaml.trim()) {
+    console.error("\nreconcile: model returned no updated spec — nothing to write.");
+    process.exit(1);
+  }
+
+  // Validate the proposed spec against the schema before doing anything with it.
+  let parsedDoc: unknown;
+  try {
+    parsedDoc = normalizeScenarioArrays(YAML.parse(out.updated_spec_yaml) as Record<string, unknown>);
+  } catch (e) {
+    console.error(`\nreconcile: proposed spec isn't valid YAML — ${(e as Error).message}`);
+    process.exit(1);
+  }
+  const check = schemas.Spec.safeParse(parsedDoc);
+  if (!check.success) {
+    console.error(`\nreconcile: proposed spec fails the spec schema (not applying):`);
+    console.error("  " + check.error.issues.slice(0, 5).map((i) => `${i.path.join(".")}: ${i.message}`).join("\n  "));
+    // Still write it as a proposal so a human can fix it.
+  }
+
+  // Re-stamp the freshness fingerprint so an accepted spec is born fresh.
+  const stamped = setPrdSha(out.updated_spec_yaml, anchorHash(init.body));
+
+  if (apply) {
+    if (!check.success) {
+      console.error("\nreconcile: refusing to --apply an invalid spec. Proposal written instead.");
+      const proposalPath = join(resolve(cwd, SPECS_DIR), `story-${storyId}.reconcile.yaml`);
+      writeFileSync(proposalPath, stamped);
+      console.error(`  proposal: ${SPECS_DIR}/story-${storyId}.reconcile.yaml`);
+      process.exit(1);
+    }
+    writeFileSync(specPath, stamped);
+    console.log(`\n✓ applied → ${SPECS_DIR}/story-${storyId}.yaml (re-stamped fresh). Review the diff before committing.`);
+  } else {
+    const proposalPath = join(resolve(cwd, SPECS_DIR), `story-${storyId}.reconcile.yaml`);
+    writeFileSync(proposalPath, stamped);
+    console.log(`\n  proposal written → ${SPECS_DIR}/story-${storyId}.reconcile.yaml`);
+    console.log(`  review it, then: \`slowcook reconcile --story ${storyId} --apply\`  (or diff & hand-merge).`);
+  }
+}

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -156,7 +156,16 @@ const SpecSchema = z.object({
   // GUCDI — provenance anchor to a PRD initiative (greenfield only). OPTIONAL:
   // brownfield specs trace via source_issue instead, and `trace check` NEVER
   // demands a prd_ref (provenance is the union {issue|prd|convention|craft}).
-  prd_ref: z.object({ file: z.string(), anchor: z.string() }).optional(),
+  prd_ref: z
+    .object({
+      file: z.string(),
+      anchor: z.string(),
+      /** Fingerprint of the anchor's PRD body at stamp time (`trace stamp`).
+       *  Lets `trace check` detect when the PRD section moved out from under the
+       *  spec. Absent = never stamped. See trace/check.ts `anchorHash`. */
+      sha: z.string().optional(),
+    })
+    .optional(),
   // GUCDI — the data contract this story needs, baked into the LCR's SQLite+ORM
   // schema and inherited by the backend (mock→prod becomes a data-source swap).
   data_contract: z

--- a/packages/cli/src/commands/trace/check.test.ts
+++ b/packages/cli/src/commands/trace/check.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { checkTrace, checkCoverage, checkSurfaces, routeSatisfies, parseLcrProvenance, type SpecNode, type LcrNode, type SpecSurface } from "./check.js";
+import {
+  checkTrace,
+  checkCoverage,
+  checkSurfaces,
+  routeSatisfies,
+  parseLcrProvenance,
+  normalizeAnchorBody,
+  contentHash,
+  anchorHash,
+  checkFreshness,
+  computeImpact,
+  diffPrdStates,
+  type SpecNode,
+  type LcrNode,
+  type SpecSurface,
+} from "./check.js";
 
 describe("parseLcrProvenance", () => {
   it("recognizes @story / story-N / @convention / @craft forms", () => {
@@ -129,5 +144,83 @@ describe("checkSurfaces — persona surfaces resolve to real routes", () => {
   });
   it("is empty-safe", () => {
     expect(checkSurfaces({ surfaces: [], routes: [] })).toMatchObject({ ok: true, dangling: [] });
+  });
+});
+
+describe("PRD↔spec interdependency", () => {
+  describe("content fingerprint", () => {
+    it("normalizeAnchorBody ignores trailing ws + blank-line runs", () => {
+      expect(normalizeAnchorBody("a   \n\n\n\nb  ")).toBe("a\n\nb");
+    });
+    it("anchorHash is stable under cosmetic reflow but moves on a semantic edit", () => {
+      const a = "The operator certifies workers.\n\nAggregates only.";
+      const cosmetic = "The operator certifies workers.   \n\n\nAggregates only.\n\n";
+      const semantic = "The operator certifies agencies.\n\nAggregates only.";
+      expect(anchorHash(a)).toBe(anchorHash(cosmetic));
+      expect(anchorHash(a)).not.toBe(anchorHash(semantic));
+    });
+    it("contentHash is 16-hex and deterministic", () => {
+      expect(contentHash("x")).toMatch(/^[0-9a-f]{16}$/);
+      expect(contentHash("hello")).toBe(contentHash("hello"));
+    });
+  });
+
+  describe("checkFreshness", () => {
+    const anchors = [
+      { anchor: "personas-operator", hash: "aaaa" },
+      { anchor: "wallet", hash: "bbbb" },
+    ];
+    it("flags a spec whose recorded sha no longer matches (PRD moved)", () => {
+      const r = checkFreshness({
+        specs: [{ storyId: "019", prdAnchor: "personas-operator", prdSha: "OLD" }],
+        anchors,
+      });
+      expect(r.stale).toEqual([{ storyId: "019", anchor: "personas-operator", recorded: "OLD", current: "aaaa" }]);
+      expect(r.freshCount).toBe(0);
+    });
+    it("counts a matching spec as fresh, not stale", () => {
+      const r = checkFreshness({ specs: [{ storyId: "007", prdAnchor: "wallet", prdSha: "bbbb" }], anchors });
+      expect(r.stale).toHaveLength(0);
+      expect(r.freshCount).toBe(1);
+    });
+    it("reports unstamped specs separately (unknown freshness, not stale)", () => {
+      const r = checkFreshness({ specs: [{ storyId: "019", prdAnchor: "personas-operator" }], anchors });
+      expect(r.stale).toHaveLength(0);
+      expect(r.unstamped).toEqual([{ storyId: "019", anchor: "personas-operator" }]);
+    });
+    it("skips specs with no anchor and anchors absent from the PRD", () => {
+      const r = checkFreshness({
+        specs: [{ storyId: "100" }, { storyId: "101", prdAnchor: "ghost", prdSha: "x" }],
+        anchors,
+      });
+      expect(r.stale).toHaveLength(0);
+      expect(r.unstamped).toHaveLength(0);
+    });
+  });
+
+  describe("computeImpact", () => {
+    const specs = [
+      { storyId: "002", prdAnchor: "personas-members" },
+      { storyId: "019", prdAnchor: "personas-operator" },
+      { storyId: "007", prdAnchor: "wallet" },
+    ];
+    it("returns the stories that link a changed anchor", () => {
+      const { affected } = computeImpact({ specs, changedAnchors: ["personas-operator", "wallet"] });
+      expect(affected).toEqual([
+        { storyId: "019", anchor: "personas-operator" },
+        { storyId: "007", anchor: "wallet" },
+      ]);
+    });
+    it("is empty when nothing relevant changed", () => {
+      expect(computeImpact({ specs, changedAnchors: ["forecast"] }).affected).toHaveLength(0);
+    });
+  });
+
+  describe("diffPrdStates", () => {
+    it("classifies changed / added / removed anchors", () => {
+      const before = [{ anchor: "a", hash: "1" }, { anchor: "b", hash: "2" }, { anchor: "gone", hash: "9" }];
+      const after = [{ anchor: "a", hash: "1" }, { anchor: "b", hash: "CHANGED" }, { anchor: "new", hash: "5" }];
+      expect(diffPrdStates(before, after)).toEqual({ changed: ["b"], added: ["new"], removed: ["gone"] });
+    });
   });
 });

--- a/packages/cli/src/commands/trace/check.ts
+++ b/packages/cli/src/commands/trace/check.ts
@@ -150,6 +150,139 @@ export function checkSurfaces(input: { surfaces: SpecSurface[]; routes: string[]
   return { dangling, unreachablePersonas, surfaceCount: input.surfaces.length, ok: dangling.length === 0 && unreachablePersonas.length === 0 };
 }
 
+// ── PRD↔spec interdependency (0.21.x) — the deterministic floor under the
+//    conversational PRD/stories review. Every spec already anchors to a PRD
+//    section (`prd_ref.anchor`); we fingerprint that section's body so a PRD
+//    edit becomes *detectable* (staleness) and *attributable* (impact). No LLM:
+//    this tells you WHICH stories a PRD change touches; reconcile narrows to HOW.
+//    See docs/plans/prd-stories-interdependency.md. ────────────────────────────
+
+/** Normalise an anchor body so cosmetic reflow (trailing ws, blank-line runs)
+ *  doesn't churn the fingerprint — only semantic edits move it. */
+export function normalizeAnchorBody(body: string): string {
+  return body
+    .split(/\r?\n/)
+    .map((l) => l.replace(/\s+$/, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Dependency-free FNV-1a (64-bit) content hash → 16-hex. Not cryptographic;
+ *  it only needs to answer "did this PRD section change?". Pure + deterministic
+ *  across environments (no node:crypto, keeping this module IO-free). */
+export function contentHash(s: string): string {
+  let h = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < s.length; i++) {
+    h ^= BigInt(s.charCodeAt(i));
+    h = (h * prime) & mask;
+  }
+  return h.toString(16).padStart(16, "0");
+}
+
+/** Fingerprint of a PRD anchor's body (normalised). */
+export function anchorHash(body: string): string {
+  return contentHash(normalizeAnchorBody(body));
+}
+
+/** Current PRD: anchor → fingerprint. */
+export interface PrdAnchorState {
+  anchor: string;
+  hash: string;
+}
+
+/** A spec's recorded link to the PRD (anchor it was refined against + the
+ *  fingerprint at stamp time, if stamped). */
+export interface SpecLink {
+  storyId: string;
+  prdAnchor?: string;
+  /** `prd_ref.sha` recorded at stamp time; absent = never stamped. */
+  prdSha?: string;
+}
+
+export interface StaleSpec {
+  storyId: string;
+  anchor: string;
+  recorded: string;
+  current: string;
+}
+
+export interface FreshnessResult {
+  /** specs whose recorded fingerprint ≠ the current PRD anchor (the PRD moved). */
+  stale: StaleSpec[];
+  /** specs that link a PRD anchor but were never stamped (unknown freshness). */
+  unstamped: { storyId: string; anchor: string }[];
+  freshCount: number;
+}
+
+/**
+ * FRESHNESS — does each spec's recorded fingerprint still match its PRD anchor?
+ * `stale` = the anchor body changed since the spec was stamped (the rot we want
+ * to catch). Specs with no `prdAnchor` are skipped (orphans are `checkTrace`'s
+ * job); anchors that no longer exist are skipped here (dangling-prd-ref already
+ * flags those). Deterministic; advisory by default (cosmetic edits can move a
+ * section hash, so the caller decides whether to fail).
+ */
+export function checkFreshness(input: {
+  specs: SpecLink[];
+  anchors: PrdAnchorState[];
+}): FreshnessResult {
+  const byAnchor = new Map(input.anchors.map((a) => [a.anchor, a.hash]));
+  const stale: StaleSpec[] = [];
+  const unstamped: { storyId: string; anchor: string }[] = [];
+  let freshCount = 0;
+  for (const s of input.specs) {
+    if (!s.prdAnchor) continue;
+    const current = byAnchor.get(s.prdAnchor);
+    if (current === undefined) continue; // dangling anchor — checkTrace handles it
+    if (!s.prdSha) {
+      unstamped.push({ storyId: s.storyId, anchor: s.prdAnchor });
+    } else if (s.prdSha !== current) {
+      stale.push({ storyId: s.storyId, anchor: s.prdAnchor, recorded: s.prdSha, current });
+    } else {
+      freshCount++;
+    }
+  }
+  return { stale, unstamped, freshCount };
+}
+
+/**
+ * IMPACT — given the set of PRD anchors whose content changed (e.g. from a git
+ * diff between two PRD revisions), which stories link them? Forward direction
+ * (PRD→stories). The reverse (story→PRD) is the same link read backward: a
+ * changed story's `prdAnchor` is the PRD section to review.
+ */
+export function computeImpact(input: {
+  specs: SpecLink[];
+  changedAnchors: string[];
+}): { affected: { storyId: string; anchor: string }[] } {
+  const changed = new Set(input.changedAnchors);
+  const affected = input.specs
+    .filter((s) => s.prdAnchor && changed.has(s.prdAnchor))
+    .map((s) => ({ storyId: s.storyId, anchor: s.prdAnchor! }));
+  return { affected };
+}
+
+/** Diff two PRD states (anchor→hash) → anchors that changed, were added, or
+ *  removed. `changed` is what impact analysis keys on. */
+export function diffPrdStates(
+  before: PrdAnchorState[],
+  after: PrdAnchorState[]
+): { changed: string[]; added: string[]; removed: string[] } {
+  const a = new Map(before.map((x) => [x.anchor, x.hash]));
+  const b = new Map(after.map((x) => [x.anchor, x.hash]));
+  const changed: string[] = [];
+  const added: string[] = [];
+  for (const [anchor, hash] of b) {
+    if (!a.has(anchor)) added.push(anchor);
+    else if (a.get(anchor) !== hash) changed.push(anchor);
+  }
+  const removed = [...a.keys()].filter((anchor) => !b.has(anchor));
+  return { changed, added, removed };
+}
+
 export function checkTrace(input: {
   specs: SpecNode[];
   /** PRD initiative anchors. Empty = no PRD (brownfield) → prd-ref checks skipped. */

--- a/packages/cli/src/commands/trace/index.ts
+++ b/packages/cli/src/commands/trace/index.ts
@@ -9,13 +9,69 @@
  *
  * Pure lint in ./check.ts; this is the IO shell.
  */
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join, relative, resolve } from "node:path";
 import YAML from "yaml";
 import { listActiveSpecs, SPECS_DIR } from "../refine/spec-yaml.js";
 import { loadMockShapeConfig } from "../../lib/mock-shape.js";
-import { parsePrdInitiatives } from "../menu/prd.js";
-import { checkTrace, checkCoverage, checkSurfaces, parseLcrProvenance, type LcrNode, type SpecNode, type SpecSurface } from "./check.js";
+import { parsePrdInitiatives, type PrdInitiative } from "../menu/prd.js";
+import {
+  checkTrace,
+  checkCoverage,
+  checkSurfaces,
+  checkFreshness,
+  computeImpact,
+  diffPrdStates,
+  anchorHash,
+  parseLcrProvenance,
+  type LcrNode,
+  type SpecNode,
+  type SpecSurface,
+  type SpecLink,
+  type PrdAnchorState,
+} from "./check.js";
+
+/** Specs → their PRD link facts (anchor + recorded fingerprint). */
+function loadSpecLinks(cwd: string): SpecLink[] {
+  return listActiveSpecs(cwd).map((s) => ({
+    storyId: s.story_id,
+    prdAnchor: s.prd_ref?.anchor,
+    prdSha: s.prd_ref?.sha,
+  }));
+}
+
+/** Parse a PRD markdown string → current anchor fingerprints. */
+function prdAnchorStates(md: string): PrdAnchorState[] {
+  return parsePrdInitiatives(md).map((i: PrdInitiative) => ({ anchor: i.anchor, hash: anchorHash(i.body) }));
+}
+
+/** Insert/replace `sha:` inside a spec's `prd_ref:` block, preserving the file's
+ *  formatting (targeted line edit, not a YAML round-trip that would reflow the
+ *  hand-tweaked spec). Returns the new text, or the original if there's no
+ *  prd_ref/anchor to stamp. */
+export function setPrdSha(text: string, hash: string): string {
+  const lines = text.split(/\r?\n/);
+  const i = lines.findIndex((l) => /^\s*prd_ref:\s*$/.test(l));
+  if (i < 0) return text;
+  const baseIndent = lines[i]!.match(/^\s*/)![0]!.length;
+  let anchorIdx = -1;
+  let shaIdx = -1;
+  let childIndent = "  ";
+  for (let j = i + 1; j < lines.length; j++) {
+    const l = lines[j]!;
+    if (l.trim() === "") continue;
+    const indent = l.match(/^\s*/)![0]!.length;
+    if (indent <= baseIndent) break; // left the prd_ref block
+    childIndent = l.match(/^\s*/)![0]!;
+    if (/^\s*anchor:/.test(l)) anchorIdx = j;
+    if (/^\s*sha:/.test(l)) shaIdx = j;
+  }
+  if (shaIdx >= 0) lines[shaIdx] = `${childIndent}sha: ${hash}`;
+  else if (anchorIdx >= 0) lines.splice(anchorIdx + 1, 0, `${childIndent}sha: ${hash}`);
+  else return text;
+  return lines.join("\n");
+}
 
 /** Read persona-surface declarations from the spec YAMLs (the `persona` +
  *  `surfaces` blocks the generator compiles into the mock). */
@@ -64,13 +120,20 @@ function walkTsx(dir: string, exclude: Set<string>): string[] {
 }
 
 export async function trace(argv: string[], _cliVersion: string): Promise<void> {
-  if (argv[0] !== "check") {
-    console.error("usage: slowcook trace check [--prd <path>] [--cwd <dir>] [--coverage]");
+  const sub = argv[0];
+  if (sub === "stamp") return runStamp(argv.slice(1));
+  if (sub === "impact") return runImpact(argv.slice(1));
+  if (sub !== "check") {
+    console.error("usage: slowcook trace <check|stamp|impact> [--prd <path>] [--cwd <dir>]");
+    console.error("  check   provenance + coverage + surface + freshness lints   [--coverage] [--strict]");
+    console.error("  stamp   record each spec's PRD-anchor fingerprint (prd_ref.sha)");
+    console.error("  impact  which stories a PRD change touches   [--since <gitref>] [--anchors a,b]");
     process.exit(64);
   }
   const rest = argv.slice(1);
   const cwd = resolve(val(rest, "--cwd") ?? ".");
   const enforceCoverage = has(rest, "--coverage"); // make uncovered stories a hard failure
+  const strict = has(rest, "--strict"); // make stale specs a hard failure too
 
   // 1. Specs → requirement-provenance facts.
   const specNodes: SpecNode[] = listActiveSpecs(cwd).map((s) => ({
@@ -79,10 +142,14 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
     sourceIssue: s.source_issue,
   }));
 
-  // 2. PRD anchors (optional — absent = brownfield).
+  // 2. PRD anchors + fingerprints (optional — absent = brownfield).
   const prdRel = val(rest, "--prd") ?? "docs/PRD.md";
   const prdAbs = resolve(cwd, prdRel);
-  const prdAnchors = existsSync(prdAbs) ? parsePrdInitiatives(readFileSync(prdAbs, "utf8")).map((i) => i.anchor) : [];
+  const prdStates = existsSync(prdAbs) ? prdAnchorStates(readFileSync(prdAbs, "utf8")) : [];
+  const prdAnchors = prdStates.map((s) => s.anchor);
+
+  // 2b. Freshness — has any spec's PRD anchor moved since it was stamped?
+  const freshness = checkFreshness({ specs: loadSpecLinks(cwd), anchors: prdStates });
 
   // 3. LCR nodes — mock screens + components (excluding the design system, which
   //    is convention/brand provenance, not story-specific).
@@ -145,10 +212,31 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
     }
   }
 
+  // Freshness (PRD↔spec): which specs were refined against a PRD section that has
+  // since changed. Advisory by default (a section hash also moves on cosmetic
+  // reflow); --strict makes it a hard failure. Unstamped specs are reported as a
+  // hint to run `trace stamp`, never as stale.
+  if (prdStates.length > 0) {
+    if (freshness.stale.length === 0 && freshness.unstamped.length === 0) {
+      console.log(`\n  freshness: ${freshness.freshCount} spec(s) match their PRD anchor — none stale.`);
+    } else {
+      if (freshness.stale.length) {
+        const stream = strict ? console.error : console.log;
+        stream(`\n  freshness: ${freshness.stale.length} spec(s) STALE — their PRD section changed since stamping${strict ? " (FAIL — --strict)" : " (review / run reconcile)"}:`);
+        for (const s of freshness.stale) stream(`    ⚠ story-${s.storyId} ← §${s.anchor} (PRD moved)`);
+      }
+      if (freshness.unstamped.length) {
+        console.log(`\n  freshness: ${freshness.unstamped.length} spec(s) unstamped — run \`slowcook trace stamp\` to baseline:`);
+        for (const s of freshness.unstamped) console.log(`    · story-${s.storyId} ← §${s.anchor}`);
+      }
+    }
+  }
+
   const provenanceOk = result.ok;
   const coverageOk = !enforceCoverage || coverage.ok;
   const surfacesOk = surfaceRes.ok;
-  if (provenanceOk && coverageOk && surfacesOk) {
+  const freshnessOk = !strict || freshness.stale.length === 0;
+  if (provenanceOk && coverageOk && surfacesOk && freshnessOk) {
     console.log("\ntrace check: PASS ✓ — every node has honest provenance" + (enforceCoverage ? ", every story has a surface," : "") + " and every persona surface resolves.");
     return;
   }
@@ -162,5 +250,79 @@ export async function trace(argv: string[], _cliVersion: string): Promise<void> 
   if (enforceCoverage && !coverage.ok) {
     console.error(`\ntrace check: FAIL ✗ — ${coverage.uncovered.length} story(ies) with no surface (--coverage).`);
   }
+  if (strict && freshness.stale.length) {
+    console.error(`\ntrace check: FAIL ✗ — ${freshness.stale.length} stale spec(s) vs the PRD (--strict).`);
+  }
   process.exit(1);
+}
+
+/** `slowcook trace stamp` — record each spec's PRD-anchor fingerprint into
+ *  `prd_ref.sha`, baselining freshness. Run after a PRD↔spec set is agreed. */
+async function runStamp(rest: string[]): Promise<void> {
+  const cwd = resolve(val(rest, "--cwd") ?? ".");
+  const prdRel = val(rest, "--prd") ?? "docs/PRD.md";
+  const prdAbs = resolve(cwd, prdRel);
+  if (!existsSync(prdAbs)) {
+    console.error(`trace stamp: no PRD at ${prdRel} — nothing to fingerprint.`);
+    process.exit(64);
+  }
+  const byAnchor = new Map(prdAnchorStates(readFileSync(prdAbs, "utf8")).map((s) => [s.anchor, s.hash]));
+  const specsDir = resolve(cwd, SPECS_DIR);
+  let stamped = 0;
+  let skipped = 0;
+  for (const spec of listActiveSpecs(cwd)) {
+    const anchor = spec.prd_ref?.anchor;
+    if (!anchor) { skipped++; continue; }
+    const hash = byAnchor.get(anchor);
+    if (hash === undefined) { console.log(`  · story-${spec.story_id}: anchor §${anchor} not in PRD — skipped`); skipped++; continue; }
+    const file = join(specsDir, `story-${spec.story_id}.yaml`);
+    const before = readFileSync(file, "utf8");
+    const after = setPrdSha(before, hash);
+    if (after !== before) { writeFileSync(file, after); stamped++; }
+  }
+  console.log(`trace stamp: ${stamped} spec(s) stamped${skipped ? `, ${skipped} skipped (no prd_ref / unknown anchor)` : ""}.`);
+}
+
+/** `slowcook trace impact` — which stories does a PRD change touch? Changed
+ *  anchors come from `--anchors a,b` or `--since <gitref>` (diff the PRD between
+ *  that revision and the working tree). Read-only. */
+async function runImpact(rest: string[]): Promise<void> {
+  const cwd = resolve(val(rest, "--cwd") ?? ".");
+  const prdRel = val(rest, "--prd") ?? "docs/PRD.md";
+  const prdAbs = resolve(cwd, prdRel);
+  const specs = loadSpecLinks(cwd);
+
+  let changedAnchors: string[];
+  const explicit = val(rest, "--anchors");
+  const since = val(rest, "--since");
+  if (explicit) {
+    changedAnchors = explicit.split(",").map((a) => a.trim()).filter(Boolean);
+  } else if (since) {
+    if (!existsSync(prdAbs)) { console.error(`trace impact: no PRD at ${prdRel}.`); process.exit(64); }
+    let beforeMd: string;
+    try {
+      beforeMd = execFileSync("git", ["show", `${since}:${prdRel}`], { cwd, encoding: "utf8" });
+    } catch {
+      console.error(`trace impact: couldn't read ${prdRel} at '${since}' (bad ref or path?).`);
+      process.exit(1);
+    }
+    const afterMd = readFileSync(prdAbs, "utf8");
+    const d = diffPrdStates(prdAnchorStates(beforeMd), prdAnchorStates(afterMd));
+    changedAnchors = d.changed;
+    const extra = [...d.added.map((a) => `+§${a}`), ...d.removed.map((a) => `-§${a}`)];
+    console.log(`trace impact: PRD diff ${since}..worktree — ${d.changed.length} changed${extra.length ? `, ${extra.join(" ")}` : ""}.`);
+  } else {
+    console.error("trace impact: pass --since <gitref> or --anchors a,b");
+    process.exit(64);
+  }
+
+  const { affected } = computeImpact({ specs, changedAnchors });
+  if (changedAnchors.length === 0) { console.log("  no PRD anchors changed — no stories impacted."); return; }
+  console.log(`  changed anchors: ${changedAnchors.map((a) => `§${a}`).join(", ")}`);
+  if (affected.length === 0) { console.log("  no stories link the changed anchors."); return; }
+  const byAnchor = new Map<string, string[]>();
+  for (const a of affected) (byAnchor.get(a.anchor) ?? byAnchor.set(a.anchor, []).get(a.anchor)!).push(`story-${a.storyId}`);
+  console.log(`\n  ${affected.length} story(ies) impacted:`);
+  for (const [anchor, stories] of byAnchor) console.log(`    §${anchor} → ${stories.join(", ")}`);
+  console.log(`\n  next: \`slowcook reconcile --story <id>\` proposes the per-story edits (one hop, review before apply).`);
 }

--- a/packages/core/src/spec.ts
+++ b/packages/core/src/spec.ts
@@ -163,7 +163,7 @@ export interface Spec {
    * GUCDI — provenance anchor to a PRD initiative (greenfield only; optional).
    * Brownfield traces via `source_issue`. `trace check` never demands this.
    */
-  prd_ref?: { file: string; anchor: string };
+  prd_ref?: { file: string; anchor: string; sha?: string };
   /**
    * GUCDI — the data contract this story needs, baked into the LCR's SQLite+ORM
    * schema and inherited by the backend (mock→prod becomes a data-source swap).

--- a/packages/llm-anthropic/src/index.ts
+++ b/packages/llm-anthropic/src/index.ts
@@ -27,6 +27,7 @@ export {
   type SiftTurnPromptArgs,
 } from "./prompts/sift.js";
 export { TESTGEN_SYSTEM } from "./prompts/testgen.js";
+export { RECONCILE_SYSTEM } from "./prompts/reconcile.js";
 export { BRAND_SYSTEM } from "./prompts/brand.js";
 export { MENU_SYSTEM, type MenuStoryDraft } from "./prompts/menu.js";
 export {

--- a/packages/llm-anthropic/src/prompts/reconcile.ts
+++ b/packages/llm-anthropic/src/prompts/reconcile.ts
@@ -1,0 +1,57 @@
+/**
+ * 0.21.x — `reconcile` system prompt. The side-effects audit (refine,
+ * issue→test) lifted one level up to PRD→spec. When a PRD section changes,
+ * reconcile takes the changed section + a single dependent spec and proposes a
+ * corrected spec — enumerating exactly which items now contradict the PRD.
+ *
+ * Contract (load-bearing — see docs/plans/prd-stories-interdependency.md):
+ *  - PROPOSE, don't apply: output is a proposal a human reviews.
+ *  - ONE HOP: reconcile only THIS spec against THIS PRD delta. Cross-impact on
+ *    the PRD itself or other stories is *reported*, never acted on.
+ *  - PRESERVE: change only what the PRD delta requires; keep every other line
+ *    (including hand-tweaks) byte-for-byte. Minimum diff.
+ */
+export const RECONCILE_SYSTEM = `You reconcile a single requirement spec (a YAML story) against a PRD section
+that has changed. You are the second pass of a side-effects audit, lifted from
+issue→test to PRD→spec.
+
+You are given:
+  1. The CURRENT text of one PRD section (its anchor + body).
+  2. One spec YAML that was refined against that section before it changed.
+
+Your job: find exactly where the spec now CONTRADICTS or UNDER-COVERS the PRD
+section, and produce a corrected spec.
+
+Hard rules:
+- PROPOSE only. A human reviews your output before anything is applied. Never
+  assume it ships.
+- ONE HOP. Reconcile this spec against this PRD section only. If your change
+  implies the PRD itself, or OTHER stories, also need editing, put that in
+  "cross_impact" as a note — do NOT try to edit them here.
+- MINIMUM DIFF. Change only what the PRD delta requires. Preserve every other
+  line of the spec exactly — including wording that looks like a human tweak.
+  Keep story_id, created_at, refined_by, prd_ref, data_contract shape, and
+  fidelity untouched unless the PRD delta directly forces a change.
+- STAY IN SCHEMA. acceptance_scenarios are strings ("Given … When … Then …").
+  invariants/non_goals are strings. actors are {name, notes}. Keep the existing
+  field structure.
+- If the PRD ADDED a capability, add the minimal invariant + acceptance_scenario
+  (+ api entry if the spec models APIs) to cover it. If the PRD REMOVED or
+  CHANGED something, flip the contradicting items.
+
+Output a SINGLE JSON object, no prose, no code fences:
+{
+  "contradictions": [
+    { "path": "invariants[3]" | "acceptance_scenarios[1]" | "actors[0].notes" | "data_contract.api" | "(new)",
+      "current": "<the spec's current text, or null if adding>",
+      "issue": "<why it contradicts / under-covers the new PRD section>",
+      "change": "add" | "modify" | "remove" }
+  ],
+  "cross_impact": [
+    "<plain-language note: 'PRD §X may also need …' or 'story-0NN likely affected because …'>"
+  ],
+  "updated_spec_yaml": "<the FULL corrected spec YAML — minimum diff from the input>"
+}
+
+If nothing contradicts (the PRD delta doesn't touch this spec's concerns), return
+empty "contradictions" and the input spec unchanged in "updated_spec_yaml".`;


### PR DESCRIPTION
The OSS half of conversational PRD/stories review (dash Q13). The PRD is the source of truth; specs derive from it; this maintains the link.

## Deterministic engine (no LLM)
- `trace stamp` — fingerprint each spec's PRD anchor (`prd_ref.sha`)
- `trace check` — + advisory **stale** report (PRD section moved since stamp; `--strict` to fail)
- `trace impact --since <ref>` — which stories a PRD change touches
- Pure core in `trace/check.ts`: `anchorHash` (FNV-1a, dependency-free), `checkFreshness`, `computeImpact`, `diffPrdStates` (+12 tests)

## LLM engine
- `reconcile --story <id>` — propose a **minimum-diff** corrected spec when its PRD section changed; the side-effects audit lifted from issue→test to PRD→spec. **Propose-not-apply** (writes `*.reconcile.yaml`; `--apply` accepts, schema-validated); **one hop** (cross-impact reported as notes, never acted on).

## Critical-eval corrections baked in
propose-not-auto-apply · one-hop propagation · unified prose/structured model · comments-as-durable-artifacts.

## Dogfood (slowcook-dev/dash)
PRD §personas-operator gained suspend/decertify → `trace impact` flagged **only** story-019 → `reconcile` proposed +1 invariant, +2 scenarios, +2 API, with 3 one-hop cross-impact notes ($0.25) → applied → 23/23 fresh.

Design: `docs/plans/prd-stories-interdependency.md`. 1334 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)