### PR TITLE
feat(review-overlay): 0.9.8 — every comment carries full context (EPSS + lang + device)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.9.8 — every comment carries full context (EPSS + lang + device)
+
+`@slowcook-ai/review-overlay` 0.9.8 (overlay-only; additive). LCR review comments now carry the FULL review context so plate (and humans) never guess the conditions a comment was filed under:
+- **EPSS state** — the active `epic ▸ context ▸ scenario ▸ state` selection + human breadcrumb (new `surface` field; rendered as `**State (EPSS):** Patient › Consider a therapist › Chosen one`). Previously only the route was recorded, so two comments on different states that share a route were indistinguishable — the state lives in `localStorage` (`slowcook_test_surface`), not the URL.
+- **Language** — new `lang` (e.g. `fa`/`en`) from `document.documentElement.lang`.
+- **Device + theme** — `viewport` already carried `colorScheme`; the rendered line now also labels mobile/desktop explicitly via new `viewportMode(width)`.
+
+Applies to BOTH element-anchored and general (page-level) comments. New `SurfaceContext` type + optional `surface`/`lang` on `ReviewCommentPayload` (back-compat: omitted when absent, parser unchanged).
+
 ## 0.22.0 — EPSS test matrix from semantics, not routes
 
 `cli 0.22.0` · `core 0.16.0` · `llm-anthropic 0.19.0`

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/src/comment-format.test.ts
+++ b/packages/review-overlay/src/comment-format.test.ts
@@ -8,6 +8,7 @@ import {
   VIBE_LABEL,
   COMMUNITY_LABEL,
   PAYLOAD_MARKER,
+  viewportMode,
 } from "./comment-format.js";
 import type { ExtractedSelector } from "./selector.js";
 
@@ -25,6 +26,55 @@ const sampleViewport = {
   colorScheme: "dark" as const,
   dpr: 3,
 };
