### PR TITLE
feat(vibe): whole-app LCR — deterministic plan foundation

### DIFF
--- a/docs/plans/vibe-whole-mock-lcr.md
+++ b/docs/plans/vibe-whole-mock-lcr.md
@@ -1,0 +1,72 @@
+# vibe: per-story → whole-app LCR
+
+**Status:** building (deterministic plan foundation landed). **Owner:** GUCDI.
+
+## The change
+
+`vibe` stops generating one mock per story. It generates **one complete, clickable
+LCR app** — richly populated, covering every epic/persona/scenario/state, with a
+shared **data adaptor** so all surfaces are visible as a navigable design. Per-story
+vibe (`--spec <id>` → one scenario file) is wrong: you can't review a product as 23
+disconnected screens, and per-scenario inline fixtures never become a coherent store.
+
+## Why now / what already exists (reuse, don't reinvent)
+
+- The **vision** (`gucdi-greenfield.md`) already specifies the LCR as a whole-app
+  requirements artifact with a **SQLite+ORM data layer** as "the keystone."
+- `review_mode: "lcr"` already exists end-to-end: run-mock device-flow auth, the
+  overlay shows on every route + persona switcher + files `[LCR] story-NNN` issues.
+- The **rewo LCR is the working precedent**: Drizzle schema (12 `@story`-annotated
+  tables) + a dense seed/query data-layer + persona variants + a 15-route auth-free
+  shell + per-route story markers.
+- The gap: **`vibe` never generated any of it** — rewo's was hand-authored.
+
+So the redesign = teach `vibe` to generate the whole-app LCR + its data adaptor,
+targeting the `lcr` mode that already exists downstream.
+
+## Architecture — staged generation (a 23-story app can't be one LLM call)
+
+1. **`vibe plan` — deterministic, no LLM.** Compile all specs → one LCR plan:
+   - **data model**: merge every story's `data_contract.entities` into one schema,
+     unioning fields, flagging cross-story field-type **conflicts**. → the adaptor spine.
+   - **persona/route map**: from each story's `persona` + `surfaces`. → navigation.
+   - **coverage**: which stories contribute a surface vs are backend-only.
+2. **schema pass (LLM)** — plan's data model → a Drizzle schema (`@story`-annotated,
+   SQLite-portable), the rewo pattern.
+3. **seed + adaptor pass (LLM)** — a dense seed covering personas/scenarios/states +
+   a typed query layer = **the data adaptor** (mock→prod swap seam; Type B, finally
+   generated not hand-authored).
+4. **surface passes (LLM, per route/epic)** — each page reads via the adaptor;
+   assembled into **one auth-free clickable app** + router + persona/state switcher +
+   per-route `@story` markers → `review_mode: "lcr"`.
+
+## Landed (this slice — deterministic foundation)
+
+- **`menu` emits `persona` + `surfaces`** per UI story (prompt + `MenuStoryDraft` +
+  schema + assemble). This is the upstream fix (chosen over vibe-infers-routes):
+  declared provenance, feeds the existing persona-surface trace lint. Backend-only
+  stories omit them.
+- **`vibe plan`** (`vibe/lcr-plan.ts`, pure + 7 tests): `compileLcrPlan(specs)` →
+  entities/conflicts/personas/surfaces/coverage. CLI prints it + writes
+  `.brewing/lcr-plan.json` for the generation passes.
+
+**Dogfood (dash, token-free):** 23 specs → **36 entities, 284 fields, 1 conflict**
+(`ExternalAccessGrant.scope_type` drifts across story-004/005/006), 0 surfaces
+(specs predate menu-emits-surfaces → re-run `menu`). The data-model + conflict
+detection is immediately useful and is the schema-pass input.
+
+## Next slices
+
+- Schema pass: `lcr-plan.json` → Drizzle schema (LLM, `@story`-annotated).
+- Seed + adaptor pass: dense seed + typed query layer covering the state matrix.
+- Surface passes + shell assembly: one clickable app targeting `lcr` mode.
+- Re-derive dash specs (menu) so the route map populates; then `vibe plan` shows
+  the full persona/route map, not just the data model.
+
+## Migration (don't break downstream at once)
+
+Per-story scenario mode stays as legacy opt-in; the whole-app LCR is the new default.
+`greenfield status` coverage shifts from per-story `@story` file-markers to
+route/marker coverage (the persona-surface trace already does most of this). `plate`,
+`recon`, `brew --mode plate` migrate from `slowcook/mockup/story-<id>` per-story
+branches to the single LCR branch incrementally — tracked as follow-ups.

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -70,8 +70,8 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "vibe",
-    usage: "slowcook vibe --spec <id> [--cwd <path>] [--owner <login>] [--repo <name>] [--dry-run]",
-    description: "Design-first mockup generator. Emits a runnable React mockup PR from spec + brownfield context.",
+    usage: "slowcook vibe (plan [--cwd <path>] | --spec <id> [--cwd <path>] [--owner <login>] [--repo <name>] [--dry-run])",
+    description: "Design-first mockup generator. `vibe plan` (deterministic, no LLM): compile all specs into the whole-app LCR plan — unified data model (entities merged + cross-story conflicts), persona/route map, coverage — written to .brewing/lcr-plan.json. `vibe --spec <id>` (legacy per-story): emit a runnable React mockup PR from spec + brownfield context.",
     group: "pipeline",
   },
   {

--- a/packages/cli/src/commands/menu/assemble.ts
+++ b/packages/cli/src/commands/menu/assemble.ts
@@ -59,6 +59,8 @@ export function assembleStories(drafts: MenuStoryDraft[], opts: AssembleOptions)
     };
     if (d.ui_behavior && Object.keys(d.ui_behavior).length > 0) spec.ui_behavior = d.ui_behavior;
     if (d.fidelity_modes && d.fidelity_modes.length > 0) spec.fidelity = { modes: d.fidelity_modes };
