### PR TITLE
docs(EPSS): an affordance's interaction is part of the requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,8 +238,11 @@ non-negotiable defaults unless the user specifically overrides.
   why a scenario is a task (not a route) and why universal states (loading/error)
   get one Foundations home instead of a per-page repeat. **Design drives state:**
   when building or reviewing a mock, treat each affordance as a requirement and each
-  affordance-variant as a State; never simplify a component without recording what you
-  dropped — a "drifted from design" comment is a dropped requirement, not a cosmetic nit.
+  affordance-variant as a State; an affordance's *interaction* (what activating it
+  does — e.g. opening a confirm modal vs navigating away) is part of the requirement
+  too, so reproduce the flow, never a stub; never simplify a component without recording
+  what you dropped — a "drifted from design" comment is a dropped requirement, not a
+  cosmetic nit, and "doesn't *behave* like design" is the same class of miss.
 - [REPORTING.md](./REPORTING.md) — how to file a slowcook bug
 - [docs/plans/](./docs/plans/) — the roadmap / design docs (if a story
   references one, read it before running the agent)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## docs(EPSS) — an affordance's interaction is part of the requirement
+
+Docs-only follow-up to the "design is a state source" section. Extends affordances→requirements from *presence + appearance + data-variant* to **interaction**: *what an affordance does when activated* is spec too. A button reproduced to look right but wired to a stub (e.g. `navigate` instead of opening the design's confirm modal) drops a requirement just as surely as a missing control — and the modal's content + data-driven branching are themselves requirements. New EPSS.md bullet + consequence sentence ("doesn't *behave* like design" is the same class of miss as "doesn't *look* like design"), mirrored in `AGENTS.md`'s pointer. Provenance: a chosen-therapist card whose Manage/Cancel buttons, reproduced visually but stubbed to a route change, dropped the cancel-confirm-sheet flow that surfaces the ≥24h-refund / <24h-charge cancellation model.
+
 ## docs(EPSS) — design is a state source (the inverse of state→data)
 
 Docs-only. `docs/EPSS.md` gains a section: the design runs the *other* direction — **affordances → requirements, affordance-variants → States** (the complement of "state drives the data, not a layout flag"). A rich component is a state-discovery surface; **a "drifted from design" review is a dropped requirement, not a cosmetic nit.** `AGENTS.md`'s EPSS pointer gets the one-line directive. Provenance: a chosen-therapist card whose dropped "next session / change-disabled" affordances turned out to encode the one-therapist-per-care-profile rule.

--- a/docs/EPSS.md
+++ b/docs/EPSS.md
@@ -171,16 +171,28 @@ spec; in slowcook it **is** the spec. So:
   absent, enabled vs disabled, booked vs unbooked, this-value vs that-value. A rich
   component is therefore a **state-discovery surface** — read its variants *backwards*
   into the EPSS matrix, including States the written spec never enumerated.
+- **An affordance's *interaction* is part of the requirement, not just its
+  presence and appearance.** *What it does when activated* is spec: a button that
+  opens a confirm modal is not satisfied by a button that navigates away; the modal's
+  content and its data-driven branching are themselves requirements. Reproducing the
+  look (and even the disabled/variant states) while stubbing the handler drops a
+  requirement just as surely as omitting the control. For each *interactive*
+  affordance ask not only "what State does this imply?" but **"what does activating it
+  do, and what does that flow reveal?"** — then reproduce that flow, not a placeholder.
 - **Simplifying a design silently drops requirements *and* States.** A "lite"
   reproduction loses behaviours, not just pixels.
 
 Consequence for the loop: a **"drifted from design" review comment is a dropped
-requirement, not a cosmetic nit.** The fix recovers the affordance **and** the
-behaviour/state it encoded. When `vibe` reproduces (or a port adapts) a component, it
-must carry the *full* affordance set and ask of each piece "what State/behaviour does
-this imply?" — then add those States to the matrix. (Provenance: a chosen-therapist
-card whose dropped "next session / change-disabled" affordances turned out to encode
-the one-therapist-per-care-profile rule.)
+requirement, not a cosmetic nit** — and "doesn't *behave* like design" is the same
+class of miss as "doesn't *look* like design." The fix recovers the affordance, the
+behaviour/state it encoded, **and the interaction it triggers.** When `vibe`
+reproduces (or a port adapts) a component, it must carry the *full* affordance set and
+ask of each piece "what State/behaviour does this imply, and what does activating it
+do?" — then add those States *and that flow* to the matrix. (Provenance: a
+chosen-therapist card whose dropped "next session / change-disabled" affordances
+encoded the one-therapist-per-care-profile rule; and whose Manage/Cancel buttons,
+reproduced to *look* right but wired to a `navigate` stub, dropped the confirm-sheet
+flow that surfaces the ≥24h-refund / <24h-charge cancellation model.)
 
 ## How it's encoded
 


### PR DESCRIPTION
Follow-up to #224 (*design is a state source — affordances are requirements, variants are states*).

#224 established that a design's affordances and their **data-variants** are requirements/States. This extends the doctrine one step that #224 didn't cover: **an affordance's *interaction* — what it does when activated — is part of the requirement too.**

A control reproduced to *look* right (even with the correct disabled/variant states) but wired to a stub — e.g. `navigate('/somewhere')` instead of opening the design's confirm modal — has dropped a requirement just as surely as omitting the control. The modal it should open, its content, and its data-driven branching are themselves requirements.

### Changes (docs-only)
- **`docs/EPSS.md`** — new bullet under *Design is a state source*: for each interactive affordance ask not only "what State does this imply?" but **"what does activating it do, and what does that flow reveal?"** Consequence paragraph gains: *"doesn't **behave** like design" is the same class of miss as "doesn't **look** like design."* Provenance extended.
- **`AGENTS.md`** — EPSS pointer gains the interaction clause.
- **`CHANGELOG.md`** — docs entry.

### Provenance
A chosen-therapist card whose Manage/Cancel buttons were reproduced visually but stubbed to a route change — dropping the cancel-confirm-sheet flow that surfaces the ≥24h-refund / <24h-charge cancellation model (the LCR that prompted this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ng8nkdyTxCiLQZJgnFv3Y