### PR TITLE
budgeting: menu emits an `effort` block + `slowcook estimate`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,6 +45,10 @@ Run `slowcook help <command>` or `slowcook <command> --help` for per-command det
   ```
   slowcook greenfield status [--prd <path>] [--cwd <dir>]
   ```
+- **`estimate`** — Budgeting: 3-point dual-currency (manhours + tokens) estimate per story from countable drivers + the menu `effort` block, rolled up to portfolio p50/p85/p95 via Monte-Carlo.
+  ```
+  slowcook estimate [--cwd <dir>] [--by-epic] [--json] [--iterations <n>]
+  ```
 - **`refine`** — Drive a GitHub issue through a clarifying-question loop until a frozen spec PR is emitted.
   ```
   slowcook refine --issue <number> [--cwd <path>] [--owner <login>] [--repo <name>]

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,6 +41,7 @@ import { brand } from "./commands/brand/index.js";
 import { eye } from "./commands/eye/index.js";
 import { gate } from "./commands/gate/index.js";
 import { menu } from "./commands/menu/index.js";
+import { runEstimate } from "./commands/estimate/index.js";
 import { trace } from "./commands/trace/index.js";
 import { reconcile } from "./commands/reconcile/index.js";
 import { greenfield } from "./commands/greenfield/index.js";
@@ -291,6 +292,12 @@ async function main(): Promise<void> {
       // GUCDI — decompose a PRD into a comprehensive, anchored, data-contracted
       // story set under specs/. The greenfield entry point.
       await menu(args.slice(1), VERSION);
+      return;
+    case "estimate":
+      // Budgeting — the post-menu cone point: 3-point dual-currency (manhours +
+      // tokens) per story from countable drivers ⊕ the LLM `effort` block, rolled
+      // up to portfolio percentiles via Monte-Carlo. dash consumes this.
+      await runEstimate(args.slice(1));
       return;
     case "trace":
       // GUCDI — provenance-completeness lint over the spine (the keystone):

--- a/packages/cli/src/commands.manifest.ts
+++ b/packages/cli/src/commands.manifest.ts
@@ -56,6 +56,12 @@ export const COMMANDS: ReadonlyArray<CommandEntry> = [
     group: "pipeline",
   },
   {
+    name: "estimate",
+    usage: "slowcook estimate [--cwd <dir>] [--by-epic] [--json] [--iterations <n>]",
+    description: "Budgeting: 3-point dual-currency (manhours + tokens) estimate per story from countable drivers + the menu `effort` block, rolled up to portfolio p50/p85/p95 via Monte-Carlo.",
+    group: "pipeline",
+  },
+  {
     name: "refine",
     usage: "slowcook refine --issue <number> [--cwd <path>] [--owner <login>] [--repo <name>]",
     description: "Drive a GitHub issue through a clarifying-question loop until a frozen spec PR is emitted.",

--- a/packages/cli/src/commands/estimate/index.ts
+++ b/packages/cli/src/commands/estimate/index.ts
@@ -1,0 +1,76 @@
+/**
+ * `slowcook estimate` — the post-`menu` budget. Reads active specs, computes a
+ * 3-point dual-currency estimate per story (countable drivers ⊕ the LLM `effort`
+ * block), and rolls the backlog up to portfolio percentiles via Monte-Carlo.
+ *
+ * This is the earliest, highest-decision-value point on the cone of uncertainty;
+ * dash consumes this output for the Forecast/roadmap surfaces. See
+ * dash docs/BUDGETING-AND-ROADMAP.md.
+ */
+import { resolve } from "node:path";
+import { listActiveSpecs } from "../refine/spec-yaml.js";
+import { estimateStory, monteCarloPortfolio, SEED_CALIBRATION, type StoryEstimate } from "./model.js";
+
+function argFlag(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+const usd = (cents: number) => `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+const hrs = (h: number) => `${h.toFixed(1)}h`;
+const tok = (t: number) => (t >= 1_000_000 ? `${(t / 1_000_000).toFixed(1)}M` : `${Math.round(t / 1000)}k`);
+
+export async function runEstimate(argv: string[]): Promise<void> {
+  const cwd = resolve(argFlag(argv, "--cwd") ?? ".");
+  const asJson = argv.includes("--json");
+  const byEpic = argv.includes("--by-epic");
+  const iterations = Number(argFlag(argv, "--iterations") ?? "10000");
+
+  const specs = listActiveSpecs(cwd);
+  if (specs.length === 0) {
+    console.error("estimate: no active specs under specs/ — run `menu` first.");
+    process.exit(1);
+  }
+  const estimates = specs.map((s) => estimateStory(s, SEED_CALIBRATION));
+  const portfolio = monteCarloPortfolio(estimates, iterations);
+  const withEffort = specs.filter((s) => s.effort).length;
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ estimates, portfolio, calibration: "seed", withEffort }, null, 2) + "\n");
+    return;
+  }
+
+  console.log(`slowcook estimate — ${estimates.length} stories · ${withEffort} carry an \`effort\` block · seed calibration\n`);
+
+  const rows = byEpic ? groupByEpic(estimates) : [{ label: null as string | null, items: estimates }];
+  for (const group of rows) {
+    if (group.label !== null) console.log(`\n  ▟ ${group.label}`);
+    for (const e of group.items) {
+      const flags = [e.risk !== "low" ? `risk:${e.risk}` : "", e.confidence < 0.6 ? `conf:${e.confidence}` : "", ...e.qualitativeDrivers]
+        .filter(Boolean).join(" ");
+      console.log(
+        `  story-${e.storyId}  ${usd(e.costCents.m).padStart(8)} p50  ${usd(e.costCents.p).padStart(8)} p-hi` +
+        `   ${hrs(e.hours.m).padStart(7)} · ${tok(e.tokens.m).padStart(5)} tok   ${e.title.slice(0, 46)}` +
+        (flags ? `\n              ↳ ${flags}` : "")
+      );
+    }
+  }
+
+  const P = portfolio;
+  console.log(`\n  ── Portfolio (Monte-Carlo, ${P.iterations.toLocaleString()} runs over ${P.stories} stories) ──`);
+  console.log(`  Cost     p50 ${usd(P.costCents.p50)}   p85 ${usd(P.costCents.p85)}   p95 ${usd(P.costCents.p95)}   (Σ-deterministic ${usd(P.deterministic.costCents)})`);
+  console.log(`  Labor    p50 ${hrs(P.hours.p50)}   p85 ${hrs(P.hours.p85)}   p95 ${hrs(P.hours.p95)}`);
+  console.log(`  Compute  p50 ${tok(P.tokens.p50)}   p85 ${tok(P.tokens.p85)}   p95 ${tok(P.tokens.p95)} tokens`);
+  console.log(`\n  p85 is the commitment threshold. The cone narrows as vibe/brew actuals replace these assumptions.`);
+}
+
+function groupByEpic(estimates: StoryEstimate[]): { label: string | null; items: StoryEstimate[] }[] {
+  const map = new Map<string, StoryEstimate[]>();
+  const order: string[] = [];
+  for (const e of estimates) {
+    const k = e.epic ?? "(no epic)";
+    if (!map.has(k)) { map.set(k, []); order.push(k); }
+    map.get(k)!.push(e);
+  }
+  return order.map((label) => ({ label, items: map.get(label)! }));
+}