+    if (d.persona) spec.persona = d.persona;
+    if (d.surfaces && d.surfaces.length > 0) spec.surfaces = d.surfaces;
     return spec;
   });
 

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -153,6 +153,24 @@ const SpecSchema = z.object({
   // Dimension-value tokens (light|dark|mobile|desktop); the eye expands them to
   // the (declared-or-full) product. Absent = eye uses its full default matrix.
   fidelity: z.object({ modes: z.array(z.string()) }).optional(),
+  // GUCDI — the primary persona this story serves in the whole-app LCR, and the
+  // UI surfaces (routes) it contributes. `menu` emits these; the LCR plan
+  // compiles them into the app's persona registry + navigation, and the
+  // persona-surface trace lint checks each route resolves to a real router path.
+  persona: z
+    .object({ id: z.string(), label: z.string().optional(), chrome: z.enum(["member", "public", "admin"]).optional() })
+    .optional(),
+  surfaces: z
+    .array(
+      z.object({
+        route: z.string(),
+        name: z.string().optional(),
+        persona: z.string().optional(),
+        home: z.boolean().optional(),
+        states: z.array(z.string()).optional(),
+      })
+    )
+    .optional(),
   // GUCDI — provenance anchor to a PRD initiative (greenfield only). OPTIONAL:
   // brownfield specs trace via source_issue instead, and `trace check` NEVER
   // demands a prd_ref (provenance is the union {issue|prd|convention|craft}).

--- a/packages/cli/src/commands/vibe/index.ts
+++ b/packages/cli/src/commands/vibe/index.ts
@@ -12,10 +12,12 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { GitHubAdapter } from "@slowcook-ai/forge-github";
 import { runVibe, type VibeContext } from "./agent.js";
+import { listActiveSpecs } from "../refine/spec-yaml.js";
+import { compileLcrPlan, type PlanSpecInput } from "./lcr-plan.js";
 
 interface VibeArgs {
   specId: string;
@@ -289,6 +291,11 @@ function walkComponents(dir: string, acc: string[] = []): string[] {
 }
 
 export async function vibe(argv: string[], cliVersion: string): Promise<void> {
+  // `slowcook vibe plan` — deterministic, no LLM. Compile all specs into the
+  // whole-app LCR plan (data model + route/persona map + coverage). The spine
+  // the schema/seed/surface generation passes hang off.
+  if (argv[0] === "plan") return runPlan(argv.slice(1));
+
   const args = parseArgs(argv);
 
   const anthropicApiKey = process.env["ANTHROPIC_API_KEY"];
@@ -498,4 +505,76 @@ function buildPrBody(
     `\n<!-- slowcook:cost agent=vibe usd=${spendUsd.toFixed(4)} model=claude-opus-4-7 cli=${cliVersion} -->`
   );
   return out.join("\n");
+}
+
+/**
+ * `slowcook vibe plan` — compile all active specs into the whole-app LCR plan and
+ * print it (data model + persona/route map + coverage). Writes the machine form
+ * to `.brewing/lcr-plan.json` for the generation passes. Deterministic, no LLM.
+ */
+async function runPlan(argv: string[]): Promise<void> {
+  const cwd = resolve(argFlag(argv, "--cwd") ?? ".");
+  const specs = listActiveSpecs(cwd);
+  if (specs.length === 0) {
+    console.error("vibe plan: no active specs under specs/ — run `menu` first.");
+    process.exit(1);
+  }
+
+  const planSpecs: PlanSpecInput[] = specs.map((s) => ({
+    storyId: s.story_id,
+    entities: (s.data_contract?.entities ?? []).map((e) => ({
+      name: e.name,
+      fields: (e.fields ?? []).map((f) => ({ name: f.name, type: f.type })),
+      relations: e.relations,
+    })),
+    actors: (s.actors ?? []).map((a) => ({ name: a.name })),
+    persona: s.persona,
+    surfaces: s.surfaces,
+  }));
+
+  const plan = compileLcrPlan(planSpecs);
+
+  const fieldCount = plan.entities.reduce((n, e) => n + e.fields.length, 0);
+  console.log(`vibe plan — whole-app LCR from ${specs.length} specs\n`);
+  console.log(`  data model:  ${plan.entities.length} entities · ${fieldCount} fields · ${plan.conflicts.length} conflict(s)`);
+  console.log(`  personas:    ${plan.personas.length}  (${plan.personas.map((p) => p.id).join(", ") || "—"})`);
+  console.log(`  surfaces:    ${plan.surfaces.length} route(s) across ${new Set(plan.surfaces.map((s) => s.route)).size} unique path(s)`);
+  console.log(`  coverage:    ${plan.stories.length - plan.uncoveredStories.length}/${plan.stories.length} stories contribute a surface`);
+
+  if (plan.conflicts.length) {
+    console.log(`\n  ⚠ data-model conflicts (same field, divergent types — resolve before schema-gen):`);
+    for (const c of plan.conflicts) {
+      const variants = c.types.map((t) => `${t.type} [${t.stories.map((s) => "story-" + s).join(",")}]`).join(" vs ");
+      console.log(`    ✗ ${c.entity}.${c.field}: ${variants}`);
+    }
+  }
+
+  console.log(`\n  entities:`);
+  for (const e of plan.entities) {
+    console.log(`    · ${e.name} (${e.fields.length} fields) ← ${e.fromStories.map((s) => "story-" + s).join(", ")}`);
+  }
+
+  if (plan.surfaces.length) {
+    console.log(`\n  surfaces (persona → route):`);
+    for (const s of plan.surfaces) console.log(`    · ${s.persona} → ${s.route}${s.home ? " [home]" : ""} (story-${s.storyId})`);
+  }
+
+  if (plan.uncoveredStories.length) {
+    console.log(`\n  no surface declared (UI gap or backend-only): ${plan.uncoveredStories.map((s) => "story-" + s).join(", ")}`);
+    if (plan.surfaces.length === 0) {
+      console.log(`  → specs declare no surfaces yet. Re-run \`menu\` (emits persona + surfaces) so the route map populates.`);
+    }
+  }
+
+  const outDir = resolve(cwd, ".brewing");
+  mkdirSync(outDir, { recursive: true });
+  const outFile = join(outDir, "lcr-plan.json");
+  writeFileSync(outFile, JSON.stringify(plan, null, 2) + "\n");
+  console.log(`\n  → .brewing/lcr-plan.json (machine form for the schema/seed/surface passes)`);
+}
+
+/** Small flag reader for the plan subcommand. */
+function argFlag(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
 }

--- a/packages/cli/src/commands/vibe/lcr-plan.test.ts
+++ b/packages/cli/src/commands/vibe/lcr-plan.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { compileLcrPlan, type PlanSpecInput } from "./lcr-plan.js";
+
+describe("compileLcrPlan — data model", () => {
+  it("merges the same entity across stories, unioning fields + tracking provenance", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "007", entities: [{ name: "Wallet", fields: [{ name: "id", type: "uuid" }, { name: "balance", type: "integer" }] }] },
+      { storyId: "008", entities: [{ name: "Wallet", fields: [{ name: "id", type: "uuid" }, { name: "currency", type: "string" }] }] },
+    ];
+    const plan = compileLcrPlan(specs);
+    expect(plan.entities).toHaveLength(1);
+    const w = plan.entities[0]!;
+    expect(w.name).toBe("Wallet");
+    expect(w.fields.map((f) => f.name).sort()).toEqual(["balance", "currency", "id"]);
+    expect(w.fromStories).toEqual(["007", "008"]);
+    expect(w.fields.find((f) => f.name === "id")!.fromStories).toEqual(["007", "008"]);
+    expect(w.fields.find((f) => f.name === "balance")!.fromStories).toEqual(["007"]);
+    expect(plan.conflicts).toHaveLength(0);
+  });
+
+  it("flags a field declared with divergent types across stories", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "001", entities: [{ name: "Project", fields: [{ name: "id", type: "uuid" }] }] },
+      { storyId: "002", entities: [{ name: "Project", fields: [{ name: "id", type: "integer" }] }] },
+    ];
+    const plan = compileLcrPlan(specs);
+    expect(plan.conflicts).toEqual([
+      { entity: "Project", field: "id", types: [{ type: "uuid", stories: ["001"] }, { type: "integer", stories: ["002"] }] },
+    ]);
+  });
+
+  it("unions relations across stories", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "001", entities: [{ name: "Ticket", fields: [], relations: ["project_id → Project.id"] }] },
+      { storyId: "002", entities: [{ name: "Ticket", fields: [], relations: ["reporter_id → Member.id", "project_id → Project.id"] }] },
+    ];
+    const plan = compileLcrPlan(specs);
+    expect(plan.entities[0]!.relations.sort()).toEqual(["project_id → Project.id", "reporter_id → Member.id"]);
+  });
+});
+
+describe("compileLcrPlan — personas + surfaces", () => {
+  it("derives personas from the persona block when present, actors as fallback", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "019", entities: [], persona: { id: "operator", chrome: "admin" }, surfaces: [{ route: "/operator", home: true }] },
+      { storyId: "001", entities: [], actors: [{ name: "Founder" }] }, // no persona block → fallback
+    ];
+    const plan = compileLcrPlan(specs);
+    const ids = plan.personas.map((p) => p.id).sort();
+    expect(ids).toEqual(["Founder", "operator"]);
+    expect(plan.personas.find((p) => p.id === "operator")!.chrome).toBe("admin");
+  });
+
+  it("collects surfaces with persona defaulting to the story's persona", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "019", entities: [], persona: { id: "operator" }, surfaces: [{ route: "/operator/workers", states: ["empty", "populated"] }] },
+    ];
+    const plan = compileLcrPlan(specs);
+    expect(plan.surfaces).toEqual([
+      { route: "/operator/workers", persona: "operator", storyId: "019", home: false, states: ["empty", "populated"] },
+    ]);
+  });
+
+  it("reports stories with no surface as uncovered (UI gap or backend-only)", () => {
+    const specs: PlanSpecInput[] = [
+      { storyId: "013", entities: [], persona: { id: "pm" }, surfaces: [{ route: "/board", home: true }] },
+      { storyId: "021", entities: [{ name: "ReviewSurface", fields: [] }] }, // backend-only, no surface
+    ];
+    const plan = compileLcrPlan(specs);
+    expect(plan.uncoveredStories).toEqual(["021"]);
+    expect(plan.stories.find((s) => s.storyId === "013")!.hasSurface).toBe(true);
+    expect(plan.stories.find((s) => s.storyId === "021")!.hasSurface).toBe(false);
+  });
+
+  it("is empty-safe", () => {
+    expect(compileLcrPlan([])).toEqual({ entities: [], conflicts: [], personas: [], surfaces: [], stories: [], uncoveredStories: [] });
+  });
+});

