### PR TITLE
docs(EPSS): design is a state source — affordances are requirements, variants are states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,10 @@ non-negotiable defaults unless the user specifically overrides.
   Read before emitting/consuming `testing-surfaces.json`, writing `epic` or
   `acceptance_scenarios` on a spec, or generating the LCR review matrix. Defines
   why a scenario is a task (not a route) and why universal states (loading/error)
-  get one Foundations home instead of a per-page repeat.
+  get one Foundations home instead of a per-page repeat. **Design drives state:**
+  when building or reviewing a mock, treat each affordance as a requirement and each
+  affordance-variant as a State; never simplify a component without recording what you
+  dropped — a "drifted from design" comment is a dropped requirement, not a cosmetic nit.
 - [REPORTING.md](./REPORTING.md) — how to file a slowcook bug
 - [docs/plans/](./docs/plans/) — the roadmap / design docs (if a story
   references one, read it before running the agent)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## docs(EPSS) — design is a state source (the inverse of state→data)
+
+Docs-only. `docs/EPSS.md` gains a section: the design runs the *other* direction — **affordances → requirements, affordance-variants → States** (the complement of "state drives the data, not a layout flag"). A rich component is a state-discovery surface; **a "drifted from design" review is a dropped requirement, not a cosmetic nit.** `AGENTS.md`'s EPSS pointer gets the one-line directive. Provenance: a chosen-therapist card whose dropped "next session / change-disabled" affordances turned out to encode the one-therapist-per-care-profile rule.
+
 ## review-overlay 0.9.9 — generic `accessory` pill slot
 
 `@slowcook-ai/review-overlay` 0.9.9 (overlay-only; additive). Adds `accessory?: ReactNode` to `SlowcookReviewOverlay` — consumer-provided content rendered INSIDE the floating pill (always visible, both nav + comment modes), after the surface switcher. The overlay stays generic: it owns the pill chrome; the consumer owns the slot. Used by dash for its premium work-session timer, so there's a single pill rather than a second floating control. No behaviour change when the prop is omitted.

--- a/docs/EPSS.md
+++ b/docs/EPSS.md
@@ -158,6 +158,30 @@ also why the *same* mock seeding can later seed the real product's test setup.
 > state token, the manifest carries the Given prose as the State label and pages stay
 > data-driven. Don't reintroduce `state === "<token>"` layout branches.
 
+## Design is a state source — the inverse
+
+The rule above runs data → render. The complement, discovered the hard way while
+building a mock: **the design runs the other direction — affordances → requirements,
+and variants of an affordance → States.** The mock isn't an *illustration* of the
+spec; in slowcook it **is** the spec. So:
+
+- **Every affordance a design shows is a requirement** — a "Next session" block, a
+  "Change therapist" button, a status badge, a disabled control. Not decoration.
+- **Every way an affordance changes with the data is a State** (a Given): present vs
+  absent, enabled vs disabled, booked vs unbooked, this-value vs that-value. A rich
+  component is therefore a **state-discovery surface** — read its variants *backwards*
+  into the EPSS matrix, including States the written spec never enumerated.
+- **Simplifying a design silently drops requirements *and* States.** A "lite"
+  reproduction loses behaviours, not just pixels.
+
+Consequence for the loop: a **"drifted from design" review comment is a dropped
+requirement, not a cosmetic nit.** The fix recovers the affordance **and** the
+behaviour/state it encoded. When `vibe` reproduces (or a port adapts) a component, it
+must carry the *full* affordance set and ask of each piece "what State/behaviour does
+this imply?" — then add those States to the matrix. (Provenance: a chosen-therapist
+card whose dropped "next session / change-disabled" affordances turned out to encode
+the one-therapist-per-care-profile rule.)
+
 ## How it's encoded
 
 - **Spec (`specs/story-*.yaml`):** `epic` (theme), `persona`, `surfaces[]` (routes +


### PR DESCRIPTION
The companion to EPSS.md's **"state drives the data, not a layout flag"** (data → render). The drift that prompted it teaches the *inverse*: **design → state.**

## The principle
The mock isn't an illustration of the spec — in slowcook it **is** the spec. So:
- **Every affordance is a requirement** (a "Next session" block, a "Change therapist" button, a disabled control — not decoration).
- **Every variant of an affordance is a State** (present/absent, enabled/disabled, booked/unbooked). A rich component is a **state-discovery surface** — read its variants *backwards* into the EPSS matrix, including States the written spec never enumerated.
- **Simplifying a design drops requirements *and* States.** A "drifted from design" review comment is a **dropped requirement, not a cosmetic nit** — recover the affordance *and* the behaviour/state it encoded.

## Provenance
A chosen-therapist card was ported "lite"; the dropped **next-session block** and **change-therapist-disabled** affordances turned out to encode the **one-therapist-per-care-profile** rule. The visual drift was a missing requirement.

## Scope
Docs only — `docs/EPSS.md` (new section after "State drives the data") + `AGENTS.md` (one-line directive on the EPSS pointer) + CHANGELOG. No code, no version change.