### PR TITLE
feat(vibe): deterministic Drizzle schema-gen (LCR data adaptor)

### DIFF
--- a/docs/plans/vibe-whole-mock-lcr.md
+++ b/docs/plans/vibe-whole-mock-lcr.md
@@ -55,10 +55,22 @@ targeting the `lcr` mode that already exists downstream.
 (specs predate menu-emits-surfaces → re-run `menu`). The data-model + conflict
 detection is immediately useful and is the schema-pass input.
 
+## Landed (schema pass — deterministic)
+
+- **`slowcook vibe schema`** (`vibe/schema-gen.ts`, pure + 10 tests): the plan's
+  data model → an `@story`-annotated Drizzle schema (SQLite-portable). Because the
+  `data_contract` types are structured, the schema is **deterministic** — no LLM,
+  no drift. Type map (uuid/string→text, timestamp→integer timestamp-mode,
+  enum(...)→text+enum, float→real, `|null`→nullable), FK thunks from relations,
+  `id`→primaryKey (never an FK — drops inverse relations). Conflicts block.
+  **This draws the boundary: structure → deterministic; content/judgment → LLM.**
+- **Dogfood (dash):** 37 tables · 292 columns, 0 PK-as-FK, no dangling FK targets,
+  valid syntax. Caught + fixed a real inverse-relation bug (`project.id` was being
+  made an FK to its child).
+
 ## Next slices
 