--- a/packages/cli/src/commands/estimate/model.test.ts
+++ b/packages/cli/src/commands/estimate/model.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import type { Spec } from "@slowcook-ai/core";
+import { extractDrivers, estimateStory, monteCarloPortfolio, sampleTriangular, SEED_CALIBRATION } from "./model.js";
+
+function spec(over: Partial<Spec>): Spec {
+  return {
+    story_id: "001", title: "T", status: "active", created_at: "", supersedes: [], superseded_by: null,
+    actors: [], preconditions: [], invariants: [], acceptance_scenarios: [], non_goals: [],
+    ...over,
+  } as Spec;
+}
+
+describe("extractDrivers", () => {
+  it("counts entities/fields/relations/api/surfaces/EPSS-cells/scenarios", () => {
+    const d = extractDrivers(spec({
+      data_contract: {
+        entities: [{ name: "A", fields: [{ name: "id", type: "uuid" }, { name: "x", type: "int" }], relations: ["A.x → B.id"] }],
+        api: [{ method: "GET", path: "/a" }],
+      },
+      surfaces: [{ route: "/a", states: ["empty", "populated"] }, { route: "/b" }],
+      acceptance_scenarios: ["Given a, When b, Then c"],
+      invariants: ["i1", "i2"],
+      fidelity: { modes: ["light", "dark"] },
+    }));
+    expect(d.entities).toBe(1);
+    expect(d.fields).toBe(2);
+    expect(d.relations).toBe(1);
+    expect(d.endpoints).toBe(1);
+    expect(d.surfaces).toBe(2);
+    expect(d.epssCells).toBe(3); // 2 states + 1 default
+    expect(d.scenarios).toBe(1);
+    expect(d.invariants).toBe(2);
+    expect(d.fidelityModes).toBe(2);
+  });
+});
+
+describe("estimateStory", () => {
+  it("produces a right-skewed 3-point (p − m > m − o)", () => {
+    const e = estimateStory(spec({ surfaces: [{ route: "/a" }], effort: { design: "m", build: "m", qa: "m", drivers: [], risk: "medium", confidence: 0.6 } }));
+    expect(e.hours.o).toBeLessThan(e.hours.m);
+    expect(e.hours.m).toBeLessThan(e.hours.p);
+    expect(e.hours.p - e.hours.m).toBeGreaterThan(e.hours.m - e.hours.o); // right skew
+  });
+
+  it("qualitative drivers raise the estimate", () => {
+    const base = estimateStory(spec({ effort: { design: "m", build: "m", qa: "m", drivers: [], risk: "low", confidence: 0.8 } }));
+    const heavy = estimateStory(spec({ effort: { design: "m", build: "m", qa: "m", drivers: ["external-integration", "novel-algorithm"], risk: "low", confidence: 0.8 } }));
+    expect(heavy.costCents.m).toBeGreaterThan(base.costCents.m);
+  });
+
+  it("lower confidence + higher risk widens the band", () => {
+    const tight = estimateStory(spec({ effort: { design: "m", build: "m", qa: "m", drivers: [], risk: "low", confidence: 0.9 } }));
+    const loose = estimateStory(spec({ effort: { design: "m", build: "m", qa: "m", drivers: [], risk: "high", confidence: 0.4 } }));
+    const w = (e: { hours: { o: number; p: number; m: number } }) => (e.hours.p - e.hours.o) / e.hours.m;
+    expect(w(loose)).toBeGreaterThan(w(tight));
+  });
+
+  it("a bigger t-shirt costs more", () => {
+    const s = estimateStory(spec({ effort: { design: "s", build: "s", qa: "s", drivers: [], risk: "low", confidence: 0.8 } }));
+    const xl = estimateStory(spec({ effort: { design: "xl", build: "xl", qa: "xl", drivers: [], risk: "low", confidence: 0.8 } }));
+    expect(xl.costCents.m).toBeGreaterThan(s.costCents.m);
+  });
+
+  it("works with no effort block (structural only)", () => {
+    const e = estimateStory(spec({ surfaces: [{ route: "/a", states: ["empty", "populated"] }], invariants: ["i1"] }));
+    expect(e.costCents.m).toBeGreaterThan(0);
+    expect(e.qualitativeDrivers).toEqual([]);
+  });
+});
+
+describe("sampleTriangular", () => {
+  it("stays within [o, p] and returns o when degenerate", () => {
+    const tp = { o: 10, m: 20, p: 40 };
+    for (const u of [0, 0.25, 0.5, 0.75, 0.999]) {
+      const x = sampleTriangular(tp, u);
+      expect(x).toBeGreaterThanOrEqual(tp.o - 1e-9);
+      expect(x).toBeLessThanOrEqual(tp.p + 1e-9);
+    }
+    expect(sampleTriangular({ o: 5, m: 5, p: 5 }, 0.3)).toBe(5);
+  });
+});
+
+describe("monteCarloPortfolio", () => {
+  it("is deterministic (seeded) and ordered p50 ≤ p85 ≤ p95", () => {
+    const ests = [
+      estimateStory(spec({ story_id: "1", surfaces: [{ route: "/a" }], effort: { design: "m", build: "l", qa: "m", drivers: ["external-integration"], risk: "high", confidence: 0.5 } })),
+      estimateStory(spec({ story_id: "2", surfaces: [{ route: "/b" }], effort: { design: "s", build: "s", qa: "s", drivers: [], risk: "low", confidence: 0.8 } })),
+    ];
+    const a = monteCarloPortfolio(ests, 2000);
+    const b = monteCarloPortfolio(ests, 2000);
+    expect(a.costCents).toEqual(b.costCents); // reproducible
+    expect(a.costCents.p50).toBeLessThanOrEqual(a.costCents.p85);
+    expect(a.costCents.p85).toBeLessThanOrEqual(a.costCents.p95);
+    // p85 sits above the deterministic Σ-of-most-likely (the fat right tail)
+    expect(a.costCents.p85).toBeGreaterThan(a.deterministic.costCents);
+    expect(a.stories).toBe(2);
+  });
+});
+
+describe("SEED_CALIBRATION", () => {
+  it("has a weight for every t-shirt size", () => {
+    for (const sz of ["xs", "s", "m", "l", "xl"] as const) expect(SEED_CALIBRATION.weight[sz]).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/commands/estimate/model.ts
+++ b/packages/cli/src/commands/estimate/model.ts
@@ -1,0 +1,258 @@
+/**
+ * Budgeting — the deterministic estimation model (pure). Converts a story's
+ * COUNTABLE drivers (spec structure) + the LLM's RELATIVE `effort` block into a
+ * 3-point, dual-currency estimate (human manhours + agent tokens), then rolls a
+ * backlog up to portfolio percentiles via Monte-Carlo simulation.
+ *
+ * Boundary: the LLM sizes relative + names qualitative drivers (it's unreliable at
+ * absolute hours); THIS model owns the absolute conversion via calibrated
+ * coefficients. The seed coefficients below are illustrative defaults — the real
+ * ones are LEARNED from actuals (reference-class forecasting / the SizeCostTable).
+ * See dash docs/BUDGETING-AND-ROADMAP.md.
+ */
+import type { Spec, EffortSize } from "@slowcook-ai/core";
+
+/** Countable complexity drivers extracted from the spec structure (the inside view). */
+export interface StoryDrivers {
+  entities: number;
+  fields: number;
+  relations: number;
+  endpoints: number;
+  surfaces: number;
+  /** Σ declared states across surfaces (≥1 per surface) — the EPSS matrix size. */
+  epssCells: number;
+  scenarios: number;
+  invariants: number;
+  fidelityModes: number;
+  openQuestions: number;
+  personas: number;
+}
+
+/** A 3-point estimate (optimistic / most-likely / pessimistic) in one unit. */
+export interface ThreePoint {
+  o: number;
+  m: number;
+  p: number;
+}
+
+/** A story's estimate across both currencies, 3-point each. */
+export interface StoryEstimate {
+  storyId: string;
+  title: string;
+  epic: string | null;
+  /** human manhours (design + qa + review). */
+  hours: ThreePoint;
+  /** agent tokens (build + test). */
+  tokens: ThreePoint;
+  /** total cost in cents (labor + compute). */
+  costCents: ThreePoint;
+  risk: "low" | "medium" | "high";
+  confidence: number;
+  drivers: StoryDrivers;
+  qualitativeDrivers: string[];
+}
+
+/** Calibration — seed coefficients (illustrative; calibrate from actuals). */
+export interface Calibration {
+  /** relative weight per t-shirt size. */
+  weight: Record<EffortSize, number>;
+  /** human hours per design/qa weight unit. */
+  designHoursPerWeight: number;
+  qaHoursPerWeight: number;
+  /** agent k-tokens per build weight unit. */
+  buildKTokPerWeight: number;
+  /** structural coefficients (the inside view). */
+  structural: {
+    designBase: number; dSurf: number; dMode: number;
+    buildBaseK: number; bEntity: number; bField: number; bApi: number; bSurf: number;
+    qaBase: number; qCell: number; qInv: number;
+    testBaseK: number; tScenario: number;
+    reviewBase: number; rSurf: number; rInv: number;
+  };
+  /** multiplier per qualitative driver (default 1.0 when absent). */
+  driverMult: Record<string, number>;
+  /** added band per risk level. */
+  riskAdd: Record<"low" | "medium" | "high", number>;
+  baseBand: number;
+  /** $/hour (cents) blended labor rate. */
+  roleRateCents: number;
+  /** $/million-tokens (cents) blended compute rate. */
+  tokenRateCentsPerM: number;
+}
+
+export const SEED_CALIBRATION: Calibration = {
+  weight: { xs: 1, s: 2, m: 4, l: 7, xl: 12 },
+  designHoursPerWeight: 2.0,
+  qaHoursPerWeight: 1.5,
+  buildKTokPerWeight: 80,
+  structural: {
+    designBase: 1, dSurf: 1.5, dMode: 0.8,
+    buildBaseK: 40, bEntity: 30, bField: 4, bApi: 15, bSurf: 20,
+    qaBase: 1, qCell: 0.6, qInv: 0.4,
+    testBaseK: 30, tScenario: 20,
+    reviewBase: 0.5, rSurf: 0.4, rInv: 0.2,
+  },
+  driverMult: {
+    "external-integration": 1.4, "novel-algorithm": 1.5, "stateful-flow": 1.25,
+    "multi-persona": 1.2, "data-migration": 1.3, realtime: 1.4, compliance: 1.3,
+    concurrency: 1.35, "ambiguous-requirements": 1.3,
+  },
+  riskAdd: { low: 0, medium: 0.25, high: 0.6 },
+  baseBand: 0.5,
+  roleRateCents: 8000,
+  tokenRateCentsPerM: 900,
+};
+
+/** Count the structural drivers from a spec (the inside view). */
+export function extractDrivers(spec: Spec): StoryDrivers {
+  const entities = spec.data_contract?.entities ?? [];
+  const surfaces = spec.surfaces ?? [];
+  const epssCells = surfaces.reduce((n, s) => n + Math.max(1, s.states?.length ?? 1), 0);
+  const personas = new Set<string>();
+  if (spec.persona?.id) personas.add(spec.persona.id);
+  for (const a of spec.actors ?? []) personas.add(a.name);
+  return {
+    entities: entities.length,
+    fields: entities.reduce((n, e) => n + (e.fields?.length ?? 0), 0),
+    relations: entities.reduce((n, e) => n + (e.relations?.length ?? 0), 0),
+    endpoints: spec.data_contract?.api?.length ?? 0,
+    surfaces: surfaces.length,
+    epssCells,
+    scenarios: spec.acceptance_scenarios?.length ?? 0,
+    invariants: spec.invariants?.length ?? 0,
+    fidelityModes: spec.fidelity?.modes?.length ?? 1,
+    openQuestions: spec.open_questions?.addressable?.length ?? 0,
+    personas: personas.size,
+  };
+}
+
+/** Geometric mean of two positive numbers (blends structural + LLM views). */
+const geomean = (a: number, b: number): number => Math.sqrt(Math.max(a, 0.01) * Math.max(b, 0.01));
+
+/** Spread a most-likely value into a right-skewed 3-point using risk + confidence. */
+function spread(m: number, risk: "low" | "medium" | "high", confidence: number, calib: Calibration): ThreePoint {
+  const band = Math.min(1.2, Math.max(0.1, (calib.baseBand * (1 + calib.riskAdd[risk])) / Math.max(confidence, 0.3)));
+  return { o: m * (1 - 0.35 * band), m, p: m * (1 + 1.0 * band) };
+}
+
+/** Estimate one story: countable drivers ⊕ the LLM effort block → 3-point dual-currency. */
+export function estimateStory(spec: Spec, calib: Calibration = SEED_CALIBRATION): StoryEstimate {
+  const d = extractDrivers(spec);
+  const s = calib.structural;
+  const eff = spec.effort;
+
+  // Structural most-likely (the inside view).
+  const designH_s = s.designBase + s.dSurf * d.surfaces + s.dMode * d.surfaces * Math.max(0, d.fidelityModes - 1);
+  const buildK_s = s.buildBaseK + s.bEntity * d.entities + s.bField * d.fields + s.bApi * d.endpoints + s.bSurf * d.surfaces;
+  const qaH_s = s.qaBase + s.qCell * d.epssCells + s.qInv * d.invariants;
+  const testK_s = s.testBaseK + s.tScenario * d.scenarios;
+  const reviewH_s = s.reviewBase + s.rSurf * d.surfaces + s.rInv * d.invariants;
+
+  // LLM holistic most-likely (the t-shirt view), blended when present.
+  const w = (sz: EffortSize) => calib.weight[sz];
+  const designH = eff ? geomean(designH_s, w(eff.design) * calib.designHoursPerWeight) : designH_s;
+  const buildK = eff ? geomean(buildK_s, w(eff.build) * calib.buildKTokPerWeight) : buildK_s;
+  const qaH = eff ? geomean(qaH_s, w(eff.qa) * calib.qaHoursPerWeight) : qaH_s;
+  const testK = eff ? geomean(testK_s, w(eff.qa) * calib.buildKTokPerWeight * 0.5) : testK_s;
+  const reviewH = eff ? geomean(reviewH_s, w(eff.build) * 0.3) : reviewH_s;
+
+  // Qualitative driver multiplier (hits implementation/test more than design).
+  const mult = (eff?.drivers ?? []).reduce((acc, dr) => acc * (calib.driverMult[dr] ?? 1), 1);
+  const designMult = Math.sqrt(mult);
+
+  const hoursM = designH * designMult + qaH * mult + reviewH * mult;
+  const tokensM = (buildK * mult + testK * mult) * 1000;
+  const costM = Math.round((hoursM * calib.roleRateCents) + (tokensM / 1_000_000) * calib.tokenRateCentsPerM);
+
+  const risk = eff?.risk ?? "medium";
+  const confidence = eff?.confidence ?? 0.5;
+  return {
+    storyId: spec.story_id,
+    title: spec.title,
+    epic: spec.epic ?? null,
+    hours: spread(hoursM, risk, confidence, calib),
+    tokens: spread(tokensM, risk, confidence, calib),
+    costCents: spread(costM, risk, confidence, calib),
+    risk,
+    confidence,
+    drivers: d,
+    qualitativeDrivers: eff?.drivers ?? [],
+  };
+}
+
+// ── Monte-Carlo portfolio rollup ─────────────────────────────────────────────
+
+/** Deterministic PRNG (mulberry32) so the simulation is reproducible + testable. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Sample a triangular(o,m,p) distribution given u∈[0,1). */
+export function sampleTriangular(tp: ThreePoint, u: number): number {
+  const { o, m, p } = tp;
+  if (p <= o) return o;
+  const fc = (m - o) / (p - o);
+  return u < fc ? o + Math.sqrt(u * (p - o) * (m - o)) : p - Math.sqrt((1 - u) * (p - o) * (p - m));
+}
+
+export interface Percentiles { p50: number; p85: number; p95: number }
+
+function percentiles(sorted: number[]): Percentiles {
+  const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]!;
+  return { p50: at(0.5), p85: at(0.85), p95: at(0.95) };
+}
+
+export interface PortfolioForecast {
+  hours: Percentiles;
+  tokens: Percentiles;
+  costCents: Percentiles;
+  /** the deterministic Σ of most-likely values (the v1 method) for comparison. */
+  deterministic: { hours: number; tokens: number; costCents: number };
+  iterations: number;
+  stories: number;
+}
+
+/** Common-mode (systemic) risk factor applied to the WHOLE backlog per iteration —
+ *  models correlated overruns (a slow team / hard codebase runs everything long).
+ *  Without it, idiosyncratic story risk over-diversifies and the portfolio band is
+ *  unrealistically tight. Right-skewed: systemic surprises are usually bad. */
+const SYSTEMIC: ThreePoint = { o: 0.92, m: 1.0, p: 1.35 };
+
+/** Monte-Carlo: per iteration draw a systemic factor, then sample each story's
+ *  3-point per currency, sum, report percentiles. */
+export function monteCarloPortfolio(estimates: StoryEstimate[], iterations = 10_000, seed = 0x5c00c): PortfolioForecast {
+  const rand = mulberry32(seed);
+  const hours: number[] = [], tokens: number[] = [], cost: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const sf = sampleTriangular(SYSTEMIC, rand()); // shared by all stories this iteration
+    let h = 0, t = 0, c = 0;
+    for (const e of estimates) {
+      // one shared draw per story keeps the currencies correlated (a story that
+      // runs long runs long in BOTH hours and tokens) — more realistic than independent.
+      const u = rand();
+      h += sampleTriangular(e.hours, u) * sf;
+      t += sampleTriangular(e.tokens, u) * sf;
+      c += sampleTriangular(e.costCents, u) * sf;
+    }
+    hours.push(h); tokens.push(t); cost.push(c);
+  }
+  hours.sort((a, b) => a - b); tokens.sort((a, b) => a - b); cost.sort((a, b) => a - b);
+  return {
+    hours: percentiles(hours),
+    tokens: percentiles(tokens),
+    costCents: percentiles(cost),
+    deterministic: {
+      hours: estimates.reduce((n, e) => n + e.hours.m, 0),
+      tokens: estimates.reduce((n, e) => n + e.tokens.m, 0),
+      costCents: estimates.reduce((n, e) => n + e.costCents.m, 0),
+    },
+    iterations,
+    stories: estimates.length,
+  };
+}

--- a/packages/cli/src/commands/menu/assemble.ts
+++ b/packages/cli/src/commands/menu/assemble.ts
@@ -60,6 +60,7 @@ export function assembleStories(drafts: MenuStoryDraft[], opts: AssembleOptions)
     if (d.ui_behavior && Object.keys(d.ui_behavior).length > 0) spec.ui_behavior = d.ui_behavior;
     if (d.fidelity_modes && d.fidelity_modes.length > 0) spec.fidelity = { modes: d.fidelity_modes };
     if (d.epic) spec.epic = d.epic;
+    if (d.effort) spec.effort = d.effort;
     if (d.persona) spec.persona = d.persona;
     if (d.surfaces && d.surfaces.length > 0) spec.surfaces = d.surfaces;
     return spec;

--- a/packages/cli/src/commands/refine/spec-yaml.ts
+++ b/packages/cli/src/commands/refine/spec-yaml.ts
@@ -162,6 +162,18 @@ const SpecSchema = z.object({
   // onboarding" spanning founder + operator. Absent = the LCR derives a label from
   // the prd_ref anchor.
   epic: z.string().optional(),
+  // Budgeting — the agent's earliest relative effort estimate (post-menu cone point).
+  effort: z
+    .object({
+      design: z.enum(["xs", "s", "m", "l", "xl"]),
+      build: z.enum(["xs", "s", "m", "l", "xl"]),
+      qa: z.enum(["xs", "s", "m", "l", "xl"]),
+      drivers: z.array(z.string()),
+      risk: z.enum(["low", "medium", "high"]),
+      confidence: z.number(),
+      rationale: z.string().optional(),
+    })
+    .optional(),
   persona: z
     .object({ id: z.string(), label: z.string().optional(), chrome: z.enum(["member", "public", "admin"]).optional() })
     .optional(),

--- a/packages/core/src/spec.ts
+++ b/packages/core/src/spec.ts
@@ -4,6 +4,9 @@
 
 export type SpecStatus = "draft" | "active" | "superseded";
 
+/** T-shirt size for the budgeting `effort` block (relative sizing per dimension). */
+export type EffortSize = "xs" | "s" | "m" | "l" | "xl";
+
 export type RelationshipKind = "overlap" | "related" | "superseded";
 
 export interface Actor {
@@ -183,6 +186,31 @@ export interface Spec {
    * LCR derives a label from the prd_ref anchor.
    */
   epic?: string;
+  /**
+   * Budgeting — the agent's earliest (post-`menu`) RELATIVE effort estimate. The
+   * LLM is poor at absolute hours but decent at relative sizing + naming drivers,
+   * so it sizes each dimension t-shirt-style and flags the qualitative cost/risk
+   * drivers that aren't countable from the spec; a calibrated deterministic model
+   * (`slowcook estimate`) converts this + the countable drivers into a 3-point
+   * dual-currency (tokens + manhours) estimate. `confidence` sets the cone band
+   * width; `risk` adds variance. See dash docs/BUDGETING-AND-ROADMAP.md.
+   */
+  effort?: {
+    /** relative size of design (plate/vibe) work. */
+    design: EffortSize;
+    /** relative size of implementation (build) work. */
+    build: EffortSize;
+    /** relative size of test + manual QA work. */
+    qa: EffortSize;
+    /** qualitative cost/risk drivers the LLM identifies (not countable). */
+    drivers: string[];
+    /** delivery risk → variance + rework likelihood. */
+    risk: "low" | "medium" | "high";
+    /** 0–1, the agent's confidence in this sizing → cone band width. */
+    confidence: number;
+    /** one line: why this size (auditability). */
+    rationale?: string;
+  };
   persona?: { id: string; label?: string; chrome?: "member" | "public" | "admin" };
   /**
    * GUCDI — the UI surfaces this story contributes to the LCR. Each is a route

--- a/packages/llm-anthropic/src/prompts/menu.ts
+++ b/packages/llm-anthropic/src/prompts/menu.ts
@@ -28,6 +28,18 @@ export interface MenuStoryDraft {
     api?: { method: string; path: string; note?: string }[];
   };
   ui_behavior?: Record<string, string>;
+  /** Budgeting — the agent's earliest RELATIVE effort estimate (the cone's first
+   *  point). Sizes each dimension t-shirt-style + names the qualitative drivers a
+   *  calibrated model can't count; `confidence` sets the band, `risk` the variance. */
+  effort: {
+    design: "xs" | "s" | "m" | "l" | "xl";
+    build: "xs" | "s" | "m" | "l" | "xl";
+    qa: "xs" | "s" | "m" | "l" | "xl";
+    drivers: string[];
+    risk: "low" | "medium" | "high";
+    confidence: number;
+    rationale?: string;
+  };
   /** GUCDI — the primary persona this story serves in the whole-app LCR.
    *  `chrome` picks the shell: member sidebar / public nav / admin toolbar.
    *  Omit for backend-only stories (no UI surface). */
@@ -68,6 +80,12 @@ Each \`<story>\`:
 - \`persona\` — **REQUIRED for any story with a UI surface.** The single primary persona this story serves: \`{ id, label?, chrome }\` where \`chrome\` ∈ \`member|public|admin\` (member sidebar / public/marketing nav / admin toolbar). Use ONE concrete persona id (e.g. \`founder\`, \`operator\`, \`worker\`) — never a slash-joined blob like "PM / Designer / QA". OMIT for backend-only stories (schema/CI/audit with no screen).
 - \`surfaces\` — **REQUIRED for any story with a UI surface.** The routes this story adds to the ONE clickable whole-app LCR (every surface reachable, no auth walls): \`[{ route, name?, persona?, home?, states }]\`. \`route\` is the production route shape (e.g. \`/operator/workers\`, \`/u/:handle\`); \`home: true\` marks the persona's landing route; \`states\` lists ONLY the **conditions that genuinely change the UI or what the user can DO** — \`empty\` vs \`populated\`, or a **business condition** like \`insufficient-funds\` (the action is blocked + a specific error shown), \`expired-voucher\`, \`mark-below-threshold\`. Do **NOT** list \`loading\` or \`error\` — those are universal *presentation* rendered by one shared primitive, never per-surface. One or two states is usually enough (none → defaults to \`populated\`); don't pad. OMIT \`surfaces\` for backend-only stories. The LCR is one app: reuse a route across stories rather than inventing near-duplicates.
 - \`fidelity_modes\` — which modes matter for this story's design, as tokens from \`light|dark|mobile|desktop\` plus \`locale:<code>\` (e.g. ["light","dark","mobile","locale:fa"]). Declare dark/mobile/RTL only when the design is genuinely mode-specific.
+- \`effort\` — the **earliest budget estimate** (the cone of uncertainty's first point). You are unreliable at absolute hours, so size **relatively** and flag what a counting model can't see:
+  - \`design\` / \`build\` / \`qa\` — t-shirt size (\`xs|s|m|l|xl\`) for, respectively, the design (plate/vibe) work, the implementation work, and the test + manual-QA work. Size by the story's intrinsic complexity, NOT its importance.
+  - \`drivers\` — qualitative cost/risk factors you can read from the PRD that aren't countable from the spec's structure. Use short kebab tags from: \`external-integration\` (3rd-party API/webhook), \`novel-algorithm\`, \`stateful-flow\` (multi-step), \`multi-persona\`, \`data-migration\`, \`realtime\`, \`compliance\`, \`concurrency\`, \`ambiguous-requirements\`. Only include ones that genuinely apply; omit the rest. \`[]\` is valid for a plain CRUD story.
+  - \`risk\` — \`low|medium|high\` delivery risk (likelihood of rework / wide variance). High when requirements are ambiguous, many invariants interact, or it integrates externally.
+  - \`confidence\` — 0–1, how confident you are in the sizing. Lower confidence widens the forecast band. Be honest: a story with open questions should be ≤0.6.
+  - \`rationale\` — one line on why (auditability). Do NOT invent hours or dollar amounts — the deterministic estimator converts your relative sizing using calibrated coefficients.
 - \`acceptance_scenarios\` — Given/When/Then; at least three (happy · validation/error · edge) per story.
 - \`non_goals\` — what this story explicitly defers.
 - \`open_questions\` — \`{ addressable: [...], deferred: [...] }\`. **addressable** = questions you could answer but the PRD left ambiguous (must be resolved before the scope is "complete"); **deferred** = genuinely undecidable now (parked, re-enter on a future amendment). NEVER silently drop a question — surface it.


### PR DESCRIPTION
The OSS half of the dash **Budgeting & Roadmap** premium features — the earliest, highest-decision-value point on the **cone of uncertainty**.

## What

- **`core` `Spec.effort`** — the agent's relative estimate: per-dimension (design/build/qa) t-shirt size, qualitative `drivers`, `risk`, `confidence`, `rationale`.
- **`menu`** emits it (`MenuStoryDraft.effort` + prompt). The LLM sizes **relative** + names the drivers a counting model can't see; it must **not** invent absolute hours/$ (LLMs are unreliable there).
- **`slowcook estimate`** (new command) — the deterministic estimation model:
  - **countable drivers** from spec structure (entities/fields/relations/api/surfaces/EPSS-cells/scenarios/invariants/open-questions) ⊕ the **effort block** ⊕ **seed calibration**.
  - a **right-skewed 3-point**, **dual-currency** (manhours + tokens → $) estimate per story.
  - **Monte-Carlo portfolio** rollup → **p50/p85/p95**, with a **common-mode (systemic) correlation factor** so the band isn't unrealistically tight.
  - exposes that **Σ-of-most-likely underestimates** (the right-tail trap).

## Boundary

The LLM owns **relative** sizing; the deterministic model owns the **absolute** conversion, calibrated from actuals later (reference-class forecasting / the SizeCostTable). Full design: `dash docs/BUDGETING-AND-ROADMAP.md` (extends `story-012`).

## Dogfood (dash)

Ran on the 27-story dash backlog: per-story 3-point cards + portfolio **p85 $91.4k vs Σ-deterministic $59.8k** — a 35% underestimate the v1 deterministic method would have hidden.

## Validation

9 new model tests (right-skew, driver scaling, band width, MC reproducibility + ordering, p85 > deterministic); 1378 cli tests green.

> Versions not bumped — bump core/llm-anthropic/cli before the next npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)