### PR TITLE
review-overlay: generic `accessory` pill slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.9.9 — generic `accessory` pill slot
+
+`@slowcook-ai/review-overlay` 0.9.9 (overlay-only; additive). Adds `accessory?: ReactNode` to `SlowcookReviewOverlay` — consumer-provided content rendered INSIDE the floating pill (always visible, both nav + comment modes), after the surface switcher. The overlay stays generic: it owns the pill chrome; the consumer owns the slot. Used by dash for its premium work-session timer, so there's a single pill rather than a second floating control. No behaviour change when the prop is omitted.
+
 ## review-overlay 0.9.8 — every comment carries full context (EPSS + lang + device)
 
 `@slowcook-ai/review-overlay` 0.9.8 (overlay-only; additive). LCR review comments now carry the FULL review context so plate (and humans) never guess the conditions a comment was filed under:

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -24,7 +24,7 @@
 
 "use client";
 
-import { useEffect, useState, useRef, useCallback, type JSX } from "react";
+import { useEffect, useState, useRef, useCallback, type JSX, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { extractSelector, resolveStoredSelector } from "../selector.js";
 import {
@@ -139,6 +139,14 @@ export interface SlowcookReviewOverlayProps {
    * Empty disables the router.
    */
   testingSurfacesUrl?: string;
+  /**
+   * Pill extension slot — arbitrary consumer-provided content rendered INSIDE the
+   * floating pill, always visible (both nav + comment modes). The overlay stays
+   * generic: it owns the pill chrome; the consumer owns what goes in the slot. dash
+   * uses it for the premium work-session timer, so there's a single pill rather than
+   * a second floating control. Keep slot content compact (it shares the pill's row).
+   */
+  accessory?: ReactNode;
 }
 
 export interface ReviewSurface {
@@ -980,6 +988,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
         identity={reviewerIdentity}
         onSignIn={() => openLogin()}
         onSignOut={signOut}
+        accessory={props.accessory}
       />
       {/* 0.3.0 — Figma-style pin layer for previously-left comments.
           Only visible in Comment mode (Nav stays clean). 0.5.0 —
@@ -1350,8 +1359,9 @@ function ModeToggle(props: {
   identity: StoredReviewerIdentity | null;
   onSignIn: () => void;
   onSignOut: () => void;
+  accessory?: ReactNode;
 }): JSX.Element {
-  const { mode, armed, onArm, onCancelArm, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, surfaces, surfaceManifest, onNavigate, reviewMode, identity, onSignIn, onSignOut } = props;
+  const { mode, armed, onArm, onCancelArm, onChange, disabled, isMobile, isApproved, commentCount, newCount, onListClick, docsEnabled, onDocsClick, surfaces, surfaceManifest, onNavigate, reviewMode, identity, onSignIn, onSignOut, accessory } = props;
   // 0.5.1 — initialise with the default; load saved position from
   // localStorage AFTER mount. Eliminates a hydration mismatch where
   // SSR/first-client render disagreed on the position value.
@@ -1615,6 +1625,9 @@ function ModeToggle(props: {
       {/* 0.7.1 — "Viewing as" surface switcher. A REVIEW affordance (a real user
           is one role), so it lives in the pane, not the mock. */}
       {surfaces.length > 0 && <SurfaceSwitcher surfaces={surfaces} onNavigate={onNavigate} disabled={disabled} />}
+      {/* Pill extension slot — consumer-provided, always visible (e.g. dash's
+          work-session timer). The overlay owns the pill; the consumer owns the slot. */}
+      {accessory}
       {/* 0.6.2 — LCR per-reviewer sign-in, inside the disk. All colours are
           explicit (white-on-dark) so the app's dark/light theme can't touch it.
           0.6.11 — only in Comment mode. */}


### PR DESCRIPTION
Adds `accessory?: ReactNode` to `SlowcookReviewOverlay` — consumer content rendered **inside** the floating pill (always visible), after the surface switcher.

## Why
The overlay should stay generic but **accommodate** consumers extending the pill. dash wants a **single pill** with its premium work-session timer inside it (not a second floating control). The timer stays 100% in dash; the overlay just exposes the slot. Any consumer can use it.

## Change
- `SlowcookReviewOverlayProps.accessory?: ReactNode`
- threaded to `ModeToggle`, rendered after the `SurfaceSwitcher` in the pill.

No behavior change when the prop is omitted. Dogfooded: dash injects `<TimerPill/>` → one pill, `nav · Docs · as founder · ● 00:00:00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)