-- Schema pass: `lcr-plan.json` → Drizzle schema (LLM, `@story`-annotated).
-- Seed + adaptor pass: dense seed + typed query layer covering the state matrix.
+- Seed + adaptor pass (LLM): dense seed + typed query layer covering the state matrix.
 - Surface passes + shell assembly: one clickable app targeting `lcr` mode.
 - Re-derive dash specs (menu) so the route map populates; then `vibe plan` shows
   the full persona/route map, not just the data model.

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -70,8 +70,8 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
   },
   {
     name: "vibe",
-    usage: "slowcook vibe (plan [--cwd <path>] | --spec <id> [--cwd <path>] [--owner <login>] [--repo <name>] [--dry-run])",
-    description: "Design-first mockup generator. `vibe plan` (deterministic, no LLM): compile all specs into the whole-app LCR plan — unified data model (entities merged + cross-story conflicts), persona/route map, coverage — written to .brewing/lcr-plan.json. `vibe --spec <id>` (legacy per-story): emit a runnable React mockup PR from spec + brownfield context.",
+    usage: "slowcook vibe (plan | schema [--out <path>] [--stdout] | --spec <id> [--owner <login>] [--repo <name>] [--dry-run]) [--cwd <path>]",
+    description: "Design-first mockup generator. `vibe plan` (deterministic): compile all specs into the whole-app LCR plan — unified data model (entities merged + cross-story conflicts), persona/route map, coverage — to .brewing/lcr-plan.json. `vibe schema` (deterministic): generate the LCR data adaptor's @story-annotated Drizzle schema from that data model (data_contract types → columns; conflicts block). `vibe --spec <id>` (legacy per-story): emit a runnable React mockup PR.",
     group: "pipeline",
   },
   {

--- a/packages/cli/src/commands/vibe/index.ts
+++ b/packages/cli/src/commands/vibe/index.ts
@@ -17,7 +17,9 @@ import { join, resolve } from "node:path";
 import { GitHubAdapter } from "@slowcook-ai/forge-github";
 import { runVibe, type VibeContext } from "./agent.js";
 import { listActiveSpecs } from "../refine/spec-yaml.js";
-import { compileLcrPlan, type PlanSpecInput } from "./lcr-plan.js";
+import { compileLcrPlan, type PlanSpecInput, type LcrPlan } from "./lcr-plan.js";
+import { compileDrizzleSchema } from "./schema-gen.js";
+import { loadMockShapeConfig } from "../../lib/mock-shape.js";
 
 interface VibeArgs {
   specId: string;
@@ -295,6 +297,9 @@ export async function vibe(argv: string[], cliVersion: string): Promise<void> {
   // whole-app LCR plan (data model + route/persona map + coverage). The spine
   // the schema/seed/surface generation passes hang off.
   if (argv[0] === "plan") return runPlan(argv.slice(1));
+  // `slowcook vibe schema` — deterministic, no LLM. Generate the LCR data
+  // adaptor's Drizzle schema from the plan's data model (the first gen pass).
+  if (argv[0] === "schema") return runSchema(argv.slice(1));
 
   const args = parseArgs(argv);
 
@@ -512,14 +517,10 @@ function buildPrBody(
  * print it (data model + persona/route map + coverage). Writes the machine form
  * to `.brewing/lcr-plan.json` for the generation passes. Deterministic, no LLM.
  */
-async function runPlan(argv: string[]): Promise<void> {
-  const cwd = resolve(argFlag(argv, "--cwd") ?? ".");
+/** Compile the LCR plan from the repo's active specs (shared by plan + schema). */
+function loadPlan(cwd: string): LcrPlan | null {
   const specs = listActiveSpecs(cwd);
-  if (specs.length === 0) {
-    console.error("vibe plan: no active specs under specs/ — run `menu` first.");
-    process.exit(1);
-  }
-
+  if (specs.length === 0) return null;
   const planSpecs: PlanSpecInput[] = specs.map((s) => ({
     storyId: s.story_id,
     entities: (s.data_contract?.entities ?? []).map((e) => ({
@@ -531,11 +532,20 @@ async function runPlan(argv: string[]): Promise<void> {
     persona: s.persona,
     surfaces: s.surfaces,
   }));
+  return compileLcrPlan(planSpecs);
+}
 
-  const plan = compileLcrPlan(planSpecs);
+async function runPlan(argv: string[]): Promise<void> {
+  const cwd = resolve(argFlag(argv, "--cwd") ?? ".");
+  const plan = loadPlan(cwd);
+  if (!plan) {
+    console.error("vibe plan: no active specs under specs/ — run `menu` first.");
+    process.exit(1);
+  }
+  const specCount = plan.stories.length;
 
   const fieldCount = plan.entities.reduce((n, e) => n + e.fields.length, 0);
-  console.log(`vibe plan — whole-app LCR from ${specs.length} specs\n`);
+  console.log(`vibe plan — whole-app LCR from ${specCount} specs\n`);
   console.log(`  data model:  ${plan.entities.length} entities · ${fieldCount} fields · ${plan.conflicts.length} conflict(s)`);
   console.log(`  personas:    ${plan.personas.length}  (${plan.personas.map((p) => p.id).join(", ") || "—"})`);
   console.log(`  surfaces:    ${plan.surfaces.length} route(s) across ${new Set(plan.surfaces.map((s) => s.route)).size} unique path(s)`);
@@ -577,4 +587,47 @@ async function runPlan(argv: string[]): Promise<void> {
 function argFlag(argv: string[], flag: string): string | undefined {
   const i = argv.indexOf(flag);
   return i >= 0 ? argv[i + 1] : undefined;
+}
+
+/**
+ * `slowcook vibe schema` — generate the LCR data adaptor's Drizzle schema from the
+ * plan's data model. Deterministic (the data_contract types map mechanically to
+ * Drizzle columns); the seed + surfaces passes (LLM) build on it. Writes to the
+ * mock's data-layer dir (default `mock/src/lib/schema.ts`).
+ */
+async function runSchema(argv: string[]): Promise<void> {
+  const cwd = resolve(argFlag(argv, "--cwd") ?? ".");
+  const plan = loadPlan(cwd);
+  if (!plan) {
+    console.error("vibe schema: no active specs under specs/ — run `menu` first.");
+    process.exit(1);
+  }
+  if (plan.entities.length === 0) {
+    console.error("vibe schema: the plan has no entities (specs carry no data_contract). Nothing to generate.");
+    process.exit(1);
+  }
+  if (plan.conflicts.length > 0) {
+    console.error(`vibe schema: ${plan.conflicts.length} data-model conflict(s) — resolve before schema-gen (run \`vibe plan\`):`);
+    for (const c of plan.conflicts) {
+      console.error(`    ✗ ${c.entity}.${c.field}: ${c.types.map((t) => t.type).join(" vs ")}`);
+    }
+    process.exit(1);
+  }
+
+  const schema = compileDrizzleSchema(plan.entities);
+
+  const mock = loadMockShapeConfig(cwd);
+  const rel = argFlag(argv, "--out") ?? join(mock.mock_root, "src/lib/schema.ts");
+  const fieldCount = plan.entities.reduce((n, e) => n + e.fields.length, 0);
+
+  if (argFlag(argv, "--stdout") !== undefined || argv.includes("--stdout")) {
+    process.stdout.write(schema);
+    return;
+  }
+
+  const outAbs = resolve(cwd, rel);
+  mkdirSync(join(outAbs, ".."), { recursive: true });
+  writeFileSync(outAbs, schema);
+  console.log(`vibe schema — ${plan.entities.length} tables · ${fieldCount} columns → ${rel}`);
+  console.log(`  deterministic (data_contract → Drizzle). Next: \`vibe seed\` (dense data) + surface passes.`);
 }

--- a/packages/cli/src/commands/vibe/schema-gen.test.ts
+++ b/packages/cli/src/commands/vibe/schema-gen.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { compileDrizzleSchema, mapType, snake, tableVar, parseRelation } from "./schema-gen.js";
+import type { PlanEntity } from "./lcr-plan.js";
+
+describe("schema-gen helpers", () => {
+  it("maps field types to Drizzle column builders", () => {
+    expect(mapType("uuid", "id").expr).toBe('text("id")');
+    expect(mapType("string", "name").expr).toBe('text("name")');
+    expect(mapType("integer", "count").expr).toBe('integer("count")');
+    expect(mapType("float", "rate").expr).toBe('real("rate")');
+    expect(mapType("boolean", "active").expr).toBe('integer("active", { mode: "boolean" })');
+    expect(mapType("timestamp", "created_at").expr).toBe('integer("created_at", { mode: "timestamp" })');
+    expect(mapType("json", "meta").expr).toBe('text("meta", { mode: "json" })');
+    expect(mapType("enum(a|b|c)", "kind").expr).toBe('text("kind", { enum: ["a", "b", "c"] })');
+    expect(mapType("enum(open,closed)", "state").expr).toBe('text("state", { enum: ["open", "closed"] })');
+    expect(mapType("weirdtype", "x").expr).toBe('text("x")'); // safe default
+  });
+
+  it("snake_cases names and lower-firsts the table var", () => {
+    expect(snake("OperatorAuditLog")).toBe("operator_audit_log");
+    expect(snake("Wallet")).toBe("wallet");
+    expect(tableVar("OperatorAuditLog")).toBe("operatorAuditLog");
+  });
+
+  it("parses relation declarations (with and without source-entity prefix)", () => {
+    expect(parseRelation("OperatorAuditLog.operator_id → Member.id")).toEqual({ field: "operator_id", targetEntity: "Member", targetField: "id" });
+    expect(parseRelation("reporter_id -> Member.id")).toEqual({ field: "reporter_id", targetEntity: "Member", targetField: "id" });
+    expect(parseRelation("garbage")).toBeNull();
+  });
+});
+
+describe("compileDrizzleSchema", () => {
+  const entities: PlanEntity[] = [
+    {
+      name: "Member",
+      fields: [
+        { name: "id", type: "uuid", fromStories: ["001"] },
+        { name: "handle", type: "string", fromStories: ["001"] },
+      ],
+      relations: [],
+      fromStories: ["001"],
+    },
+    {
+      name: "OperatorAuditLog",
+      fields: [
+        { name: "id", type: "uuid", fromStories: ["017"] },
+        { name: "operator_id", type: "uuid", fromStories: ["017"] },
+        { name: "action_type", type: "enum(worker_certified|worker_decertified)", fromStories: ["017"] },
+        { name: "note", type: "text|null", fromStories: ["017"] },
+        { name: "created_at", type: "timestamp", fromStories: ["017"] },
+      ],
+      relations: ["OperatorAuditLog.operator_id → Member.id"],
+      fromStories: ["017"],
+    },
+  ];
+
+  const out = compileDrizzleSchema(entities);
+
+  it("emits a sqliteTable per entity with @story provenance", () => {
+    expect(out).toContain("// @story story-001\nexport const member = sqliteTable(\"member\", {");
+    expect(out).toContain("// @story story-017\nexport const operatorAuditLog = sqliteTable(\"operator_audit_log\", {");
+  });
+
+  it("makes `id` the primary key and non-id non-null fields .notNull()", () => {
+    expect(out).toContain('id: text("id").primaryKey(),');
+    expect(out).toContain('handle: text("handle").notNull(),');
+  });
+
+  it("resolves a relation to a typed .references() thunk", () => {
+    expect(out).toContain('operator_id: text("operator_id").references(() => member.id).notNull(),');
+  });
+
+  it("keeps a `|null` field nullable (no .notNull())", () => {
+    expect(out).toContain('note: text("note"),');
+    expect(out).not.toContain('note: text("note").notNull()');
+  });
+
+  it("emits an enum column + inferred row types + minimal imports", () => {
+    expect(out).toContain('action_type: text("action_type", { enum: ["worker_certified", "worker_decertified"] }).notNull(),');
+    expect(out).toContain("export type OperatorAuditLog = typeof operatorAuditLog.$inferSelect;");
+    expect(out).toContain("export type NewMember = typeof member.$inferInsert;");
+    expect(out).toContain('import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";');
+  });
+
+  it("never makes the `id` primary key a foreign key (drops the inverse relation)", () => {
+    const inverse = compileDrizzleSchema([
+      { name: "Project", fields: [{ name: "id", type: "uuid", fromStories: ["1"] }], relations: ["Project.id → Wallet.project_id"], fromStories: ["1"] },
+      { name: "Wallet", fields: [{ name: "id", type: "uuid", fromStories: ["1"] }, { name: "project_id", type: "uuid", fromStories: ["1"] }], relations: ["Wallet.project_id → Project.id"], fromStories: ["1"] },
+    ]);
+    expect(inverse).toContain('id: text("id").primaryKey(),'); // project.id is a clean PK, no FK
+    expect(inverse).not.toContain("references(() => wallet");
+    expect(inverse).toContain('project_id: text("project_id").references(() => project.id).notNull(),'); // FK on the child
+  });
+
+  it("skips .references() when the target entity isn't in the model", () => {
+    const orphan = compileDrizzleSchema([
+      { name: "Ticket", fields: [{ name: "id", type: "uuid", fromStories: ["x"] }, { name: "ghost_id", type: "uuid", fromStories: ["x"] }], relations: ["ghost_id → Ghost.id"], fromStories: ["x"] },
+    ]);
+    expect(orphan).not.toContain(".references(");
+    expect(orphan).toContain('ghost_id: text("ghost_id").notNull(),');
+  });
+});

--- a/packages/cli/src/commands/vibe/schema-gen.ts
+++ b/packages/cli/src/commands/vibe/schema-gen.ts
@@ -1,0 +1,126 @@
+/**
+ * GUCDI — deterministic Drizzle schema generator (pure). The first GENERATION
+ * pass of the whole-app LCR vibe. Because the LCR plan's data model is already
+ * well-typed (menu emits structured `data_contract` field types + relations),
+ * the SQLite/Drizzle schema falls out mechanically — no LLM, no drift, testable.
+ *
+ * Structure → deterministic; content/judgment (seed data, surfaces) → LLM. This
+ * is that boundary. Output mirrors the rewo LCR precedent: one `@story`-annotated
+ * table per entity + inferred row types, SQLite-portable (brew swaps SQLite →
+ * Postgres, inheriting the models). See docs/plans/vibe-whole-mock-lcr.md.
+ */
+import type { PlanEntity } from "./lcr-plan.js";
+
+/** Table variable name: lower-first-letter of the entity (OperatorAuditLog →
+ *  operatorAuditLog, Wallet → wallet). */
+export function tableVar(name: string): string {
+  return name.charAt(0).toLowerCase() + name.slice(1);
+}
+
+/** SQL table/column name: snake_case. */
+export function snake(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+interface Mapped {
+  /** the drizzle column expression sans chaining, e.g. `text("status", { enum: [...] })` */
+  expr: string;
+  /** which top-level drizzle builders this used (for the import line) */
+  builder: "text" | "integer" | "real";
+}
+
+/** Map a data_contract field type → a Drizzle SQLite column builder. Robust to
+ *  the `|null` nullability suffix (stripped by the caller) and unknown types
+ *  (default to text). */
+export function mapType(rawType: string, sqlName: string): Mapped {
+  const t = rawType.trim().toLowerCase();
+  const col = JSON.stringify(sqlName);
+
+  const enumMatch = /^enum\s*\((.*)\)$/.exec(t);
+  if (enumMatch) {
+    const values = enumMatch[1]!
+      .split(/[|,]/)
+      .map((v) => v.trim())
+      .filter(Boolean);
+    return { expr: `text(${col}, { enum: [${values.map((v) => JSON.stringify(v)).join(", ")}] })`, builder: "text" };
+  }
+  if (/^(uuid|string|text|varchar|char)/.test(t)) return { expr: `text(${col})`, builder: "text" };
+  if (/^(timestamp|datetime|date|time)/.test(t)) return { expr: `integer(${col}, { mode: "timestamp" })`, builder: "integer" };
+  if (/^(bool|boolean)/.test(t)) return { expr: `integer(${col}, { mode: "boolean" })`, builder: "integer" };
+  if (/^(int|integer|bigint|serial|number)/.test(t)) return { expr: `integer(${col})`, builder: "integer" };
+  if (/^(float|real|double|decimal|numeric|money)/.test(t)) return { expr: `real(${col})`, builder: "real" };
+  if (/^(json|jsonb)/.test(t)) return { expr: `text(${col}, { mode: "json" })`, builder: "text" };
+  return { expr: `text(${col})`, builder: "text" }; // safe default
+}
+
+/** Parse a relation declaration into (sourceField → targetEntity.targetField).
+ *  Accepts `Entity.field → Target.tcol`, `field → Target.tcol`, with `→` or `->`. */
+export function parseRelation(rel: string): { field: string; targetEntity: string; targetField: string } | null {
+  const parts = rel.split(/→|->/).map((s) => s.trim());
+  if (parts.length !== 2) return null;
+  const [left, right] = parts;
+  const field = left!.includes(".") ? left!.split(".").pop()!.trim() : left!.trim();
+  const rdot = right!.split(".");
+  if (rdot.length < 2) return null;
+  const targetEntity = rdot[0]!.trim();
+  const targetField = rdot[1]!.trim();
+  if (!field || !targetEntity || !targetField) return null;
+  return { field, targetEntity, targetField };
+}
+
+/** Generate the full `schema.ts` content from the plan's entity model. */
+export function compileDrizzleSchema(entities: PlanEntity[]): string {
+  const usedBuilders = new Set<string>(["sqliteTable"]);
+  const knownEntities = new Set(entities.map((e) => e.name));
+  const blocks: string[] = [];
+
+  for (const e of entities) {
+    // field → reference (only when the target entity is in the model).
+    const refByField = new Map<string, { targetEntity: string; targetField: string }>();
+    for (const rel of e.relations) {
+      const parsed = parseRelation(rel);
+      if (parsed && knownEntities.has(parsed.targetEntity)) {
+        refByField.set(parsed.field, { targetEntity: parsed.targetEntity, targetField: parsed.targetField });
+      }
+    }
+
+    const cols: string[] = [];
+    for (const f of e.fields) {
+      const nullable = /\|\s*null\s*$/.test(f.type);
+      const baseType = f.type.replace(/\|\s*null\s*$/, "");
+      const sqlName = snake(f.name);
+      const m = mapType(baseType, sqlName);
+      usedBuilders.add(m.builder);
+      const isPk = f.name === "id";
+      let chain = m.expr;
+      if (isPk) chain += ".primaryKey()";
+      // A foreign key lives on the *referencing* column, never on the PK. A
+      // relation that names this entity's `id` as the source is the inverse
+      // (has-one/has-many) of a real FK that lives on the child table — skip it
+      // here; the child emits the actual `.references()`.
+      const ref = isPk ? undefined : refByField.get(f.name);
+      if (ref) chain += `.references(() => ${tableVar(ref.targetEntity)}.${ref.targetField})`;
+      if (!nullable && !isPk) chain += ".notNull()";
+      cols.push(`  ${f.name}: ${chain},`);
+    }
+
+    const provenance = `// @story ${e.fromStories.map((s) => `story-${s}`).join(", ")}`;
+    blocks.push(
+      `${provenance}\nexport const ${tableVar(e.name)} = sqliteTable(${JSON.stringify(snake(e.name))}, {\n${cols.join("\n")}\n});\n` +
+        `export type ${e.name} = typeof ${tableVar(e.name)}.$inferSelect;\n` +
+        `export type New${e.name} = typeof ${tableVar(e.name)}.$inferInsert;`
+    );
+  }
+
+  const importLine = `import { ${[...usedBuilders].sort().join(", ")} } from "drizzle-orm/sqlite-core";`;
+  const header =
+    `// @convention LCR data adaptor — generated by \`slowcook vibe schema\` from the\n` +
+    `// LCR plan's data model (specs' data_contract). Deterministic; do not hand-edit —\n` +
+    `// change a spec's data_contract and regenerate. SQLite-portable (brew swaps to\n` +
+    `// Postgres, inheriting these models). ${entities.length} entities.`;
+
+  return `${header}\n${importLine}\n\n${blocks.join("\n\n")}\n`;
+}


### PR DESCRIPTION
Generation **pass 1** of the whole-app LCR (builds on #211's plan foundation). The plan's data model is well-typed, so the Drizzle schema is **deterministic** — no LLM, no drift.

`slowcook vibe schema` → `compileDrizzleSchema` (pure, 10 tests): `@story`-annotated, SQLite-portable schema. uuid/string→text, timestamp→integer ts-mode, enum(...)→text+enum, float→real, `|null`→nullable; FK thunks from relations; `id`→primaryKey and **never** an FK (drops inverse relations). Conflicts block the run.

**This draws the architectural boundary: structure → deterministic; content/judgment (seed, surfaces) → LLM.**

**Dogfood (dash):** re-derived specs (now with persona+surfaces) → `vibe schema` → **37 tables · 292 columns**, 0 PK-as-FK, no dangling FK targets, valid syntax. Vetting caught + fixed a real inverse-relation bug (`project.id` was being made an FK to its child `wallet`).

Next: seed+adaptor pass (LLM, dense state-covering data) → surface passes → shell. Design: `docs/plans/vibe-whole-mock-lcr.md`. 1341 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)