--- a/packages/cli/src/commands/vibe/lcr-plan.ts
+++ b/packages/cli/src/commands/vibe/lcr-plan.ts
@@ -1,0 +1,189 @@
+/**
+ * GUCDI — LCR plan compiler (pure). The deterministic spine of the whole-app
+ * `vibe` redesign: instead of generating one mock per story, vibe first compiles
+ * ALL specs into a single coherent plan for one clickable LCR app —
+ *   - the unified DATA MODEL (every story's `data_contract.entities` merged into
+ *     one schema, with cross-story field conflicts surfaced) → the data adaptor's
+ *     spine (a Drizzle/SQLite schema is generated from this);
+ *   - the ROUTE / PERSONA map (from each story's `persona` + `surfaces`) → the
+ *     app's navigation, every surface reachable;
+ *   - per-story COVERAGE (which stories contribute a surface vs are backend-only).
+ *
+ * No LLM: this is aggregation over the specs. The schema/seed/surface GENERATION
+ * passes (LLM) hang off this plan. See docs/plans/vibe-whole-mock-lcr.md.
+ */
+
+/** The slice of a spec the planner needs (kept minimal so the core stays pure +
+ *  unit-testable independent of the full Spec type). */
+export interface PlanSpecInput {
+  storyId: string;
+  entities: { name: string; fields: { name: string; type: string }[]; relations?: string[] }[];
+  actors?: { name: string }[];
+  persona?: { id: string; chrome?: string };
+  surfaces?: { route: string; persona?: string; home?: boolean; states?: string[] }[];
+}
+
+export interface PlanField {
+  name: string;
+  type: string;
+  fromStories: string[];
+}
+export interface PlanEntity {
+  name: string;
+  fields: PlanField[];
+  relations: string[];
+  fromStories: string[];
+}
+/** Same entity+field declared with divergent types across stories — the thing
+ *  that silently breaks a hand-merged schema; we surface it for resolution. */
+export interface FieldConflict {
+  entity: string;
+  field: string;
+  types: { type: string; stories: string[] }[];
+}
+export interface PlanPersona {
+  id: string;
+  chrome?: string;
+  fromStories: string[];
+}
+export interface PlanSurface {
+  route: string;
+  persona: string;
+  storyId: string;
+  home: boolean;
+  states: string[];
+}
+export interface PlanStory {
+  storyId: string;
+  entities: string[];
+  personas: string[];
+  routes: string[];
+  hasSurface: boolean;
+}
+export interface LcrPlan {
+  entities: PlanEntity[];
+  conflicts: FieldConflict[];
+  personas: PlanPersona[];
+  surfaces: PlanSurface[];
+  stories: PlanStory[];
+  /** stories that declare no surface — either a UI gap or a legitimately
+   *  backend-only story (the planner can't tell; it reports). */
+  uncoveredStories: string[];
+}
+
+function pushUnique(arr: string[], v: string): void {
+  if (!arr.includes(v)) arr.push(v);
+}
+
+/** Merge every spec's data_contract.entities into one data model, unioning
+ *  fields by name and tracking which stories contributed each entity/field.
+ *  Divergent field types across stories become `conflicts`. */
+function compileEntities(specs: PlanSpecInput[]): { entities: PlanEntity[]; conflicts: FieldConflict[] } {
+  const byName = new Map<string, PlanEntity>();
+  // entity → field → type → stories  (for conflict detection)
+  const typeWitness = new Map<string, Map<string, Map<string, string[]>>>();
+
+  for (const spec of specs) {
+    for (const e of spec.entities) {
+      let ent = byName.get(e.name);
+      if (!ent) {
+        ent = { name: e.name, fields: [], relations: [], fromStories: [] };
+        byName.set(e.name, ent);
+        typeWitness.set(e.name, new Map());
+      }
+      pushUnique(ent.fromStories, spec.storyId);
+      for (const r of e.relations ?? []) pushUnique(ent.relations, r);
+
+      const fieldWitness = typeWitness.get(e.name)!;
+      for (const f of e.fields) {
+        let field = ent.fields.find((x) => x.name === f.name);
+        if (!field) {
+          field = { name: f.name, type: f.type, fromStories: [] };
+          ent.fields.push(field);
+        }
+        pushUnique(field.fromStories, spec.storyId);
+        if (!fieldWitness.has(f.name)) fieldWitness.set(f.name, new Map());
+        const types = fieldWitness.get(f.name)!;
+        if (!types.has(f.type)) types.set(f.type, []);
+        pushUnique(types.get(f.type)!, spec.storyId);
+      }
+    }
+  }
+
+  const conflicts: FieldConflict[] = [];
+  for (const [entity, fields] of typeWitness) {
+    for (const [field, types] of fields) {
+      if (types.size > 1) {
+        conflicts.push({
+          entity,
+          field,
+          types: [...types.entries()].map(([type, stories]) => ({ type, stories })),
+        });
+      }
+    }
+  }
+
+  return { entities: [...byName.values()], conflicts };
+}
+
+/** Compile the whole-app plan from the spec set. Deterministic. */
+export function compileLcrPlan(specs: PlanSpecInput[]): LcrPlan {
+  const { entities, conflicts } = compileEntities(specs);
+
+  const personaById = new Map<string, PlanPersona>();
+  const surfaces: PlanSurface[] = [];
+  const stories: PlanStory[] = [];
+  const uncoveredStories: string[] = [];
+
+  for (const spec of specs) {
+    // Personas: prefer the explicit `persona` block; fall back to `actors` names
+    // so the list is non-empty on specs that predate menu-emits-surfaces.
+    const personaIds: string[] = [];
+    if (spec.persona?.id) {
+      personaIds.push(spec.persona.id);
+      const p = personaById.get(spec.persona.id) ?? { id: spec.persona.id, chrome: spec.persona.chrome, fromStories: [] };
+      if (spec.persona.chrome && !p.chrome) p.chrome = spec.persona.chrome;
+      pushUnique(p.fromStories, spec.storyId);
+      personaById.set(p.id, p);
+    } else {
+      for (const a of spec.actors ?? []) {
+        personaIds.push(a.name);
+        const p = personaById.get(a.name) ?? { id: a.name, fromStories: [] };
+        pushUnique(p.fromStories, spec.storyId);
+        personaById.set(p.id, p);
+      }
+    }
+
+    const routes: string[] = [];
+    for (const s of spec.surfaces ?? []) {
+      const persona = s.persona ?? spec.persona?.id ?? "—";
+      surfaces.push({
+        route: s.route,
+        persona,
+        storyId: spec.storyId,
+        home: s.home === true,
+        states: s.states ?? [],
+      });
+      pushUnique(routes, s.route);
+    }
+
+    const hasSurface = (spec.surfaces?.length ?? 0) > 0;
+    if (!hasSurface) uncoveredStories.push(spec.storyId);
+    stories.push({
+      storyId: spec.storyId,
+      entities: spec.entities.map((e) => e.name),
+      personas: personaIds,
+      routes,
+      hasSurface,
+    });
+  }
+
+  return {
+    entities,
+    conflicts,
+    personas: [...personaById.values()],
+    surfaces,
+    stories,
+    uncoveredStories,
+  };
+}

