### PR TITLE
docs(review-overlay): vite dev-server mocks behind a CDN — the ?v= immutable trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay — docs: vite dev-server mocks behind a CDN (the `?v=` immutable trap)
+
+Docs-only (no code/version change). README `Hosting the built mock` section gains a subsection for the **live vite dev-server** case: vite serves optimized dep bundles (`/node_modules/.vite/deps/*.js?v=<hash>`) as `immutable`, but reuses the `?v` across re-optimizes — so a CDN (Cloudflare) caches a redeployed-but-same-version dep bundle immutably and serves the **stale** overlay to reviewers forever (`cf-cache-status: HIT`), even though the origin serves the new code. Documents the symptom and the fix (`proxy_hide_header Cache-Control; add_header Cache-Control "no-store"` on the dev proxy locations, + a one-time CDN purge to evict the already-poisoned entry). Surfaced by the delgoosh dogfood.
+
 ## review-overlay 0.9.5 — live EPSS status, login hints, signed-in pill no longer clips
 
 `@slowcook-ai/review-overlay` 0.9.5 (overlay-only; additive). Three fixes from the delgoosh dogfood:

--- a/packages/review-overlay/README.md
+++ b/packages/review-overlay/README.md
@@ -84,6 +84,47 @@ location / { try_files $uri $uri/ /index.html; }   # SPA fallback
 > `no-cache` (don't let the CDN cache `index.html`). `slowcook run-mock` already serves
 > with no-store dev headers; this note is for **self-hosted static deploys**.
 
+### Live vite **dev**-server mocks behind a CDN — the `?v=` immutable trap
+
+If you serve a **running vite dev server** for review (e.g. `vite --base=/p/`
+proxied through nginx + Cloudflare, as the delgoosh box does) instead of a static
+build, there's a sharper version of the same trap. Vite serves its **optimized
+dependency bundles** at
+
+```
+/node_modules/.vite/deps/<dep>.js?v=<hash>
+```
+
+with `Cache-Control: max-age=31536000, immutable`. The `?v=<hash>` *looks* like a
+content hash but **is not** — vite derives it from the lockfile + config and
+**reuses the same `?v` across re-optimizes**, even when a dependency's built
+output changed (e.g. you rebuilt the overlay and reinstalled it in place at the
+same version). A CDN in front caches that URL **immutably for a year** and keeps
+serving the **old** bundle to every reviewer no matter how often you redeploy —
+and a hard refresh won't help, because the stale copy lives at the **CDN edge**,
+not the browser.
+
+**Symptom:** the box origin serves the new overlay
+(`curl http://127.0.0.1:<vite-port>/…/.vite/deps/<dep>.js` shows the new code) but
+reviewers still see the old pill/UX through the public URL, with
+`cf-cache-status: HIT`.
+
+**Fix:** strip vite's `immutable` and force `no-store` on the dev proxy locations
+so the CDN never caches dev bundles:
+
+```nginx
+location /p/ {                        # …and /t/, and any other dev SPA
+  proxy_pass http://127.0.0.1:5181;
+  proxy_hide_header Cache-Control;
+  add_header Cache-Control "no-store" always;
+  # …proxy_set_header Upgrade / Connection for HMR, etc.
+}
+```
+
+After adding this, **purge the CDN once** (or publish a new version so the `?v`
+changes) to evict any already-poisoned `immutable` entry — `no-store` only
+prevents *future* caching, it can't drop a pre-existing immutable hit.
+
 ## How a comment lands in the PR
 
 1. PM clicks the floating toggle → **💬 Comment**.


### PR DESCRIPTION
Burns the cache gotcha that bit the delgoosh box into the serving directives.

## Problem
Serving a **live vite dev server** for LCR review (e.g. `vite --base=/p/` behind nginx + Cloudflare) — not a static build. Vite serves optimized dep bundles at `/node_modules/.vite/deps/<dep>.js?v=<hash>` with `Cache-Control: max-age=31536000, immutable`, but **reuses the same `?v` across re-optimizes** (it keys on the lockfile, not the dist content). A CDN caches that URL immutably and serves the **stale** overlay to every reviewer no matter how often you redeploy — hard refresh doesn't help (stale copy is at the CDN edge). Symptom: origin `curl` shows new code; public URL shows old pill with `cf-cache-status: HIT`.

## Fix (documented)
- `proxy_hide_header Cache-Control; add_header Cache-Control "no-store" always;` on the dev proxy `location` blocks (`/p/`, `/t/`, …) so the CDN never caches dev bundles.
- One-time CDN purge (or publish a new version → new `?v`) to evict the already-poisoned immutable entry.

## Scope
- Docs only — `packages/review-overlay/README.md` (new subsection under *Hosting the built mock*) + CHANGELOG entry.
- No code/version change, so no tests.