### PR TITLE
feat(review-overlay): 0.9.5 — live EPSS status, login hint, signed-in pill no clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.9.5 — live EPSS status, login hints, signed-in pill no longer clips
+
+`@slowcook-ai/review-overlay` 0.9.5 (overlay-only; additive). Three fixes from the delgoosh dogfood:
+
+- **The EPSS status is now LIVE** — it reflects the surface the reviewer is *actually* on (reactive to navigation), not just the last picked surface. It tracks SPA navigation (`history.pushState`/`replaceState` patched to notify, plus `popstate`/`hashchange` and a low-frequency poll). When the live path matches the selection it shows the full `Context › Scenario › State`; navigate away and it shows the live `Context › Scenario`; off-manifest it shows `Identity › /path`. New helpers `findSurfaceByPath` / `liveSurfaceLabel`.
+- **Login/OTP "how to enter" hint.** An anonymous context can now carry a `hint` (manifest field); on its login/OTP surface the pill shows it in a **distinct colour** (🔑, amber) under the status, telling the reviewer how to sign in (test OTP / email / masterkey, or "use the jumper"). New helper `activeHint`.
+- **Signed-in pill no longer clips.** With the 0.9.3 `min-content` column, a wide signed-in button row (the `@user` identity chip) overflowed *outside* the pill border because the width was hard-capped at 300px. The cap is now `min(560px, 94vw)` — the pill sizes to its button row and keeps the chip inside; the grip still pans it on a tiny viewport.
+
+No breaking changes (adds `ManifestContext.hint` + the three helpers).
+
 ## review-overlay 0.9.4 — distinct comments-panel header bar
 
 `@slowcook-ai/review-overlay` 0.9.4 (overlay-only; additive). The comments side-panel header ("Comments (N)") was transparent over the panel body — correctly themed but blending in, so it read as a flat/unfinished header. It now has a **distinct elevated header bar** (`#23232e` dark / `#f4f5f7` light) with the divider below, so the title reads as a proper header in both schemes. No API changes.

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -67,7 +67,7 @@ import {
 } from "../reviewer-session.js";
 import { isResolvedStatus } from "../comment-format.js";
 import { readCurrentStory } from "./use-story-marker.js";
