### PR TITLE
feat(review-overlay): 0.9.7 — ☰ All lists every EPSS surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.9.7
+
+- EPSS jump palette: a **☰ All** button lists every surface (epic/persona/scenario/state) without the ≥3-char spotlight gate — an empty query matches all rows. Browsing the full route set no longer requires guessing search terms.
+
+
 ## review-overlay — docs: vite dev-server mocks behind a CDN (the `?v=` immutable trap)
 
 Docs-only (no code/version change). README `Hosting the built mock` section gains a subsection for the **live vite dev-server** case: vite serves optimized dep bundles (`/node_modules/.vite/deps/*.js?v=<hash>`) as `immutable`, but reuses the `?v` across re-optimizes — so a CDN (Cloudflare) caches a redeployed-but-same-version dep bundle immutably and serves the **stale** overlay to reviewers forever (`cf-cache-status: HIT`), even though the origin serves the new code. Documents the symptom and the fix (`proxy_hide_header Cache-Control; add_header Cache-Control "no-store"` on the dev proxy locations, + a one-time CDN purge to evict the already-poisoned entry). Surfaced by the delgoosh dogfood.

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1745,6 +1745,9 @@ function SurfacePalette(props: {
   const dark = usePrefersDark();
   const S = sheetTheme(dark);
   const [q, setQ] = useState("");
+  // 0.9.7 — "list all" affordance: the ☰ button reveals the full grouped list
+  // without the ≥3-char spotlight gate (an empty query matches every row).
+  const [showAll, setShowAll] = useState(false);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", onKey);
@@ -1754,7 +1757,8 @@ function SurfacePalette(props: {
   const sel = getSelection();
   interface Row { epicId: string; contextId: string; scenarioId: string; stateId: string; epicLabel: string; ctxLabel: string; scnLabel: string; stLabel: string; hard?: boolean; becomes?: boolean; q: string }
   const query = q.trim();
-  const show = query.length >= PALETTE_MIN_CHARS; // Spotlight: results only after 3 chars
+  // Spotlight: results after ≥3 chars — OR show everything when "list all" is on.
+  const show = showAll || query.length >= PALETTE_MIN_CHARS;
   const groups: { key: string; rows: Row[] }[] = [];
   let count = 0;
   if (show) {
@@ -1794,9 +1798,15 @@ function SurfacePalette(props: {
           <input className="sc-ovl-palette-input" autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Jump to a surface / state…" aria-label="Search surfaces"
             style={{ flex: 1, minWidth: 0, outline: "none", fontSize: 16, padding: "8px 10px", borderRadius: 8, borderStyle: "solid", borderWidth: 1, appearance: "none", WebkitAppearance: "none", colorScheme: dark ? "dark" : "light" }} />
           {q && <button type="button" aria-label="Clear" onClick={() => setQ("")} style={{ border: "none", background: "transparent", color: S.fgDim, cursor: "pointer", fontSize: 16, lineHeight: 1 }}>×</button>}
+          <button type="button" aria-label="List all surfaces" title="List all surfaces" aria-pressed={showAll}
+            onClick={() => setShowAll((v) => !v)}
+            style={{ flexShrink: 0, border: `1px solid ${S.inputBorder}`, background: showAll ? S.rowActive : "transparent", color: S.fg, cursor: "pointer", fontSize: 12.5, fontWeight: 600, lineHeight: 1, borderRadius: 8, padding: "7px 10px" }}>☰ All</button>
         </div>
         {query.length > 0 && !show && (
-          <div style={{ borderTop: `1px solid ${S.border}`, padding: "12px 16px", fontSize: 12.5, color: S.fgDim }}>Keep typing… ({PALETTE_MIN_CHARS}+ letters)</div>
+          <div style={{ borderTop: `1px solid ${S.border}`, padding: "12px 16px", fontSize: 12.5, color: S.fgDim }}>Keep typing… ({PALETTE_MIN_CHARS}+ letters) — or tap <b>☰ All</b> to list everything.</div>
+        )}
+        {!show && query.length === 0 && (
+          <div style={{ borderTop: `1px solid ${S.border}`, padding: "12px 16px", fontSize: 12.5, color: S.fgDim }}>Type to search, or tap <b>☰ All</b> to list every surface.</div>
         )}
         {show && (
           <div style={{ borderTop: `1px solid ${S.border}`, overflow: "auto", padding: "4px 8px 8px" }}>


### PR DESCRIPTION
The EPSS jump palette gated results behind ≥3 typed chars (spotlight-style), so seeing the full route set meant guessing search terms (you had to 'try 3 chars to hit some routes').

Added a **☰ All** toggle in the palette's search bar that lists the complete grouped surface set (epic ▸ persona ▸ scenario ▸ state) — the existing filter already matches every row on an empty query, so this just lifts the char gate. Empty-state hints now point at it.

**Tested live (dash_mock.slowcook.dev):** clicking ☰ All lists all **87** surface rows (8 personas × routes × states); 0 before. 89 overlay tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)