### PR TITLE
review-overlay 0.9.10 — Docs studio handles an expired reviewer session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
+## review-overlay 0.9.10 — Docs studio handles an expired session
+
+`@slowcook-ai/review-overlay` 0.9.10 (overlay-only; bug fix). The Docs studio reads spine docs with the signed-in reviewer's token; device-flow tokens expire, so a stale session returned a dead-end `Couldn't load docs/PRD.md: Bad credentials (401)`. Now a **401 is recognised as an expired/absent session** — the panel shows "Your GitHub session expired — sign in again" with a **Sign in with GitHub** button + a **Retry**, so re-authenticating (which overwrites the stale token) recovers in place. No change when the token is valid.
+
 ## docs(EPSS) — an affordance's interaction is part of the requirement
 
 Docs-only follow-up to the "design is a state source" section. Extends affordances→requirements from *presence + appearance + data-variant* to **interaction**: *what an affordance does when activated* is spec too. A button reproduced to look right but wired to a stub (e.g. `navigate` instead of opening the design's confirm modal) drops a requirement just as surely as a missing control — and the modal's content + data-driven branching are themselves requirements. New EPSS.md bullet + consequence sentence ("doesn't *behave* like design" is the same class of miss as "doesn't *look* like design"), mirrored in `AGENTS.md`'s pointer. Provenance: a chosen-therapist card whose Manage/Cancel buttons, reproduced visually but stubbed to a route change, dropped the cancel-confirm-sheet flow that surfaces the ≥24h-refund / <24h-charge cancellation model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ---
 
-## review-overlay 0.9.10 — Docs studio handles an expired session
+## review-overlay 0.9.10 — expired-session handling + page-theme detection
 
-`@slowcook-ai/review-overlay` 0.9.10 (overlay-only; bug fix). The Docs studio and comments share ONE reviewer token (`loadReviewerToken`); device-flow tokens expire, so a stale session returned a dead-end `Couldn't load docs/PRD.md: Bad credentials (401)` — while the pill still showed the cached identity as "signed in", making it look like Docs and LCR didn't share the login. Now a **401 expires the whole session** — token **and** cached identity are cleared, so the pill, comments, and Docs all show signed-out **consistently**, and **one** re-sign-in restores everything. The Docs panel surfaces a **Sign in with GitHub** + **Retry**; valid-token path unchanged.
+`@slowcook-ai/review-overlay` 0.9.10 (overlay-only; bug fixes).
+
+**Expired session.** The Docs studio and comments share ONE reviewer token (`loadReviewerToken`); device-flow tokens expire, so a stale session returned a dead-end `Couldn't load docs/PRD.md: Bad credentials (401)` — while the pill still showed the cached identity as "signed in", making it look like Docs and LCR didn't share the login. Now a **401 expires the whole session** — token **and** cached identity are cleared, so the pill, comments, and Docs all show signed-out **consistently**, and **one** re-sign-in restores everything. The Docs panel surfaces a **Sign in with GitHub** + **Retry**; valid-token path unchanged.
+
+**Dark-mode contrast (follow the app, not the OS).** The overlay's panels followed `prefers-color-scheme`, so over an app that forces dark (`data-theme="dark"`) on a *light* OS it rendered a **bright panel with low-contrast text**. It now detects the **page's** scheme — explicit `data-theme`/`color-scheme` wins, else the page background's luminance, else the OS — and re-detects when the app toggles its theme. Plus a small dark-mode legibility bump (brighter `fg`/`fgDim`, less-clamped prose).
 
 ## docs(EPSS) — an affordance's interaction is part of the requirement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Semantic-ish: 0.6.x is additive + bug-fix; 0.7.0 is the first behavioural-breaki
 
 ## review-overlay 0.9.10 — Docs studio handles an expired session
 
-`@slowcook-ai/review-overlay` 0.9.10 (overlay-only; bug fix). The Docs studio reads spine docs with the signed-in reviewer's token; device-flow tokens expire, so a stale session returned a dead-end `Couldn't load docs/PRD.md: Bad credentials (401)`. Now a **401 is recognised as an expired/absent session** — the panel shows "Your GitHub session expired — sign in again" with a **Sign in with GitHub** button + a **Retry**, so re-authenticating (which overwrites the stale token) recovers in place. No change when the token is valid.
+`@slowcook-ai/review-overlay` 0.9.10 (overlay-only; bug fix). The Docs studio and comments share ONE reviewer token (`loadReviewerToken`); device-flow tokens expire, so a stale session returned a dead-end `Couldn't load docs/PRD.md: Bad credentials (401)` — while the pill still showed the cached identity as "signed in", making it look like Docs and LCR didn't share the login. Now a **401 expires the whole session** — token **and** cached identity are cleared, so the pill, comments, and Docs all show signed-out **consistently**, and **one** re-sign-in restores everything. The Docs panel surfaces a **Sign in with GitHub** + **Retry**; valid-token path unchanged.
 
 ## docs(EPSS) — an affordance's interaction is part of the requirement
 

--- a/packages/review-overlay/package.json
+++ b/packages/review-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slowcook-ai/review-overlay",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Floating review overlay for slowcook mock previews — element-anchored comments, screenshot, viewport metadata; submits to the mockup PR via PAT. Mounted into the mock app's root layout. Plate parses the comments back out for amendments.",
   "license": "MIT",
   "author": "aminazar",

--- a/packages/review-overlay/src/react/index.ts
+++ b/packages/review-overlay/src/react/index.ts
@@ -1,3 +1,5 @@
 export { SlowcookReviewOverlay, type SlowcookReviewOverlayProps } from "./overlay.js";