-import { loadManifest, applySelection, getSelection, selectionBreadcrumb, type Manifest } from "../testing-surfaces.js";
+import { loadManifest, applySelection, getSelection, liveSurfaceLabel, activeHint, type Manifest } from "../testing-surfaces.js";
 
 export interface SlowcookReviewOverlayProps {
   /**
@@ -1243,6 +1243,32 @@ function usePrefersDark(): boolean {
   return dark;
 }
 
+// 0.9.5 — track the live pathname so the EPSS status reflects where the reviewer
+// ACTUALLY is, reactively. react-router (and most SPA routers) navigate via
+// history.pushState without firing popstate, so patch it to notify us; popstate +
+// a low-freq poll are belt-and-braces.
+function useCurrentPath(): string {
+  const [path, setPath] = useState<string>(() => { try { return window.location.pathname; } catch { return "/"; } });
+  useEffect(() => {
+    const update = () => { try { setPath(window.location.pathname); } catch { /* ssr */ } };
+    window.addEventListener("popstate", update);
+    window.addEventListener("hashchange", update);
+    const origPush = history.pushState; const origReplace = history.replaceState;
+    try {
+      history.pushState = function (this: History, ...a: Parameters<History["pushState"]>) { const r = origPush.apply(this, a); update(); return r; };
+      history.replaceState = function (this: History, ...a: Parameters<History["replaceState"]>) { const r = origReplace.apply(this, a); update(); return r; };
+    } catch { /* history not patchable */ }
+    const iv = setInterval(update, 700);
+    return () => {
+      window.removeEventListener("popstate", update);
+      window.removeEventListener("hashchange", update);
+      try { history.pushState = origPush; history.replaceState = origReplace; } catch { /* */ }
+      clearInterval(iv);
+    };
+  }, []);
+  return path;
+}
+
 interface PillTheme { bg: string; border: string; fg: string; fgDim: string; sub: string; subBorder: string; shadow: string; ghBg: string; ghFg: string; }
 function pillTheme(dark: boolean): PillTheme {
   return dark
@@ -1327,6 +1353,8 @@ function ModeToggle(props: {
   // 0.9.0 — follow the system colour scheme.
   const dark = usePrefersDark();
   const T = pillTheme(dark);
+  // 0.9.5 — live pathname so the EPSS status tracks navigation.
+  const currentPath = useCurrentPath();
 
   // 0.6.3 — sign-out is a two-step confirm: the disk floats, so a single
   // mis-click shouldn't log you out. First click/tap on the identity chip arms
@@ -1393,7 +1421,12 @@ function ModeToggle(props: {
         display: "flex",
         flexDirection: "row",
         alignItems: "stretch",
-        maxWidth: "min(300px, 90vw)",
+        // 0.9.5 — cap at the viewport, not a fixed 300px: the content column is
+        // min-content (= button-row width), so the pill is already only as wide
+        // as its buttons; a hard 300px cap clipped the signed-in identity chip
+        // OUTSIDE the pill border. 94vw keeps a wide (signed-in) row inside the
+        // pill; on a truly tiny viewport the grip still pans it left.
+        maxWidth: "min(560px, 94vw)",
         gap: 4,
         // 0.4.2 — green-tinted when approved; else follows the system theme.
         background: isApproved ? (dark ? "rgba(20, 83, 45, 0.92)" : "rgba(220, 245, 228, 0.96)") : T.bg,
@@ -1625,28 +1658,47 @@ function ModeToggle(props: {
       )}
       </div>{/* /top row */}
 
-      {/* 0.9.1 — EPSS current location: always shown, small font, both modes.
-          Tapping it opens the jump palette (the dedicated 🎛 button was dropped).
-          The status WRAPS onto a few lines instead of widening the pill right. */}
+      {/* 0.9.1/0.9.5 — EPSS current location: always shown, small font, both
+          modes. 0.9.5 — it's now LIVE: reflects the surface the reviewer is
+          actually on (reactive to navigation), not just the last pick. Tapping
+          it opens the jump palette. Wraps instead of widening the pill. */}
       {surfaceManifest && surfaceManifest.epics.length > 0 && (() => {
         const sel = getSelection();
-        const crumb = sel ? selectionBreadcrumb(surfaceManifest, sel) : null;
+        const crumb = liveSurfaceLabel(surfaceManifest, sel, currentPath);
+        const hint = activeHint(surfaceManifest, sel, currentPath);
         return (
-          <button
-            type="button"
-            data-slowcook-overlay-ui="1"
-            data-testid="epss-status"
-            onClick={() => setPaletteOpen(true)}
-            title={crumb ? `${crumb} — tap to jump` : "No surface selected — tap to jump"}
-            style={{
-              width: "100%", maxWidth: "100%", display: "block", textAlign: "start",
-              padding: "0 2px 1px", margin: 0, border: "none", background: "transparent",
-              color: T.fgDim, cursor: "pointer", font: "inherit", fontSize: 9.5, lineHeight: 1.25,
-              whiteSpace: "normal", overflowWrap: "anywhere", wordBreak: "break-word",
-            }}
-          >
-            {crumb ?? "no surface selected"}
-          </button>
+          <>
+            <button
+              type="button"
+              data-slowcook-overlay-ui="1"
+              data-testid="epss-status"
+              onClick={() => setPaletteOpen(true)}
+              title={crumb ? `${crumb} — tap to jump` : "No surface selected — tap to jump"}
+              style={{
+                width: "100%", maxWidth: "100%", display: "block", textAlign: "start",
+                padding: "0 2px 1px", margin: 0, border: "none", background: "transparent",
+                color: T.fgDim, cursor: "pointer", font: "inherit", fontSize: 9.5, lineHeight: 1.25,
+                whiteSpace: "normal", overflowWrap: "anywhere", wordBreak: "break-word",
+              }}
+            >
+              {crumb ?? "no surface selected"}
+            </button>
+            {/* 0.9.5 — on an anonymous (login/OTP) surface, a distinct-colour hint
+                telling the reviewer HOW to enter (test OTP / email / masterkey). */}
+            {hint && (
+              <div
+                data-slowcook-overlay-ui="1"
+                data-testid="epss-hint"
+                style={{
+                  width: "100%", maxWidth: "100%", padding: "1px 2px 0", margin: 0,
+                  color: dark ? "#ffd27a" : "#a8660a", font: "inherit", fontSize: 9.5,
+                  lineHeight: 1.25, whiteSpace: "normal", overflowWrap: "anywhere", wordBreak: "break-word",
+                }}
+              >
+                🔑 {hint}
+              </div>
+            )}
+          </>
         );
       })()}
       </div>{/* /content column */}

--- a/packages/review-overlay/src/testing-surfaces.test.ts
+++ b/packages/review-overlay/src/testing-surfaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSelection, resolveSeed, selectionBreadcrumb, type Manifest } from "./testing-surfaces.js";
+import { resolveSelection, resolveSeed, selectionBreadcrumb, findSurfaceByPath, liveSurfaceLabel, activeHint, type Manifest } from "./testing-surfaces.js";
 
 const M: Manifest = {
   epics: [
@@ -9,6 +9,7 @@ const M: Manifest = {
       contexts: [
         {
           id: "guest", label: "Guest (logged out)", group: "Logged out", base: "/p/", status: "anonymous",
+          hint: "Mock: any phone, OTP 000000",
           scenarios: [
             { id: "login", label: "Log in", route: "/login", states: [
               { id: "form", label: "Login form" },
@@ -95,5 +96,35 @@ describe("selectionBreadcrumb", () => {
     const legacy = { epicId: "x", contextId: "x", scenarioId: "x", stateId: "x", status: "authed" as const, route: "/", base: "/p/" as const, label: "Therapist · Bond · No-show penalty", user: null, seed: {}, fixtures: {} };
     expect(selectionBreadcrumb(M, legacy)).toBe("Therapist › Bond › No-show penalty");
     expect(selectionBreadcrumb(null, legacy)).toBe("Therapist › Bond › No-show penalty");
+  });
+});
+
+describe("live surface (reactive status)", () => {
+  it("findSurfaceByPath matches base+route (base-aware), else null", () => {
+    expect(findSurfaceByPath(M, "/p/login")?.scn.id).toBe("login");
+    expect(findSurfaceByPath(M, "/p/patient/wallet")?.ctx.id).toBe("pf");
+    expect(findSurfaceByPath(M, "/t/therapist/accounting")?.ctx.id).toBe("ti");
+    expect(findSurfaceByPath(M, "/p/nope")).toBeNull();
+  });
+  it("shows the full breadcrumb when the live path matches the selection", () => {
+    const sel = resolveSelection(M, "payment", "pf", "cancel", "has")!.selection;
+    expect(liveSurfaceLabel(M, sel, "/p/patient/wallet")).toBe("Patient › Cancel › Has upcoming");
+  });
+  it("tracks navigation away to a different surface (identity › live scenario, no state)", () => {
+    const sel = resolveSelection(M, "payment", "pf", "cancel", "has")!.selection;
+    expect(liveSurfaceLabel(M, sel, "/t/therapist/accounting")).toBe("Therapist › Payout");
+  });
+  it("with no selection, labels the live surface; unknown path → null", () => {
+    expect(liveSurfaceLabel(M, null, "/p/login")).toBe("Guest (logged out) › Log in");
+    expect(liveSurfaceLabel(M, null, "/p/nope")).toBeNull();
+  });
+});
+
+describe("activeHint (login/OTP how-to-enter)", () => {
+  it("returns the anonymous context hint on its login surface", () => {
+    expect(activeHint(M, null, "/p/login")).toBe("Mock: any phone, OTP 000000");
+  });
+  it("no hint on an authed surface", () => {
+    expect(activeHint(M, null, "/p/patient/wallet")).toBeNull();
   });
 });

--- a/packages/review-overlay/src/testing-surfaces.ts
+++ b/packages/review-overlay/src/testing-surfaces.ts
@@ -42,6 +42,9 @@ export interface ManifestContext {
   base: string;
   status: "anonymous" | "authed";
   user?: Record<string, unknown>;
+  /** Reviewer hint for anonymous surfaces — how to "enter" (e.g. test OTP /
+   *  email / masterkey). Shown in the pill, in a distinct colour, on login/OTP. */
+  hint?: string;
   scenarios: ManifestScenario[];
 }
 export interface Epic {
@@ -135,6 +138,49 @@ export function selectionBreadcrumb(m: Manifest | null, sel: ResolvedSelection):
   const st = scn?.states.find((s) => s.id === sel.stateId);
   if (ctx && scn && st) return `${ctx.label.split(" · ")[0]} › ${scn.label} › ${st.label}`;
   return (sel.label || "").replace(/ · /g, " › ");
+}
+
+/** Base-aware full path of a surface (context base + scenario route). */
+function surfacePath(base: string, route: string): string {
+  return (`${base.replace(/\/$/, "")}${route}`).replace(/\/{2,}/g, "/").replace(/\/$/, "") || "/";
+}
+
+/** The context+scenario whose route matches the live pathname (base-aware), or null. */
+export function findSurfaceByPath(m: Manifest | null, pathname: string): { ctx: ManifestContext; scn: ManifestScenario } | null {
+  if (!m) return null;
+  const p = (pathname || "/").replace(/\/$/, "") || "/";
+  for (const epic of m.epics)
+    for (const ctx of epic.contexts)
+      for (const scn of ctx.scenarios)
+        if (surfacePath(ctx.base, scn.route) === p) return { ctx, scn };
+  return null;
+}
+
+/**
+ * LIVE status breadcrumb — reflects where the reviewer ACTUALLY is (reactive to
+ * navigation), not just the last picked surface. If the current path matches the
+ * selected scenario, show the full selection breadcrumb (with state); else show
+ * the matched surface (identity › scenario); else identity › raw-path.
+ */
+export function liveSurfaceLabel(m: Manifest | null, sel: ResolvedSelection | null, pathname: string): string | null {
+  const hit = findSurfaceByPath(m, pathname);
+  if (hit) {
+    if (sel && sel.contextId === hit.ctx.id && sel.route === hit.scn.route) return selectionBreadcrumb(m, sel);
+    return `${hit.ctx.label.split(" · ")[0]} › ${hit.scn.label}`;
+  }
+  if (sel) {
+    const id = selectionBreadcrumb(m, sel).split(" › ")[0];
+    return `${id} › ${(pathname || "/").replace(/\/$/, "") || "/"}`;
+  }
+  return null;
+}
+
+/** Reviewer "how to enter" hint for the active anonymous surface, if authored. */
+export function activeHint(m: Manifest | null, sel: ResolvedSelection | null, pathname: string): string | null {
+  const hit = findSurfaceByPath(m, pathname);
+  const ctx = hit?.ctx
+    ?? (sel && m ? m.epics.flatMap((e) => e.contexts).find((c) => c.id === sel.contextId) ?? null : null);
+  return ctx && ctx.status === "anonymous" && ctx.hint ? ctx.hint : null;
 }
 
 /** Pure resolver — manifest + ids → the selection to persist + the target URL (handles `becomes`). */


### PR DESCRIPTION
Brings review-overlay **0.9.5** onto \`main\` (the only overlay commit on \`feat/review-overlay-epss\` not yet on main after #206).

## What
- Live EPSS status in the pill
- Login hint for unauthenticated reviewers
- Signed-in pill no longer clips
- (carries the full 0.9.x pill UX: nav/rev toggle, left-anchored pill, light/dark theming, Spotlight jump palette, EPSS breadcrumb, compaction)

## Why
The delgoosh-box review overlay tracks **HEAD of main**. This 0.9.5 work was stranded on the feature branch, so head-of-main deploys silently dropped it. Merging makes main the single source of truth for the deployed pill.

## Contribution checklist
- ✅ CHANGELOG.md updated
- ✅ Tests included (testing-surfaces.test.ts)
- ✅ Clean merge into main (0 conflicts)