--- a/packages/core/src/spec.ts
+++ b/packages/core/src/spec.ts
@@ -172,6 +172,20 @@ export interface Spec {
     entities?: { name: string; fields?: { name: string; type: string }[]; relations?: string[] }[];
     api?: { method: string; path: string; note?: string }[];
   };
+  /**
+   * GUCDI — the primary persona this story serves in the whole-app LCR. `chrome`
+   * selects the shell variant (member sidebar / public nav / admin toolbar).
+   * `menu` emits this; the LCR plan compiles it into the app's persona registry.
+   */
+  persona?: { id: string; label?: string; chrome?: "member" | "public" | "admin" };
+  /**
+   * GUCDI — the UI surfaces this story contributes to the LCR. Each is a route
+   * the whole-app mock must expose (every surface reachable, no auth walls).
+   * `home: true` marks a persona's landing route; `states` lists the meaningful
+   * data states the surface must render (empty / populated / error / edge).
+   * The persona-surface trace lint checks each route resolves to a real router path.
+   */
+  surfaces?: { route: string; name?: string; persona?: string; home?: boolean; states?: string[] }[];
   /** GUCDI — open questions; addressable must resolve before the scope is "complete". */
   open_questions?: { addressable: string[]; deferred: string[] };
 

--- a/packages/llm-anthropic/src/prompts/menu.ts
+++ b/packages/llm-anthropic/src/prompts/menu.ts
@@ -21,6 +21,15 @@ export interface MenuStoryDraft {
     api?: { method: string; path: string; note?: string }[];
   };
   ui_behavior?: Record<string, string>;