+
+const sampleSurface = {
+  epicId: "patient-care",
+  contextId: "patient",
+  scenarioId: "consider-therapist",
+  stateId: "chosen",
+  crumb: "Patient › Consider a therapist › Chosen one",
+};
+
+describe("full review context (EPSS surface + lang + viewport mode)", () => {
+  it("viewportMode classifies by width (mobile < 768 ≤ desktop)", () => {
+    expect(viewportMode(390)).toBe("mobile");
+    expect(viewportMode(767)).toBe("mobile");
+    expect(viewportMode(768)).toBe("desktop");
+    expect(viewportMode(1440)).toBe("desktop");
+  });
+
+  it("buildPayload carries surface + lang and round-trips through parse", () => {
+    const p = buildPayload({
+      overlayVersion: "0.9.8", storyId: null, url: "http://x/p/patient/therapists",
+      prose: "x", viewport: sampleViewport, userAgent: "UA", surface: sampleSurface, lang: "fa",
+    });
+    expect(p.surface).toEqual(sampleSurface);
+    expect(p.lang).toBe("fa");
+    expect(parseReviewComment(formatReviewComment({ payload: p }))).toMatchObject({ surface: sampleSurface, lang: "fa" });
+  });
+
+  it("renders the full context on a GENERAL (page-level, no element) comment", () => {
+    const p = buildPayload({
+      overlayVersion: "0.9.8", storyId: null, url: "http://x/p/patient/therapists",
+      prose: "page comment", viewport: sampleViewport, userAgent: "UA", surface: sampleSurface, lang: "fa",
+    });
+    expect(p.element).toBeNull(); // general / page-level
+    const body = formatReviewComment({ payload: p });
+    expect(body).toContain("Review note (general"); // page-level comment
+    expect(body).toContain("(mobile)");             // viewport mode
+    expect(body).toContain("dark mode");            // colorScheme
+    expect(body).toContain("lang `fa`");            // language
+    expect(body).toContain("**State (EPSS):**");    // EPSS context
+    expect(body).toContain("Chosen one");           // crumb
+  });
+
+  it("omits surface/lang when absent (back-compat)", () => {
+    const p = buildPayload({ overlayVersion: "0.9.8", storyId: null, url: "http://x", prose: "x", viewport: sampleViewport, userAgent: "UA" });
+    expect(p.surface).toBeUndefined();
+    expect(p.lang).toBeUndefined();
+    expect(formatReviewComment({ payload: p })).not.toContain("**State (EPSS):**");
+  });
+});
 
 describe("buildPayload", () => {
   it("populates every required field + carries the timestamp", () => {
@@ -126,7 +176,7 @@ describe("formatReviewComment + parseReviewComment round trip", () => {
     const body = formatReviewComment({ payload });
     expect(body).toContain("### Review comment — `#unread-badge`");
     expect(body).toContain("**Element:** `span` · \"3\"");
-    expect(body).toContain("**Viewport:** 390×844 dark (dpr 3)");
+    expect(body).toContain("**Viewport:** 390×844 (mobile) · dark mode (dpr 3)");
     expect(body).toContain("> Pin button looks dead.");
     expect(body).toContain("> ");
     expect(body).toContain("> The disabled state is invisible.");

--- a/packages/review-overlay/src/comment-format.ts
+++ b/packages/review-overlay/src/comment-format.ts
@@ -24,6 +24,26 @@ export interface ViewportInfo {
   dpr: number;
 }
 
+/**
+ * The EPSS selection active when the comment was filed (epic ▸ context ▸
+ * scenario ▸ state) — so plate knows the exact precondition/state the reviewer
+ * was looking at, rather than guessing from the route (multiple states share a
+ * route, and the state lives in localStorage, not the URL).
+ */
+export interface SurfaceContext {
+  epicId: string;
+  contextId: string;
+  scenarioId: string;
+  stateId: string;
+  /** Human-readable breadcrumb, e.g. "Patient › Consider a therapist › Chosen one". */
+  crumb: string;
+}
+
+/** Coarse device class from viewport width — for plate + humans. */
+export function viewportMode(width: number): "mobile" | "desktop" {
+  return width < 768 ? "mobile" : "desktop";
+}
+
 export interface ReviewCommentPayload {
   slowcook_overlay_version: string;
   story_id: string | null;
@@ -66,6 +86,15 @@ export interface ReviewCommentPayload {
   } | null;
   viewport: ViewportInfo;
   user_agent: string;
+  /**
+   * Full review CONTEXT so plate never guesses the conditions. `viewport`
+   * already carries colorScheme (dark/light) + size (mobile/desktop); these add
+   * the EPSS state and the UI language. Present on BOTH element-anchored and
+   * general (page-level) comments.
+   */
+  surface?: SurfaceContext | null;
+  /** App language at comment time, e.g. "fa" | "en" (document.documentElement.lang). */
+  lang?: string;
 }
 
 export const PAYLOAD_MARKER = "slowcook:review-overlay";
@@ -186,9 +215,16 @@ export function formatReviewComment(args: FormatArgs): string {
     lines.push(`### Review note (general — no element anchor)`);
     lines.push("");
   }
+  // Full context so plate (and humans) never guess the conditions. Rendered for
+  // BOTH element-anchored and general (page-level) comments.
   lines.push(
-    `**Viewport:** ${payload.viewport.width}×${payload.viewport.height} ${payload.viewport.colorScheme} (dpr ${payload.viewport.dpr})`
+    `**Viewport:** ${payload.viewport.width}×${payload.viewport.height} (${viewportMode(payload.viewport.width)}) · ${payload.viewport.colorScheme} mode${payload.lang ? ` · lang \`${payload.lang}\`` : ""} (dpr ${payload.viewport.dpr})`
   );
+  if (payload.surface) {
+    lines.push(
+      `**State (EPSS):** ${payload.surface.crumb}  \`${payload.surface.epicId} ▸ ${payload.surface.contextId} ▸ ${payload.surface.scenarioId} ▸ ${payload.surface.stateId}\``
+    );
+  }
   if (payload.pathname) {
     lines.push(`**Route:** \`${payload.pathname}${payload.route_query ?? ""}\``);
   }
@@ -339,6 +375,10 @@ export function buildPayload(args: {
   bbox?: { x: number; y: number; w: number; h: number };
   viewport: ViewportInfo;
   userAgent: string;
+  /** EPSS selection active at comment time (epic ▸ context ▸ scenario ▸ state). */
+  surface?: SurfaceContext | null;
+  /** UI language at comment time (e.g. "fa" | "en"). */
+  lang?: string;
 }): ReviewCommentPayload {
   const element =
     args.selector && args.bbox
@@ -363,5 +403,7 @@ export function buildPayload(args: {
     element,
     viewport: args.viewport,
     user_agent: args.userAgent,
+    ...(args.surface ? { surface: args.surface } : {}),
+    ...(args.lang ? { lang: args.lang } : {}),
   };
 }

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -33,6 +33,7 @@ import {
   formatLcrIssue,
   type ViewportInfo,
   type ReviewCommentPayload,
+  type SurfaceContext,
 } from "../comment-format.js";
 import {
   loadPat,
@@ -68,6 +69,21 @@ import {
 import { isResolvedStatus } from "../comment-format.js";
 import { readCurrentStory } from "./use-story-marker.js";
 import { loadManifest, applySelection, getSelection, liveSurfaceLabel, activeHint, type Manifest } from "../testing-surfaces.js";
+
+/**
+ * Collect the full review CONTEXT so EVERY comment — element-anchored or
+ * page-level (general) — carries the EPSS state + crumb and the UI language.
+ * colorScheme (dark/light) + viewport size (mobile/desktop) ride along in
+ * `viewport`. Lets plate act without guessing the conditions.
+ */
+function collectReviewContext(manifest: Manifest | null): { surface: SurfaceContext | null; lang: string | undefined } {
+  const s = getSelection();
+  const surface: SurfaceContext | null = s
+    ? { epicId: s.epicId, contextId: s.contextId, scenarioId: s.scenarioId, stateId: s.stateId, crumb: liveSurfaceLabel(manifest, s, window.location.pathname) ?? "" }
+    : null;
+  const lang = (typeof document !== "undefined" && document.documentElement.lang) || undefined;
+  return { surface, lang };
+}
 
 export interface SlowcookReviewOverlayProps {
   /**
@@ -748,6 +764,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
             : "light",
           dpr: window.devicePixelRatio || 1,
         };
+        const ctx = collectReviewContext(surfaceManifest);
         const payload = buildPayload({
           overlayVersion,
           storyId,
@@ -760,6 +777,8 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           bbox: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
           viewport,
           userAgent: navigator.userAgent,
+          surface: ctx.surface,
+          lang: ctx.lang,
         });
         const { res: result, kind } = await postPayload(payload, pat);
         if (result.ok) {
@@ -818,6 +837,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
             : "light",
           dpr: window.devicePixelRatio || 1,
         };
+        const ctx = collectReviewContext(surfaceManifest);
         const payload = buildPayload({
           overlayVersion,
           storyId,
@@ -828,7 +848,10 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           prose,
           viewport,
           userAgent: navigator.userAgent,
-          // No selector + no bbox → general comment.
+          // No selector + no bbox → general (page-level) comment — still carries
+          // the full surface + lang context.
+          surface: ctx.surface,
+          lang: ctx.lang,
         });
         const { res: result, kind } = await postPayload(payload, pat);
         if (result.ok) {


### PR DESCRIPTION
LCR review comments dropped the conditions they were filed under, so **plate had to guess**. Now every comment — element-anchored **and** general (page-level) — carries the full review context.

## What's added to the comment payload
- **EPSS state** — the active `epic ▸ context ▸ scenario ▸ state` selection + human breadcrumb (`surface`), rendered as `**State (EPSS):** Patient › Consider a therapist › Chosen one`. The overlay already knew this (the pill shows it) but never recorded it; since the state lives in `localStorage` (`slowcook_test_surface`), not the URL, two comments on different states of the **same route** were previously indistinguishable.
- **Language** — `lang` (`fa`/`en`) from `document.documentElement.lang`.
- **Device + theme** — `viewport` already had `colorScheme`; the rendered line now labels **mobile/desktop** explicitly via new `viewportMode(width)`.

## Implementation
- `comment-format.ts`: new `SurfaceContext` type + `viewportMode()`; optional `surface`/`lang` on `ReviewCommentPayload`; `buildPayload` + `formatReviewComment` carry/render them. Back-compat: omitted when absent; parser unchanged.
- `overlay.tsx`: `collectReviewContext(manifest)` reads `getSelection()` + `liveSurfaceLabel()` + `document.documentElement.lang`; wired into **both** `buildPayload` call sites (element + general).

## Tests
- New: `viewportMode` classification; payload carries surface+lang + round-trips; **general (page-level) comment renders the full context**; back-compat omission. All 93 pass; clean `tsc -b`.

0.9.7 → 0.9.8 (overlay-only, additive). CHANGELOG updated.