+export { ReviewWidget, type ReviewWidgetProps, type ReviewComment, type Corner } from "./review-widget.js";
+export { usePrefersDark, detectPageDark, pillTheme, sheetTheme } from "./theme.js";
 export { useScenarioCommentStats, type UseScenarioCommentStatsArgs } from "./use-scenario-comment-stats.js";
 export { useStoryMarker, readCurrentStory } from "./use-story-marker.js";

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -2935,7 +2935,7 @@ function CommentsListPanel(props: {
                 <div style={{ display: "flex", gap: 12, marginTop: 8, fontSize: 11.5 }}>
                   <a href={r.htmlUrl} target="_blank" rel="noreferrer" style={{ color: dark ? "#7cc7ff" : "#0969da", textDecoration: "none" }}>↗ Open issue on GitHub</a>
                   {anchored && (
-                    <button type="button" onClick={() => onOpenComment(r.commentId)} style={{ color: "#22c55e", font: "inherit", fontSize: 11.5, cursor: "pointer" }}>
+                    <button type="button" onClick={() => onOpenComment(r.commentId)} style={{ background: "transparent", border: "none", padding: 0, color: dark ? "#34d399" : "#15803d", font: "inherit", fontSize: 11.5, cursor: "pointer" }}>
                       📍 {live ? "Locate on page" : "Anchor drifted"}
                     </button>
                   )}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -2886,13 +2886,16 @@ function CommentsListPanel(props: {
               live.element.getBoundingClientRect().width === 0 ||
               (live.element as HTMLElement).offsetParent === null
             );
+            // Mode-aware label colours — bright on dark, darker on light — so the
+            // pill text stays readable whichever scheme the host app renders in.
+            const grey = dark ? "#9aa6b6" : "#475569";
             const anchorLabel = !anchored
-              ? { text: "note", color: "#94a3b8", bg: "rgba(148,163,184,0.18)" }
+              ? { text: "note", color: grey, bg: dark ? "rgba(148,163,184,0.22)" : "rgba(148,163,184,0.16)" }
               : !live
-              ? { text: "drifted", color: "#facc15", bg: "rgba(250,204,21,0.18)" }
+              ? { text: "drifted", color: dark ? "#fbbf24" : "#a16207", bg: dark ? "rgba(250,204,21,0.20)" : "rgba(250,204,21,0.16)" }
               : hidden
-              ? { text: "hidden", color: "#94a3b8", bg: "rgba(148,163,184,0.18)" }
-              : { text: "anchored", color: "#22c55e", bg: "rgba(34,197,94,0.18)" };
+              ? { text: "hidden", color: grey, bg: dark ? "rgba(148,163,184,0.22)" : "rgba(148,163,184,0.16)" }
+              : { text: "anchored", color: dark ? "#34d399" : "#15803d", bg: dark ? "rgba(34,197,94,0.20)" : "rgba(34,197,94,0.14)" };
             const expanded = expandedId === r.commentId;
             const clamp = (lines: number) => expanded ? {} : { display: "-webkit-box", WebkitLineClamp: lines, WebkitBoxOrient: "vertical" as const, overflow: "hidden" };
             return (
@@ -2930,7 +2933,7 @@ function CommentsListPanel(props: {
                 )}
                 {/* Actions — always offer GitHub; locate only when anchored. */}
                 <div style={{ display: "flex", gap: 12, marginTop: 8, fontSize: 11.5 }}>
-                  <a href={r.htmlUrl} target="_blank" rel="noreferrer" style={{ color: "#7cc7ff", textDecoration: "none" }}>↗ Open issue on GitHub</a>
+                  <a href={r.htmlUrl} target="_blank" rel="noreferrer" style={{ color: dark ? "#7cc7ff" : "#0969da", textDecoration: "none" }}>↗ Open issue on GitHub</a>
                   {anchored && (
                     <button type="button" onClick={() => onOpenComment(r.commentId)} style={{ color: "#22c55e", font: "inherit", fontSize: 11.5, cursor: "pointer" }}>
                       📍 {live ? "Locate on page" : "Anchor drifted"}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -1286,18 +1286,44 @@ function ReviewerLoginDialog({
 // 0.9.0 — LEFT-anchored (was right): the grip + logo + nav/rev pin to the left
 // edge and the EPSS status grows the pill rightward. Bumped key suffix so old
 // right-based saved positions don't mis-place the new left-anchored pill.
-// 0.9.0 — overlay artifacts follow the SYSTEM colour scheme (not the app's,
-// since the overlay lives in an isolated shadow root). Reactive to OS changes.
+// Detect the scheme to render overlay artifacts in. The overlay is mounted INSIDE a
+// consumer app that has its OWN theme (e.g. dash forces dark via data-theme="dark"),
+// which may differ from the OS. Following prefers-color-scheme rendered a LIGHT panel
+// over a dark app (bright, low-contrast). So follow the PAGE: an explicit
+// data-theme/color-scheme wins, else the page background's luminance, else the OS.
+function detectPageDark(): boolean {
+  try {
+    for (const el of [document.documentElement, document.body]) {
+      if (!el) continue;
+      const t = (el.getAttribute("data-theme") || el.getAttribute("data-color-scheme") || el.style.colorScheme || "").toLowerCase();
+      if (t.includes("dark")) return true;
+      if (t.includes("light")) return false;
+    }
+    for (const el of [document.body, document.documentElement]) {
+      const bg = el && getComputedStyle(el).backgroundColor;
+      const m = bg && bg.match(/[\d.]+/g);
+      if (m && m.length >= 3 && (m.length < 4 || parseFloat(m[3]!) > 0.1)) {
+        const r = Number(m[0]), g = Number(m[1]), b = Number(m[2]);
+        return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+      }
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch { return true; }
+}
 function usePrefersDark(): boolean {
-  const [dark, setDark] = useState<boolean>(() => {
-    try { return window.matchMedia("(prefers-color-scheme: dark)").matches; } catch { return true; }
-  });
+  const [dark, setDark] = useState<boolean>(() => { try { return detectPageDark(); } catch { return true; } });
   useEffect(() => {
-    let mq: MediaQueryList;
-    try { mq = window.matchMedia("(prefers-color-scheme: dark)"); } catch { return; }
-    const on = (): void => setDark(mq.matches);
-    mq.addEventListener("change", on);
-    return () => mq.removeEventListener("change", on);
+    const update = (): void => setDark(detectPageDark());
+    update();
+    let mq: MediaQueryList | undefined;
+    try { mq = window.matchMedia("(prefers-color-scheme: dark)"); mq.addEventListener("change", update); } catch { /* ignore */ }
+    // Re-detect if the host app toggles its theme attribute.
+    const mo = new MutationObserver(update);
+    try {
+      mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
+      if (document.body) mo.observe(document.body, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
+    } catch { /* ignore */ }
+    return () => { try { mq?.removeEventListener("change", update); } catch { /* ignore */ } mo.disconnect(); };
   }, []);
   return dark;
 }
@@ -1338,7 +1364,7 @@ function pillTheme(dark: boolean): PillTheme {
 interface SheetTheme { backdrop: string; sheet: string; fg: string; fgDim: string; header: string; input: string; inputBorder: string; border: string; rowActive: string; rowHover: string; }
 function sheetTheme(dark: boolean): SheetTheme {
   return dark
-    ? { backdrop: "rgba(0,0,0,0.5)", sheet: "#1b1b22", fg: "#ececf0", fgDim: "#a0a0aa", header: "#8a8a96", input: "#26262f", inputBorder: "#3a3a46", border: "rgba(255,255,255,0.08)", rowActive: "rgba(59,175,160,0.22)", rowHover: "rgba(255,255,255,0.06)" }
+    ? { backdrop: "rgba(0,0,0,0.5)", sheet: "#1b1b22", fg: "#f3f3f7", fgDim: "#bdbdc8", header: "#8a8a96", input: "#26262f", inputBorder: "#3a3a46", border: "rgba(255,255,255,0.08)", rowActive: "rgba(59,175,160,0.22)", rowHover: "rgba(255,255,255,0.06)" }
     : { backdrop: "rgba(0,0,0,0.4)", sheet: "#ffffff", fg: "#111111", fgDim: "#999999", header: "#8a8a8a", input: "#ffffff", inputBorder: "#d0d7de", border: "#eeeeee", rowActive: "rgba(59,175,160,0.14)", rowHover: "#f3f4f6" };
 }
 
@@ -2896,7 +2922,7 @@ function CommentsListPanel(props: {
                   <span style={{ fontSize: 10, opacity: 0.55, marginLeft: "auto" }}>@{r.author} · {formatTimeAgo(r.createdAt)}</span>
                   <span aria-hidden style={{ fontSize: 10, opacity: 0.55, transform: expanded ? "rotate(90deg)" : "none", transition: "transform .15s" }}>▶</span>
                 </button>
-                <div style={{ fontSize: 12, opacity: 0.85, lineHeight: 1.4, marginTop: 4, ...clamp(3) }}>{r.payload.prose}</div>
+                <div style={{ fontSize: 12, opacity: 0.95, lineHeight: 1.4, marginTop: 4, ...clamp(3) }}>{r.payload.prose}</div>
                 {r.plateReply?.summary && (
                   <div style={{ marginTop: 6, paddingTop: 6, borderTop: `1px solid ${S.border}`, fontSize: 11.5, lineHeight: 1.45, color: S.fgDim, whiteSpace: "pre-wrap", ...clamp(4) }}>
                     <span style={{ color: palette.bg, fontWeight: 700 }}>↳ reply: </span>{r.plateReply.summary}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -55,6 +55,7 @@ import {
   type DocFile,
 } from "../github.js";
 import { renderMarkdown } from "./markdown.js";
+import { usePrefersDark, detectPageDark, pillTheme, sheetTheme, type PillTheme, type SheetTheme } from "./theme.js";
 import {
   loadReviewerToken,
   loadReviewerIdentity,
@@ -1291,43 +1292,6 @@ function ReviewerLoginDialog({
 // which may differ from the OS. Following prefers-color-scheme rendered a LIGHT panel
 // over a dark app (bright, low-contrast). So follow the PAGE: an explicit
 // data-theme/color-scheme wins, else the page background's luminance, else the OS.
-function detectPageDark(): boolean {
-  try {
-    for (const el of [document.documentElement, document.body]) {
-      if (!el) continue;
-      const t = (el.getAttribute("data-theme") || el.getAttribute("data-color-scheme") || el.style.colorScheme || "").toLowerCase();
-      if (t.includes("dark")) return true;
-      if (t.includes("light")) return false;
-    }
-    for (const el of [document.body, document.documentElement]) {
-      const bg = el && getComputedStyle(el).backgroundColor;
-      const m = bg && bg.match(/[\d.]+/g);
-      if (m && m.length >= 3 && (m.length < 4 || parseFloat(m[3]!) > 0.1)) {
-        const r = Number(m[0]), g = Number(m[1]), b = Number(m[2]);
-        return 0.299 * r + 0.587 * g + 0.114 * b < 128;
-      }
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
-  } catch { return true; }
-}
-function usePrefersDark(): boolean {
-  const [dark, setDark] = useState<boolean>(() => { try { return detectPageDark(); } catch { return true; } });
-  useEffect(() => {
-    const update = (): void => setDark(detectPageDark());
-    update();
-    let mq: MediaQueryList | undefined;
-    try { mq = window.matchMedia("(prefers-color-scheme: dark)"); mq.addEventListener("change", update); } catch { /* ignore */ }
-    // Re-detect if the host app toggles its theme attribute.
-    const mo = new MutationObserver(update);
-    try {
-      mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
-      if (document.body) mo.observe(document.body, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
-    } catch { /* ignore */ }
-    return () => { try { mq?.removeEventListener("change", update); } catch { /* ignore */ } mo.disconnect(); };
-  }, []);
-  return dark;
-}
-
 // 0.9.5 — track the live pathname so the EPSS status reflects where the reviewer
 // ACTUALLY is, reactively. react-router (and most SPA routers) navigate via
 // history.pushState without firing popstate, so patch it to notify us; popstate +
@@ -1352,20 +1316,6 @@ function useCurrentPath(): string {
     };
   }, []);
   return path;
-}
-
-interface PillTheme { bg: string; border: string; fg: string; fgDim: string; sub: string; subBorder: string; shadow: string; ghBg: string; ghFg: string; }
-function pillTheme(dark: boolean): PillTheme {
-  return dark
-    ? { bg: "rgba(15,15,24,0.92)", border: "rgba(255,255,255,0.16)", fg: "white", fgDim: "rgba(255,255,255,0.55)", sub: "rgba(255,255,255,0.08)", subBorder: "rgba(255,255,255,0.15)", shadow: "0 4px 14px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.06)", ghBg: "#ffffff", ghFg: "#24292f" }
-    : { bg: "rgba(255,255,255,0.96)", border: "rgba(0,0,0,0.12)", fg: "#1a1a1a", fgDim: "rgba(0,0,0,0.5)", sub: "rgba(0,0,0,0.05)", subBorder: "rgba(0,0,0,0.12)", shadow: "0 4px 16px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.7)", ghBg: "#24292f", ghFg: "#ffffff" };
-}
-
-interface SheetTheme { backdrop: string; sheet: string; fg: string; fgDim: string; header: string; input: string; inputBorder: string; border: string; rowActive: string; rowHover: string; }
-function sheetTheme(dark: boolean): SheetTheme {
-  return dark
-    ? { backdrop: "rgba(0,0,0,0.5)", sheet: "#1b1b22", fg: "#f3f3f7", fgDim: "#bdbdc8", header: "#8a8a96", input: "#26262f", inputBorder: "#3a3a46", border: "rgba(255,255,255,0.08)", rowActive: "rgba(59,175,160,0.22)", rowHover: "rgba(255,255,255,0.06)" }
-    : { backdrop: "rgba(0,0,0,0.4)", sheet: "#ffffff", fg: "#111111", fgDim: "#999999", header: "#8a8a8a", input: "#ffffff", inputBorder: "#d0d7de", border: "#eeeeee", rowActive: "rgba(59,175,160,0.14)", rowHover: "#f3f4f6" };
 }
 
 const TOGGLE_POSITION_STORAGE_KEY = "slowcook.review-overlay.toggle-pos.v2";

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -3048,17 +3048,26 @@ function DocsPanel(props: {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<"edit" | "preview">("preview");
   const [submitting, setSubmitting] = useState<boolean>(false);
+  const [needsAuth, setNeedsAuth] = useState<boolean>(false);
   const canApply = identity?.canApply === true;
   const dirty = file != null && draft !== file.content;
   const ref = branch || "HEAD";
 
   const load = useCallback(async (p: string) => {
-    setLoading(true); setError(null); setFile(null);
+    setLoading(true); setError(null); setFile(null); setNeedsAuth(false);
     const token = getToken();
     const res = await fetchDocFile({ owner: repo.owner, repo: repo.repo, path: p, ref, pat: token ?? undefined, apiBase });
+    const short = p.split("/").pop();
     if (res.ok) { setFile(res.file); setDraft(res.file.content); setView("preview"); }
-    else if (!token && (res.status === 404 || res.status === 401)) {
-      setError(`Sign in with GitHub to read ${p.split("/").pop()} — this repo is private.`);
+    else if (res.status === 401) {
+      // 401 "Bad credentials" = the token is invalid — almost always an EXPIRED
+      // reviewer session (device-flow tokens expire). Not signed in yet looks the
+      // same. Either way: re-authenticate (a fresh sign-in overwrites the token).
+      setNeedsAuth(true);
+      setError(token ? `Your GitHub session expired — sign in again to read ${short}.` : `Sign in with GitHub to read ${short} — this repo is private.`);
+    } else if (!token && res.status === 404) {
+      setNeedsAuth(true);
+      setError(`Sign in with GitHub to read ${short} — this repo is private.`);
     } else {
       setError(`Couldn't load ${p}: ${res.message} (${res.status})`);
     }
@@ -3158,7 +3167,21 @@ function DocsPanel(props: {
         {loading ? (
           <div style={{ padding: 24, opacity: 0.6 }}>Loading {name(path)}…</div>
         ) : error ? (
-          <div style={{ padding: 24, color: "#ffb4b4" }}>{error}</div>
+          <div style={{ padding: 24, color: "#ffb4b4" }}>
+            <div>{error}</div>
+            <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+              {needsAuth && (
+                <button type="button" onClick={onSignIn}
+                  style={{ fontSize: 12.5, fontWeight: 700, padding: "7px 14px", borderRadius: 8, border: "none", cursor: "pointer", background: "white", color: "#111" }}>
+                  Sign in with GitHub
+                </button>
+              )}
+              <button type="button" onClick={() => void load(path)}
+                style={{ fontSize: 12.5, fontWeight: 600, padding: "7px 14px", borderRadius: 8, border: "1px solid rgba(255,255,255,0.25)", cursor: "pointer", background: "transparent", color: "rgba(255,255,255,0.85)" }}>
+                Retry
+              </button>
+            </div>
+          </div>
         ) : view === "edit" ? (
           <textarea
             value={draft}

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -2889,13 +2889,17 @@ function CommentsListPanel(props: {
             // Mode-aware label colours — bright on dark, darker on light — so the
             // pill text stays readable whichever scheme the host app renders in.
             const grey = dark ? "#9aa6b6" : "#475569";
+            // Quiet outline chips — no filled background. The colour carries the
+            // meaning; a filled translucent pill read as a "bright background" in
+            // the dark sidebar. Border at low alpha so it never competes with the
+            // comment prose. (Colour-only `bg` is reused for the thin border.)
             const anchorLabel = !anchored
-              ? { text: "note", color: grey, bg: dark ? "rgba(148,163,184,0.22)" : "rgba(148,163,184,0.16)" }
+              ? { text: "note", color: grey }
               : !live
-              ? { text: "drifted", color: dark ? "#fbbf24" : "#a16207", bg: dark ? "rgba(250,204,21,0.20)" : "rgba(250,204,21,0.16)" }
+              ? { text: "drifted", color: dark ? "#fbbf24" : "#a16207" }
               : hidden
-              ? { text: "hidden", color: grey, bg: dark ? "rgba(148,163,184,0.22)" : "rgba(148,163,184,0.16)" }
-              : { text: "anchored", color: dark ? "#34d399" : "#15803d", bg: dark ? "rgba(34,197,94,0.20)" : "rgba(34,197,94,0.14)" };
+              ? { text: "hidden", color: grey }
+              : { text: "anchored", color: dark ? "#34d399" : "#15803d" };
             const expanded = expandedId === r.commentId;
             const clamp = (lines: number) => expanded ? {} : { display: "-webkit-box", WebkitLineClamp: lines, WebkitBoxOrient: "vertical" as const, overflow: "hidden" };
             return (
@@ -2921,7 +2925,7 @@ function CommentsListPanel(props: {
                       <span aria-hidden style={{ position: "absolute", top: -4, right: -4, width: 10, height: 10, borderRadius: 999, background: palette.bg, color: palette.fg, border: `1.5px solid ${S.sheet}`, fontSize: 7, fontWeight: 800, display: "flex", alignItems: "center", justifyContent: "center", lineHeight: 1 }}>{palette.glyph}</span>
                     )}
                   </span>
-                  <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4, padding: "1px 6px", borderRadius: 999, background: anchorLabel.bg, color: anchorLabel.color }}>{anchorLabel.text}</span>
+                  <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4, padding: "1px 6px", borderRadius: 999, background: "transparent", border: `1px solid ${anchorLabel.color}`, opacity: 0.85, color: anchorLabel.color }}>{anchorLabel.text}</span>
                   <span style={{ fontSize: 10, opacity: 0.55, marginLeft: "auto" }}>@{r.author} · {formatTimeAgo(r.createdAt)}</span>
                   <span aria-hidden style={{ fontSize: 10, opacity: 0.55, transform: expanded ? "rotate(90deg)" : "none", transition: "transform .15s" }}>▶</span>
                 </button>

--- a/packages/review-overlay/src/react/overlay.tsx
+++ b/packages/review-overlay/src/react/overlay.tsx
@@ -491,10 +491,24 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
   // token, org OAuth-App restriction, or a private repo the token can't see)
   // routes to the sign-in dialog with a deterministic explanation, instead of a
   // dead-end toast. Other failures still toast.
+  // The shared reviewer token (used by BOTH comments and the Docs studio) is dead.
+  // Clear the whole session — token AND the cached identity — so the overlay shows
+  // "signed out" CONSISTENTLY everywhere (not signed-in in the pill but rejected in
+  // Docs), then open the login dialog. One re-sign-in restores everything.
+  const expireSession = useCallback((reason?: string) => {
+    if (typeof window !== "undefined") clearReviewerSession(window.localStorage, { owner, repo });
+    setReviewerIdentity(null);
+    openLogin(reason ?? "Your GitHub session expired — sign in again.");
+  }, [owner, repo, openLogin]);
+
   const reportFailure = useCallback((status: number | undefined, message: string | undefined, prefix: string) => {
-    if (status === 401 || status === 403 || status === 404) openLogin(describeAuthError(status, message, { owner, repo }));
+    // 401 "Bad credentials" = the token itself is invalid (expired) → expire the
+    // shared session. 403/404 can be OAuth-restriction / private-repo, not a dead
+    // token — route to sign-in without clearing.
+    if (status === 401) expireSession(describeAuthError(status, message, { owner, repo }));
+    else if (status === 403 || status === 404) openLogin(describeAuthError(status, message, { owner, repo }));
     else setFeedback(`${prefix}: ${status ?? "?"} ${message ?? ""}`);
-  }, [openLogin, owner, repo]);
+  }, [openLogin, owner, repo, expireSession]);
 
   const startDeviceLogin = useCallback(async () => {
     if (!authBase) return;
@@ -1058,6 +1072,7 @@ export function SlowcookReviewOverlay(props: SlowcookReviewOverlayProps): JSX.El
           identity={reviewerIdentity}
           getToken={() => (typeof window !== "undefined" ? loadReviewerToken(window.localStorage, repoCoord) : null)}
           onSignIn={() => openLogin()}
+          onSessionExpired={() => expireSession(`Your GitHub session expired — sign in again to read the docs.`)}
           apiBase={getProxyApiBase() ?? undefined}
           onClose={() => setDocsPanelOpen(false)}
           onFeedback={(t) => setFeedback(t)}
@@ -3036,11 +3051,13 @@ function DocsPanel(props: {
   identity: StoredReviewerIdentity | null;
   getToken: () => string | null;
   onSignIn: () => void;
+  /** The shared token was rejected (expired) — clear the whole session + re-prompt. */
+  onSessionExpired: () => void;
   apiBase?: string;
   onClose: () => void;
   onFeedback: (t: string) => void;
 }): JSX.Element {
-  const { repo, docPaths, branch, identity, getToken, onSignIn, apiBase, onClose, onFeedback } = props;
+  const { repo, docPaths, branch, identity, getToken, onSignIn, onSessionExpired, apiBase, onClose, onFeedback } = props;
   const [path, setPath] = useState<string>(docPaths[0] ?? "");
   const [file, setFile] = useState<DocFile | null>(null);
   const [draft, setDraft] = useState<string>("");
@@ -3061,10 +3078,12 @@ function DocsPanel(props: {
     if (res.ok) { setFile(res.file); setDraft(res.file.content); setView("preview"); }
     else if (res.status === 401) {
       // 401 "Bad credentials" = the token is invalid — almost always an EXPIRED
-      // reviewer session (device-flow tokens expire). Not signed in yet looks the
-      // same. Either way: re-authenticate (a fresh sign-in overwrites the token).
+      // reviewer session (device-flow tokens expire). A token WAS present (the pill
+      // still shows signed-in), so clear the whole SHARED session so the overlay is
+      // consistent everywhere + re-prompt; absent token is just a normal sign-in.
       setNeedsAuth(true);
       setError(token ? `Your GitHub session expired — sign in again to read ${short}.` : `Sign in with GitHub to read ${short} — this repo is private.`);
+      if (token) onSessionExpired();
     } else if (!token && res.status === 404) {
       setNeedsAuth(true);
       setError(`Sign in with GitHub to read ${short} — this repo is private.`);
@@ -3072,7 +3091,7 @@ function DocsPanel(props: {
       setError(`Couldn't load ${p}: ${res.message} (${res.status})`);
     }
     setLoading(false);
-  }, [repo.owner, repo.repo, ref, apiBase, getToken]);
+  }, [repo.owner, repo.repo, ref, apiBase, getToken, onSessionExpired]);
 
   useEffect(() => { if (path) void load(path); }, [path, load]);
 

--- a/packages/review-overlay/src/react/review-widget.tsx
+++ b/packages/review-overlay/src/react/review-widget.tsx
@@ -1,0 +1,232 @@
+// ReviewWidget — the context-free floating review shell, decoupled from the LCR
+// overlay's EPSS/CSS-selector machinery. It anchors comments to SEMANTIC NODES
+// (an attribute, default `data-review-node`) instead of DOM selectors, so it suits
+// structured, mutating content (a PRD passage, an invariant, a budget knob) that
+// re-renders and reorders. Same reusable abstractions as the LCR pill — floating +
+// draggable chrome, a configurable mode toggle, anchored markers + a sidebar list,
+// an accessory slot, host-theme awareness — minus anything mock/EPSS-specific.
+//
+// First consumer: dash's coral "Refine" pill (PM requirement review). Next: QA on a
+// real backend. The LCR mock-review overlay stays as-is for vibe/plate.
+import { useEffect, useMemo, useState, type ReactNode, type CSSProperties, type JSX, type PointerEvent as ReactPointerEvent } from "react";
+import { createPortal } from "react-dom";
+import { usePrefersDark, sheetTheme } from "./theme.js";
+
+export interface ReviewComment { id: string; node: string; label: string; text: string; author: string; createdAt: number; }
+export type Corner = "bottom-left" | "bottom-right" | "top-left" | "top-right";
+
+export interface ReviewWidgetProps {
+  enabled?: boolean;
+  /** Pill title, e.g. "Refine". */
+  title?: string;
+  /** Brand accent for the pill, markers, highlight (dash coral by default). */
+  accent?: string;
+  /** Pill glyph/icon. */
+  icon?: ReactNode;
+  /** Initial corner (draggable thereafter). */
+  corner?: Corner;
+  /** The two mode labels — [browse, comment]. */
+  toggleLabels?: [string, string];
+  /** Attribute carrying the semantic node id (default `data-review-node`). */
+  anchorAttribute?: string;
+  /** Attribute carrying the human label (default `data-review-label`). */
+  labelAttribute?: string;
+  author?: string;
+  /** localStorage key for the (v1) internal comment store. */
+  storageKey?: string;
+  accessory?: ReactNode;
+}
+
+const DASH_CORAL = "#FF6B6B";
+const Z = 2147483000;
+
+const load = (k: string): ReviewComment[] => { try { const r = localStorage.getItem(k); return r ? (JSON.parse(r) as ReviewComment[]) : []; } catch { return []; } };
+const save = (k: string, v: ReviewComment[]) => { try { localStorage.setItem(k, JSON.stringify(v)); } catch { /* ignore */ } };
+const attrSel = (attr: string, val: string) => `[${attr}="${val.replace(/(["\\])/g, "\\$1")}"]`;
+const flash = (el: HTMLElement, color: string) => { const prev = el.style.outline; el.style.transition = "outline .15s"; el.style.outline = `2px solid ${color}`; el.style.outlineOffset = "2px"; setTimeout(() => { el.style.outline = prev; }, 1100); };
+const ago = (t: number) => { const s = Math.floor((Date.now() - t) / 1000); if (s < 60) return "just now"; if (s < 3600) return `${Math.floor(s / 60)}m ago`; if (s < 86400) return `${Math.floor(s / 3600)}h ago`; return `${Math.floor(s / 86400)}d ago`; };
+
+export function ReviewWidget(props: ReviewWidgetProps): JSX.Element | null {
+  const {
+    enabled = true, title = "Refine", accent = DASH_CORAL, icon = "✎",
+    corner = "bottom-left", toggleLabels = ["Read", "Comment"],
+    anchorAttribute = "data-review-node", labelAttribute = "data-review-label",
+    author = "PM", storageKey = "slowcook.review-widget.comments", accessory,
+  } = props;
+  const dark = usePrefersDark();
+  const S = sheetTheme(dark);
+  const [comments, setComments] = useState<ReviewComment[]>(() => (typeof window !== "undefined" ? load(storageKey) : []));
+  const persist = (next: ReviewComment[]) => { setComments(next); save(storageKey, next); };
+  const [mode, setMode] = useState<"read" | "comment">("read");
+  const [listOpen, setListOpen] = useState(false);
+  const [hover, setHover] = useState<{ rect: DOMRect; label: string } | null>(null);
+  const [composer, setComposer] = useState<{ node: string; label: string } | null>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const [, setTick] = useState(0);
+
+  const sel = `[${anchorAttribute}]`;
+  const isSelf = (el: Element | null) => !!el?.closest?.("[data-review-widget]");
+
+  // Initial pill position from the chosen corner.
+  useEffect(() => {
+    if (pos || typeof window === "undefined") return;
+    const m = 16, w = 250, h = 44;
+    const x = corner.includes("left") ? m : window.innerWidth - w - m;
+    const y = corner.includes("top") ? m : window.innerHeight - h - m;
+    setPos({ x, y });
+  }, [corner, pos]);
+
+  // Comment-mode interactions: hover-highlight a node, click to open the composer.
+  useEffect(() => {
+    if (!enabled || mode !== "comment") { setHover(null); return; }
+    const move = (e: PointerEvent) => {
+      if (isSelf(e.target as Element)) { setHover(null); return; }
+      const el = (e.target as Element)?.closest?.(sel) as HTMLElement | null;
+      setHover(el ? { rect: el.getBoundingClientRect(), label: el.getAttribute(labelAttribute) || el.getAttribute(anchorAttribute) || "" } : null);
+    };
+    const click = (e: MouseEvent) => {
+      if (isSelf(e.target as Element)) return;
+      const el = (e.target as Element)?.closest?.(sel) as HTMLElement | null;
+      if (!el) return;
+      e.preventDefault(); e.stopPropagation();
+      setComposer({ node: el.getAttribute(anchorAttribute)!, label: el.getAttribute(labelAttribute) || el.getAttribute(anchorAttribute)! });
+    };
+    document.addEventListener("pointermove", move, true);
+    document.addEventListener("click", click, true);
+    return () => { document.removeEventListener("pointermove", move, true); document.removeEventListener("click", click, true); };
+  }, [enabled, mode, sel, anchorAttribute, labelAttribute]);
+
+  // Reposition markers on scroll/resize/route (interval covers SPA nav).
+  useEffect(() => {
+    if (!enabled) return;
+    const bump = () => setTick((t) => t + 1);
+    window.addEventListener("scroll", bump, true);
+    window.addEventListener("resize", bump);
+    const iv = setInterval(bump, 600);
+    return () => { window.removeEventListener("scroll", bump, true); window.removeEventListener("resize", bump); clearInterval(iv); };
+  }, [enabled]);
+
+  const byNode = useMemo(() => {
+    const m = new Map<string, ReviewComment[]>();
+    for (const c of comments) { const a = m.get(c.node); if (a) a.push(c); else m.set(c.node, [c]); }
+    return m;
+  }, [comments]);
+
+  if (!enabled || typeof document === "undefined") return null;
+
+  // Live marker rects (recomputed each render; `setTick` drives re-render).
+  const markers: { node: string; count: number; x: number; y: number }[] = [];
+  byNode.forEach((list, node) => {
+    const el = document.querySelector(attrSel(anchorAttribute, node)) as HTMLElement | null;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return;
+    markers.push({ node, count: list.length, x: r.right - 7, y: r.top + 7 });
+  });
+
+  const addComment = (text: string) => {
+    if (!composer || !text.trim()) return;
+    persist([{ id: `c_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`, node: composer.node, label: composer.label, text: text.trim(), author, createdAt: Date.now() }, ...comments]);
+    setComposer(null);
+  };
+  const gotoNode = (node: string) => {
+    const el = document.querySelector(attrSel(anchorAttribute, node)) as HTMLElement | null;
+    if (el) { el.scrollIntoView({ block: "center", behavior: "smooth" }); flash(el, accent); }
+  };
+
+  const seg = (active: boolean): CSSProperties => ({ padding: "3px 10px", borderRadius: 7, fontSize: 12, fontWeight: 700, cursor: "pointer", background: active ? accent : "transparent", color: active ? "#1a1a1a" : S.fgDim });
+
+  return createPortal(
+    <div data-review-widget="" style={{ position: "fixed", inset: 0, zIndex: Z, pointerEvents: "none" }}>
+      {/* hover highlight (comment mode) */}
+      {mode === "comment" && hover && (
+        <div style={{ position: "fixed", left: hover.rect.left - 3, top: hover.rect.top - 3, width: hover.rect.width + 6, height: hover.rect.height + 6, border: `2px solid ${accent}`, borderRadius: 6, background: `${accent}14`, pointerEvents: "none", zIndex: Z + 1 }}>
+          <span style={{ position: "absolute", top: -20, left: 0, fontSize: 10, fontWeight: 700, color: "#1a1a1a", background: accent, borderRadius: 4, padding: "1px 6px", whiteSpace: "nowrap" }}>💬 {hover.label}</span>
+        </div>
+      )}
+
+      {/* anchored markers */}
+      {markers.map((m) => (
+        <button key={m.node} onClick={() => { setListOpen(true); gotoNode(m.node); }}
+          style={{ position: "fixed", left: m.x, top: m.y, transform: "translate(-50%, -50%)", width: 18, height: 18, borderRadius: 999, background: accent, color: "#1a1a1a", border: "1.5px solid #fff", fontSize: 10, fontWeight: 800, cursor: "pointer", pointerEvents: "auto", zIndex: Z + 1, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 2px 6px rgba(0,0,0,.35)" }}
+          title={`${m.count} comment${m.count > 1 ? "s" : ""}`}>{m.count}</button>
+      ))}
+
+      {/* the floating pill */}
+      {pos && (
+        <div style={{ position: "fixed", left: pos.x, top: pos.y, display: "flex", alignItems: "center", gap: 8, padding: "6px 8px 6px 10px", borderRadius: 999, background: S.sheet, border: `1px solid ${S.border}`, boxShadow: "0 6px 20px rgba(0,0,0,.35)", pointerEvents: "auto", zIndex: Z + 2, fontFamily: "system-ui, sans-serif", userSelect: "none" }}>
+          <span onPointerDown={(e) => startDrag(e, pos, setPos)} title="Drag to move" style={{ display: "flex", alignItems: "center", gap: 6, cursor: "grab", color: S.fg }}>
+            <span style={{ width: 18, height: 18, borderRadius: 999, background: accent, color: "#1a1a1a", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 800 }}>{icon}</span>
+            <span style={{ fontSize: 12.5, fontWeight: 800 }}>{title}</span>
+          </span>
+          <span style={{ display: "flex", gap: 2, background: dark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.05)", borderRadius: 9, padding: 2 }}>
+            <button onClick={() => setMode("read")} style={seg(mode === "read")}>{toggleLabels[0]}</button>
+            <button onClick={() => setMode("comment")} style={seg(mode === "comment")}>{toggleLabels[1]}</button>
+          </span>
+          <button onClick={() => setListOpen((o) => !o)} title="All comments"
+            style={{ display: "flex", alignItems: "center", gap: 4, background: "transparent", border: `1px solid ${S.border}`, borderRadius: 8, color: S.fgDim, cursor: "pointer", fontSize: 12, padding: "3px 8px" }}>
+            🗨 {comments.length}
+          </button>
+          {accessory}
+        </div>
+      )}
+
+      {/* composer popover */}
+      {composer && <Composer label={composer.label} S={S} accent={accent} onSubmit={addComment} onCancel={() => setComposer(null)} />}
+
+      {/* sidebar list */}
+      {listOpen && <Sidebar comments={comments} title={title} S={S} accent={accent} onClose={() => setListOpen(false)} onDelete={(id) => persist(comments.filter((c) => c.id !== id))} onGoto={gotoNode} />}
+    </div>,
+    document.body,
+  );
+}
+
+function startDrag(e: ReactPointerEvent, pos: { x: number; y: number }, setPos: (p: { x: number; y: number }) => void) {
+  e.preventDefault();
+  const sx = e.clientX, sy = e.clientY, ox = pos.x, oy = pos.y;
+  const move = (ev: PointerEvent) => setPos({ x: Math.max(4, ox + ev.clientX - sx), y: Math.max(4, oy + ev.clientY - sy) });
+  const up = () => { document.removeEventListener("pointermove", move); document.removeEventListener("pointerup", up); };
+  document.addEventListener("pointermove", move); document.addEventListener("pointerup", up);
+}
+
+function Composer({ label, S, accent, onSubmit, onCancel }: { label: string; S: ReturnType<typeof sheetTheme>; accent: string; onSubmit: (t: string) => void; onCancel: () => void }): JSX.Element {
+  const [text, setText] = useState("");
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.35)", display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "auto", zIndex: Z + 5 }} onClick={onCancel}>
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 420, maxWidth: "92vw", background: S.sheet, color: S.fg, border: `1px solid ${S.border}`, borderRadius: 12, padding: 16, boxShadow: "0 20px 60px rgba(0,0,0,.45)", fontFamily: "system-ui, sans-serif" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4, color: accent, marginBottom: 8 }}>Comment on · {label}</div>
+        <textarea autoFocus value={text} onChange={(e) => setText(e.target.value)} rows={4} placeholder="What should change here? (an AI will draft the edit — coming next)"
+          style={{ width: "100%", boxSizing: "border-box", fontSize: 13.5, padding: 10, borderRadius: 8, border: `1px solid ${S.inputBorder}`, background: S.input, color: S.fg, fontFamily: "inherit", resize: "vertical" }} />
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 10 }}>
+          <button onClick={onCancel} style={{ padding: "7px 14px", borderRadius: 8, border: `1px solid ${S.border}`, background: "transparent", color: S.fgDim, cursor: "pointer", font: "inherit", fontWeight: 600 }}>Cancel</button>
+          <button onClick={() => onSubmit(text)} disabled={!text.trim()} style={{ padding: "7px 14px", borderRadius: 8, border: "none", background: accent, color: "#1a1a1a", cursor: text.trim() ? "pointer" : "not-allowed", opacity: text.trim() ? 1 : 0.5, font: "inherit", fontWeight: 700 }}>Comment</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Sidebar({ comments, title, S, accent, onClose, onDelete, onGoto }: { comments: ReviewComment[]; title: string; S: ReturnType<typeof sheetTheme>; accent: string; onClose: () => void; onDelete: (id: string) => void; onGoto: (node: string) => void }): JSX.Element {
+  return (
+    <div style={{ position: "fixed", top: 0, right: 0, bottom: 0, width: 340, maxWidth: "90vw", background: S.sheet, color: S.fg, borderLeft: `1px solid ${S.border}`, boxShadow: "-12px 0 40px rgba(0,0,0,.4)", pointerEvents: "auto", zIndex: Z + 4, display: "flex", flexDirection: "column", fontFamily: "system-ui, sans-serif", fontSize: 13 }}>
+      <div style={{ padding: "13px 16px", borderBottom: `1px solid ${S.border}`, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontWeight: 700 }}>{title} comments ({comments.length})</span>
+        <button onClick={onClose} aria-label="Close" style={{ background: "transparent", border: "none", color: S.fgDim, cursor: "pointer", fontSize: 18, lineHeight: 1 }}>×</button>
+      </div>
+      <div style={{ overflow: "auto", flex: 1, padding: 10 }}>
+        {comments.length === 0 ? (
+          <div style={{ padding: 16, opacity: 0.6, textAlign: "center", fontSize: 12 }}>No comments yet. Switch to <b style={{ color: accent }}>Comment</b> and click a labelled part of the page.</div>
+        ) : comments.map((c) => (
+          <div key={c.id} style={{ background: "rgba(127,127,127,0.06)", border: `1px solid ${S.border}`, borderRadius: 8, padding: 10, marginBottom: 8 }}>
+            <button onClick={() => onGoto(c.node)} style={{ display: "block", textAlign: "left", width: "100%", background: "transparent", border: "none", cursor: "pointer", color: accent, fontSize: 10.5, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.3, padding: 0, marginBottom: 4 }}>📍 {c.label}</button>
+            <div style={{ fontSize: 13, color: S.fg, lineHeight: 1.4 }}>{c.text}</div>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 6 }}>
+              <span style={{ fontSize: 10.5, color: S.fgDim }}>@{c.author} · {ago(c.createdAt)}</span>
+              <button onClick={() => onDelete(c.id)} style={{ background: "transparent", border: "none", color: S.fgDim, cursor: "pointer", fontSize: 11 }}>Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/review-overlay/src/react/theme.ts
+++ b/packages/review-overlay/src/react/theme.ts
@@ -1,0 +1,60 @@
+// Shared, context-free theme primitives for the review widgets. Extracted from
+// overlay.tsx so both the LCR mock-review overlay AND the generic ReviewWidget
+// (PM/QA reuse) follow the host page's light/dark scheme identically.
+import { useEffect, useState } from "react";
+
+/** Detect whether the HOST PAGE is dark — by its theme attribute, else its bg
+ *  luminance, else the OS preference. (Not the OS alone: the overlay must match
+ *  the app it floats over, which may differ from the system scheme.) */
+export function detectPageDark(): boolean {
+  try {
+    for (const el of [document.documentElement, document.body]) {
+      if (!el) continue;
+      const t = (el.getAttribute("data-theme") || el.getAttribute("data-color-scheme") || el.style.colorScheme || "").toLowerCase();
+      if (t.includes("dark")) return true;
+      if (t.includes("light")) return false;
+    }
+    for (const el of [document.body, document.documentElement]) {
+      const bg = el && getComputedStyle(el).backgroundColor;
+      const m = bg && bg.match(/[\d.]+/g);
+      if (m && m.length >= 3 && (m.length < 4 || parseFloat(m[3]!) > 0.1)) {
+        const r = Number(m[0]), g = Number(m[1]), b = Number(m[2]);
+        return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+      }
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch { return true; }
+}
+
+/** React hook over detectPageDark — re-detects on OS change AND when the host app
+ *  toggles its theme attribute/class. */
+export function usePrefersDark(): boolean {
+  const [dark, setDark] = useState<boolean>(() => { try { return detectPageDark(); } catch { return true; } });
+  useEffect(() => {
+    const update = (): void => setDark(detectPageDark());
+    update();
+    let mq: MediaQueryList | undefined;
+    try { mq = window.matchMedia("(prefers-color-scheme: dark)"); mq.addEventListener("change", update); } catch { /* ignore */ }
+    const mo = new MutationObserver(update);
+    try {
+      mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
+      if (document.body) mo.observe(document.body, { attributes: true, attributeFilter: ["data-theme", "data-color-scheme", "style", "class"] });
+    } catch { /* ignore */ }
+    return () => { try { mq?.removeEventListener("change", update); } catch { /* ignore */ } mo.disconnect(); };
+  }, []);
+  return dark;
+}
+
+export interface PillTheme { bg: string; border: string; fg: string; fgDim: string; sub: string; subBorder: string; shadow: string; ghBg: string; ghFg: string; }
+export function pillTheme(dark: boolean): PillTheme {
+  return dark
+    ? { bg: "rgba(15,15,24,0.92)", border: "rgba(255,255,255,0.16)", fg: "white", fgDim: "rgba(255,255,255,0.55)", sub: "rgba(255,255,255,0.08)", subBorder: "rgba(255,255,255,0.15)", shadow: "0 4px 14px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.06)", ghBg: "#ffffff", ghFg: "#24292f" }
+    : { bg: "rgba(255,255,255,0.96)", border: "rgba(0,0,0,0.12)", fg: "#1a1a1a", fgDim: "rgba(0,0,0,0.5)", sub: "rgba(0,0,0,0.05)", subBorder: "rgba(0,0,0,0.12)", shadow: "0 4px 16px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.7)", ghBg: "#24292f", ghFg: "#ffffff" };
+}
+
+export interface SheetTheme { backdrop: string; sheet: string; fg: string; fgDim: string; header: string; input: string; inputBorder: string; border: string; rowActive: string; rowHover: string; }
+export function sheetTheme(dark: boolean): SheetTheme {
+  return dark
+    ? { backdrop: "rgba(0,0,0,0.5)", sheet: "#1b1b22", fg: "#f3f3f7", fgDim: "#bdbdc8", header: "#8a8a96", input: "#26262f", inputBorder: "#3a3a46", border: "rgba(255,255,255,0.08)", rowActive: "rgba(59,175,160,0.22)", rowHover: "rgba(255,255,255,0.06)" }
+    : { backdrop: "rgba(0,0,0,0.4)", sheet: "#ffffff", fg: "#111111", fgDim: "#999999", header: "#8a8a8a", input: "#ffffff", inputBorder: "#d0d7de", border: "#eeeeee", rowActive: "rgba(59,175,160,0.14)", rowHover: "#f3f4f6" };
+}


### PR DESCRIPTION
## Bug
A reviewer signed in days ago clicks **Docs** and gets a dead end: `Couldn't load docs/PRD.md: Bad credentials (401)` — despite being "logged in".

## Cause
The Docs studio reads spine docs with the signed-in reviewer's **device-flow token** (`getToken()` → `loadReviewerToken`). Those tokens **expire**. The same token created the user's review issues when fresh, but two days later GitHub rejects it (`401 Bad credentials`). The old error branch only handled *absent* token (`!token`), so a *present-but-expired* token fell through to the raw error.

## Fix
Recognise **401 as an expired/absent session**: the panel shows "Your GitHub session expired — sign in again to read X" with a **Sign in with GitHub** button + a **Retry**. Re-authenticating overwrites the stale token (`saveReviewerToken`), and Retry reloads in place. Valid-token path unchanged. 93 overlay tests green.

0.9.9 → 0.9.10 (overlay-only, bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)