+  /** GUCDI — the primary persona this story serves in the whole-app LCR.
+   *  `chrome` picks the shell: member sidebar / public nav / admin toolbar.
+   *  Omit for backend-only stories (no UI surface). */
+  persona?: { id: string; label?: string; chrome?: "member" | "public" | "admin" };
+  /** GUCDI — the UI surfaces (routes) this story contributes to the one
+   *  clickable LCR app. `home: true` is the persona's landing route; `states`
+   *  lists the data states the surface must render (empty/populated/error/edge).
+   *  Empty/omitted = backend-only story. */
+  surfaces?: { route: string; name?: string; persona?: string; home?: boolean; states?: string[] }[];
   /** Dimension tokens: light|dark|mobile|desktop and locale:<code>. */
   fidelity_modes: string[];
   acceptance_scenarios: string[];
@@ -48,6 +57,8 @@ Each \`<story>\`:
 - \`invariants\` — rules that must always hold.
 - \`data_contract\` — **REQUIRED and load-bearing.** The real data this story needs: \`{ entities: [{ name, fields: [{ name, type }], relations? }], api?: [{ method, path, note? }] }\`. The LCR bakes a real SQLite+ORM store from these, and the backend INHERITS them (mock→prod is a data-source swap), so shape them like real entities — relations, types, no flat fakes.
 - \`ui_behavior\` — optional map keyed by mode, e.g. { "desktop_light": "...", "mobile_dark": "..." }.
+- \`persona\` — **REQUIRED for any story with a UI surface.** The single primary persona this story serves: \`{ id, label?, chrome }\` where \`chrome\` ∈ \`member|public|admin\` (member sidebar / public/marketing nav / admin toolbar). Use ONE concrete persona id (e.g. \`founder\`, \`operator\`, \`worker\`) — never a slash-joined blob like "PM / Designer / QA". OMIT for backend-only stories (schema/CI/audit with no screen).
+- \`surfaces\` — **REQUIRED for any story with a UI surface.** The routes this story adds to the ONE clickable whole-app LCR (every surface reachable, no auth walls): \`[{ route, name?, persona?, home?, states }]\`. \`route\` is the production route shape (e.g. \`/operator/workers\`, \`/u/:handle\`); \`home: true\` marks the persona's landing route; \`states\` lists the data states the surface must render — choose from \`empty|populated|loading|error|edge\` so the mock can be densely populated AND show every meaningful case. OMIT for backend-only stories. The LCR is one app: reuse a route across stories rather than inventing near-duplicates.
 - \`fidelity_modes\` — which modes matter for this story's design, as tokens from \`light|dark|mobile|desktop\` plus \`locale:<code>\` (e.g. ["light","dark","mobile","locale:fa"]). Declare dark/mobile/RTL only when the design is genuinely mode-specific.
 - \`acceptance_scenarios\` — Given/When/Then; at least three (happy · validation/error · edge) per story.
 - \`non_goals\` — what this story explicitly defers.


### PR DESCRIPTION
Moves `vibe` from per-story scenarios toward **one complete, clickable, richly-populated LCR app** with a shared data adaptor (the rewo LCR precedent, finally generated not hand-authored). This PR is the **deterministic foundation**; the LLM generation passes (schema/seed/surfaces) build on it.

## Landed
- **`menu` emits `persona` + `surfaces`** per UI story (prompt + `MenuStoryDraft` + spec schema + assemble). Declared route provenance (chosen over vibe-infers-routes); feeds the existing persona-surface trace lint. Backend-only stories omit them.
- **`slowcook vibe plan`** (`vibe/lcr-plan.ts`, pure + 7 tests): `compileLcrPlan(specs)` → unified **data model** (entities merged across stories, cross-story field-type **conflicts** flagged), **persona/route map**, **coverage**. Prints + writes `.brewing/lcr-plan.json` for the generation passes.

## Dogfood (dash, token-free)
23 specs → **36 entities · 284 fields · 1 conflict** (`ExternalAccessGrant.scope_type` drifts across story-004/005/006), 0 surfaces (specs predate menu-emits-surfaces → re-run `menu`). Caught real schema drift and stale agency entities deterministically.

## Next
schema pass (→ Drizzle) · seed+adaptor pass (dense, state-covering) · surface passes + shell assembly (→ `review_mode: lcr`). Migration keeps per-story mode as legacy opt-in. Design: `docs/plans/vibe-whole-mock-lcr.md`. 1331 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)